### PR TITLE
Update hero card icon with child sprite

### DIFF
--- a/Assets/Scripts/CharacterCardReferences.cs
+++ b/Assets/Scripts/CharacterCardReferences.cs
@@ -19,4 +19,13 @@ public class CharacterCardReferences : MonoBehaviour
 
     [Header("Party Selection")] public GameObject[] heroSelectionPips;
     public Button[] heroSelectionButtons;
+
+    /// <summary>
+    /// Updates the card's icon with the provided sprite.
+    /// </summary>
+    /// <param name="sprite">The sprite to display for the hero.</param>
+    public void UpdateHeroIcon(Sprite sprite)
+    {
+        if (heroIcon) heroIcon.sprite = sprite;
+    }
 }

--- a/Assets/Scripts/PartyManager.cs
+++ b/Assets/Scripts/PartyManager.cs
@@ -183,8 +183,8 @@ public class PartyManager : MonoBehaviour
 
         /* name / icon */
         if (card.heroNameText) card.heroNameText.text = hero.name;
-        if (card.heroIcon && hero.TryGetComponent(out SpriteRenderer sr))
-            card.heroIcon.sprite = sr.sprite;
+        var sr = hero.GetComponentInChildren<SpriteRenderer>();
+        if (sr) card.UpdateHeroIcon(sr.sprite);
 
         /* green pips */
         if (card.heroSelectionPips != null)


### PR DESCRIPTION
## Summary
- update CharacterCardReferences newline
- load hero sprite from child SpriteRenderer when refreshing card visuals

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684953a8d27c832e98c2d446c01075e2