### PR TITLE
Add XP on kill to slayer

### DIFF
--- a/Assets/Scripts/BasicAttackTelegraphed.cs
+++ b/Assets/Scripts/BasicAttackTelegraphed.cs
@@ -101,7 +101,7 @@ public class BasicAttackTelegraphed : MonoBehaviour
         }
 
         var proj = Instantiate(projectilePrefab, firePos, Quaternion.identity);
-        proj.GetComponent<Projectile>().Init(target, projectileSpeed, finalDamage);
+        proj.GetComponent<Projectile>().Init(target, projectileSpeed, finalDamage, gameObject);
 
         var anim = GetComponentInChildren<HeroAnimator>();
         if (target != null && anim != null)
@@ -125,7 +125,7 @@ public class BasicAttackTelegraphed : MonoBehaviour
         }
 
         var proj = Instantiate(projectilePrefab, firePos, Quaternion.identity);
-        proj.GetComponent<Projectile>().Init(target, projectileSpeed, finalHeal, true);
+        proj.GetComponent<Projectile>().Init(target, projectileSpeed, finalHeal, gameObject, true);
 
         var anim = GetComponentInChildren<HeroAnimator>();
         if (target != null && anim != null)

--- a/Assets/Scripts/Health.cs
+++ b/Assets/Scripts/Health.cs
@@ -17,14 +17,23 @@ public class Health : MonoBehaviour, IDamageable
         OnHealthChanged?.Invoke(CurrentHP, maxHP);      // push initial value
     }
 
-    public void TakeDamage(int dmg)
+    public void TakeDamage(int dmg, GameObject attacker)
     {
         if (CurrentHP <= 0) return;
 
         CurrentHP -= dmg;
         OnHealthChanged?.Invoke(CurrentHP, maxHP);
 
-        if (CurrentHP <= 0) OnDeath?.Invoke();
+        if (CurrentHP <= 0)
+        {
+            OnDeath?.Invoke();
+
+            if (CompareTag("Enemy") && attacker && attacker.CompareTag("Hero"))
+            {
+                if (attacker.TryGetComponent(out LevelSystem lvl))
+                    lvl.GrantXP(5);
+            }
+        }
     }
 
     /* Optional heal helper */

--- a/Assets/Scripts/IDamageable.cs
+++ b/Assets/Scripts/IDamageable.cs
@@ -1,5 +1,10 @@
 /// <summary>Standard interface so any object can receive damage.</summary>
+using UnityEngine;
+
 public interface IDamageable
 {
-    void TakeDamage(int amount);
+    /// <summary>Apply damage from an attacker.</summary>
+    /// <param name="amount">The amount of damage to apply.</param>
+    /// <param name="attacker">The GameObject responsible for the damage.</param>
+    void TakeDamage(int amount, GameObject attacker);
 }

--- a/Assets/Scripts/PartyManager.cs
+++ b/Assets/Scripts/PartyManager.cs
@@ -22,6 +22,9 @@ public class PartyManager : MonoBehaviour
     private CameraController camController; // WASD mover on the anchor
     private bool followActiveHero;
 
+    /// <summary>The currently active hero or null if none.</summary>
+    public GameObject ActiveHero => IsValidIndex(activeIdx) ? heroes[activeIdx] : null;
+
     // stored delegates so we can unsubscribe on destroy
     private readonly List<System.Action<int, int>> hpChangedDelegates = new();
     private readonly List<System.Action<int, int>> xpChangedDelegates = new();

--- a/Assets/Scripts/Projectile.cs
+++ b/Assets/Scripts/Projectile.cs
@@ -7,6 +7,7 @@ public class Projectile : MonoBehaviour
     private int damage;
     private float speed;
     private bool isHealing;
+    private GameObject owner;
 
     // How close we need to be to "hit" the target.
     public float TARGET_RADIUS = 0.1f;
@@ -17,12 +18,14 @@ public class Projectile : MonoBehaviour
     /// <param name="target">The transform to home in on.</param>
     /// <param name="speed">How fast the projectile moves.</param>
     /// <param name="damage">Amount to apply on impact.</param>
+    /// <param name="owner">GameObject that fired the projectile.</param>
     /// <param name="healing">If true the amount will heal instead of damage.</param>
-    public void Init(Transform target, float speed, int damage, bool healing = false)
+    public void Init(Transform target, float speed, int damage, GameObject owner, bool healing = false)
     {
         this.target = target;
         this.speed = speed;
         this.damage = damage;
+        this.owner = owner;
         this.isHealing = healing;
 
         Destroy(gameObject, 5f); // Failsafe to clean up projectiles that never hit.
@@ -58,7 +61,7 @@ public class Projectile : MonoBehaviour
             }
             else
             {
-                if (target.TryGetComponent(out IDamageable d)) d.TakeDamage(damage);
+                if (target.TryGetComponent(out IDamageable d)) d.TakeDamage(damage, owner);
             }
             Destroy(gameObject); // Destroy self on impact.
         }


### PR DESCRIPTION
## Summary
- include attacker in damage interface
- track projectile owner
- pass owner from attacks
- award XP to the hero that lands the killing blow

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68495a2434a4832ebba5d66f98d7a069