### PR TITLE
Implement hero return-to-position behavior

### DIFF
--- a/Assets/Scripts/SelectionController.cs
+++ b/Assets/Scripts/SelectionController.cs
@@ -56,11 +56,12 @@ public class SelectionController : MonoBehaviour
         if (selectedMover.TryGetComponent(out AIPath aiPath))
             aiPath.endReachedDistance = 0.5f; // A small value for precise ground-targeting.
 
-        // Also, notify the HeroAI that the player has taken control.
-        if (selectedMover.TryGetComponent(out HeroAI heroAI)) heroAI.NotifyPlayerCommand();
-
         var mWorld = cam.ScreenToWorldPoint(Input.mousePosition);
         mWorld.z = 0;
+
+        // Also, notify the HeroAI that the player has taken control and the desired destination.
+        if (selectedMover.TryGetComponent(out HeroAI heroAI)) heroAI.NotifyPlayerCommand((Vector2)mWorld);
+
         selectedMover.SetDestination((Vector2)mWorld);
     }
 }


### PR DESCRIPTION
## Summary
- remember the last player-issued move target
- send the player destination to `HeroAI` when issuing a move
- command heroes to go back to that spot once combat ends

## Testing
- `unity-editor -runTests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849629b9124832eaedb516d54bc0dcf