### PR TITLE
Implement hero look-at targeting

### DIFF
--- a/Assets/Scripts/BasicAttackTelegraphed.cs
+++ b/Assets/Scripts/BasicAttackTelegraphed.cs
@@ -13,6 +13,7 @@ public class BasicAttackTelegraphed : MonoBehaviour
 
     [Header("Ranged")] [SerializeField] private GameObject projectilePrefab;
     [SerializeField] private float projectileSpeed = 6f;
+    [SerializeField] private float lookAtDuration = 0.2f;
 
     public bool IsPlayerControlled { get; set; }
     private float nextAttackTime;
@@ -59,6 +60,9 @@ public class BasicAttackTelegraphed : MonoBehaviour
 
         var proj = Instantiate(projectilePrefab, firePos, Quaternion.identity);
         proj.GetComponent<Projectile>().Init(target, projectileSpeed, finalDamage);
+
+        if (target != null && TryGetComponent(out HeroAnimator anim))
+            anim.OverrideLookDirection(target.position - transform.position, lookAtDuration);
 
         nextAttackTime = Time.time + attackRate;
 

--- a/Assets/Scripts/HeroAnimator.cs
+++ b/Assets/Scripts/HeroAnimator.cs
@@ -10,6 +10,22 @@ public class HeroAnimator : MonoBehaviour
     private AIPath aiPath;
     private Vector2 lastMoveDir = Vector2.down;
     public bool logVelocity = false; // Toggle for logging velocity
+    private Vector2 lookOverrideDir;
+    private float lookOverrideEndTime;
+
+    /// <summary>
+    ///     Temporarily override the look direction of the hero for a set duration.
+    /// </summary>
+    /// <param name="dir">Direction to face.</param>
+    /// <param name="duration">How long to face that direction.</param>
+    public void OverrideLookDirection(Vector2 dir, float duration)
+    {
+        if (dir.sqrMagnitude > 0.0001f)
+        {
+            lookOverrideDir = dir.normalized;
+            lookOverrideEndTime = Time.time + duration;
+        }
+    }
 
     private void Awake()
     {
@@ -28,8 +44,9 @@ public class HeroAnimator : MonoBehaviour
             Debug.Log($"Velocity: {velocity}, Magnitude: {velocity.magnitude}");
         }
         float magnitude = velocity.magnitude / aiPath.maxSpeed;
+        bool overriding = Time.time < lookOverrideEndTime;
 
-        if (velocity.sqrMagnitude > 0.0001f)
+        if (!overriding && velocity.sqrMagnitude > 0.0001f)
         {
             Vector2 norm = velocity.normalized;
 
@@ -51,6 +68,10 @@ public class HeroAnimator : MonoBehaviour
                     0f,
                     Mathf.Abs(norm.y) > 0.01f ? Mathf.Sign(norm.y) : 0f);
             }
+        }
+        else if (overriding)
+        {
+            lastMoveDir = lookOverrideDir;
         }
 
         animator.SetFloat("MoveX", lastMoveDir.x);


### PR DESCRIPTION
## Summary
- allow overriding hero look direction for a short duration
- add ability for BasicAttackTelegraphed to tell the animator to look at its target

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848f6af9930832e8f8c2135c89ac4c7