### PR TITLE
Enhance hero card

### DIFF
--- a/Assets/Prefabs/Hero.prefab
+++ b/Assets/Prefabs/Hero.prefab
@@ -143,6 +143,7 @@ GameObject:
   - component: {fileID: 3963385185172838639}
   - component: {fileID: 8421911332518481540}
   - component: {fileID: 8749329354619873494}
+  - component: {fileID: 5197636492741234567}
   m_Layer: 7
   m_Name: Hero
   m_TagString: Hero
@@ -405,6 +406,19 @@ CircleCollider2D:
   m_CompositeOrder: 0
   m_Offset: {x: 0, y: 0}
   m_Radius: 0.5
+--- !u!114 &5197636492741234567
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1941723749653959437}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c95e0ebea679214db1e1e0303db8363f, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  defense: 1
 --- !u!1 &7367172317507442004
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/BasicAttackTelegraphed.cs
+++ b/Assets/Scripts/BasicAttackTelegraphed.cs
@@ -7,6 +7,9 @@ public class BasicAttackTelegraphed : MonoBehaviour
     [SerializeField] private LayerMask allyMask;
     [SerializeField] private float attackRate = 1f;
     [SerializeField] private int baseDamage = 2;
+
+    /// <summary>Base damage dealt by this hero.</summary>
+    public int BaseDamage => baseDamage;
     [SerializeField] private float attackRange = 15f;
 
     [Header("Healing")] [SerializeField] private bool canHealAllies = false;

--- a/Assets/Scripts/HeroStats.cs
+++ b/Assets/Scripts/HeroStats.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+/// <summary>Simple container for hero base stats.</summary>
+public class HeroStats : MonoBehaviour
+{
+    [SerializeField] private int defense = 1;
+
+    public int Defense => defense;
+}

--- a/Assets/Scripts/HeroStats.cs.meta
+++ b/Assets/Scripts/HeroStats.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c95e0ebea679214db1e1e0303db8363f
+timeCreated: 1749385186

--- a/Assets/Scripts/PartyManager.cs
+++ b/Assets/Scripts/PartyManager.cs
@@ -192,6 +192,13 @@ public class PartyManager : MonoBehaviour
                 if (card.heroSelectionPips[i])
                     card.heroSelectionPips[i].SetActive(i == idx);
 
+        /* damage / defense */
+        if (card.heroDamageText && hero.TryGetComponent(out BasicAttackTelegraphed atk))
+            card.heroDamageText.text = $"Damage: {atk.BaseDamage}";
+
+        if (card.heroDefenseText && hero.TryGetComponent(out HeroStats stats))
+            card.heroDefenseText.text = $"Defense: {stats.Defense}";
+
         /* HP / XP */
         var hp = hero.GetComponent<Health>();
         var lv = hero.GetComponent<LevelSystem>();


### PR DESCRIPTION
## Summary
- add `HeroStats` MonoBehaviour to store defense value
- expose BaseDamage from `BasicAttackTelegraphed`
- update `PartyManager` to show damage & defense on hero card
- attach `HeroStats` to hero prefab

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68494b182cbc832eaa6add2073ad4195