### PR TITLE
Reduce allocations in AI search

### DIFF
--- a/Assets/Scripts/EnemyAI.cs
+++ b/Assets/Scripts/EnemyAI.cs
@@ -32,6 +32,9 @@ public class EnemyAI : MonoBehaviour
     private float timeToNextWander;
     private BasicAttackTelegraphed attacker; // Reference to the attack script
 
+    // Preallocated buffer for non-allocating physics queries
+    private readonly Collider2D[] heroBuffer = new Collider2D[16];
+
     // --- A* Components ---
     private AIPath ai;
     private Seeker seeker;
@@ -132,12 +135,13 @@ public class EnemyAI : MonoBehaviour
 
     private void FindTarget()
     {
-        var potentialTargets = Physics2D.OverlapCircleAll(transform.position, visionRange, heroLayer);
+        var hitCount = Physics2D.OverlapCircleNonAlloc(transform.position, visionRange, heroBuffer, heroLayer);
         var closestDist = float.MaxValue;
         Transform closestTarget = null;
 
-        foreach (var hit in potentialTargets)
+        for (var i = 0; i < hitCount; i++)
         {
+            var hit = heroBuffer[i];
             var dist = Vector2.Distance(transform.position, hit.transform.position);
             if (dist < closestDist)
             {


### PR DESCRIPTION
## Summary
- use `Collider2D` buffers for `EnemyAI` target search
- use `Collider2D` buffers in `HeroAI` for kiting and targeting
- drop `System.Linq` usage from `HeroAI`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848c741efec832eb1ef8cd0e4265b6c