### PR TITLE
Add null check for projectilePrefab

### DIFF
--- a/Assets/Scripts/BasicAttackTelegraphed.cs
+++ b/Assets/Scripts/BasicAttackTelegraphed.cs
@@ -51,6 +51,12 @@ public class BasicAttackTelegraphed : MonoBehaviour
         var firePos = transform.position;
         var finalDamage = isPlayerAttack ? baseDamage * 2 : baseDamage;
 
+        if (projectilePrefab == null)
+        {
+            Debug.LogError($"{nameof(BasicAttackTelegraphed)} on {name} has no projectile prefab set.");
+            return;
+        }
+
         var proj = Instantiate(projectilePrefab, firePos, Quaternion.identity);
         proj.GetComponent<Projectile>().Init(target, projectileSpeed, finalDamage);
 


### PR DESCRIPTION
## Summary
- avoid instantiating a projectile when the prefab isn't set

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6848c7316ac8832e8f233cda7974fe31