### PR TITLE
Fix stray move target object in HeroClickMover

### DIFF
--- a/Assets/Scripts/HeroClickMover.cs
+++ b/Assets/Scripts/HeroClickMover.cs
@@ -28,6 +28,7 @@ public class HeroClickMover : MonoBehaviour
         // personal hidden target ------------------------------------
         var go = new GameObject($"{name}_MoveTarget");
         moveTarget = go.transform;
+        moveTarget.SetParent(transform);
         dst.target = moveTarget;
         go.hideFlags = HideFlags.HideInHierarchy;
 
@@ -74,5 +75,11 @@ public class HeroClickMover : MonoBehaviour
     {
         // As you pointed out, using isStopped is better than disabling canMove.
         ai.isStopped = hold;
+    }
+
+    private void OnDestroy()
+    {
+        if (moveTarget)
+            Destroy(moveTarget.gameObject);
     }
 }


### PR DESCRIPTION
## Summary
- parent generated move target objects to the hero transform
- clean them up in `OnDestroy`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848c7125950832e9c1f3cfee5b7a8ba