### PR TITLE
Fix hero not resuming destination after combat

### DIFF
--- a/Assets/Scripts/HeroAI.cs
+++ b/Assets/Scripts/HeroAI.cs
@@ -62,6 +62,7 @@ public class HeroAI : MonoBehaviour
             if (wasInCombat)
             {
                 wasInCombat = false;
+                mover.SetHold(false); // ensure movement resumes
                 if (hasReturnDestination)
                 {
                     mover.SetDestination(lastPlayerDestination);


### PR DESCRIPTION
## Summary
- resume hero movement after combat ends

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684966cd84b0832eb46d70ab72a3dde4