### PR TITLE
Prioritize horizontal animations

### DIFF
--- a/Assets/Scripts/HeroAnimator.cs
+++ b/Assets/Scripts/HeroAnimator.cs
@@ -32,9 +32,25 @@ public class HeroAnimator : MonoBehaviour
         if (velocity.sqrMagnitude > 0.0001f)
         {
             Vector2 norm = velocity.normalized;
-            lastMoveDir = new Vector2(
-                Mathf.Abs(norm.x) > 0.01f ? Mathf.Sign(norm.x) : 0f,
-                Mathf.Abs(norm.y) > 0.01f ? Mathf.Sign(norm.y) : 0f);
+
+            // Prefer upward animation if the velocity is strongly upward
+            if (velocity.y > 3f)
+            {
+                lastMoveDir = Vector2.up;
+            }
+            // Prioritize horizontal movement when both components are present
+            else if (Mathf.Abs(norm.x) >= Mathf.Abs(norm.y))
+            {
+                lastMoveDir = new Vector2(
+                    Mathf.Abs(norm.x) > 0.01f ? Mathf.Sign(norm.x) : 0f,
+                    0f);
+            }
+            else
+            {
+                lastMoveDir = new Vector2(
+                    0f,
+                    Mathf.Abs(norm.y) > 0.01f ? Mathf.Sign(norm.y) : 0f);
+            }
         }
 
         animator.SetFloat("MoveX", lastMoveDir.x);


### PR DESCRIPTION
## Summary
- bias hero animation toward side views when moving diagonally
- prefer upward animation if upward velocity exceeds 3 units per second

## Testing
- `git show --stat`


------
https://chatgpt.com/codex/tasks/task_e_6848f2ee3344832e89ec50fb9465b0ec