### PR TITLE
Move hero defence to Health

### DIFF
--- a/Assets/Prefabs/Hero.prefab
+++ b/Assets/Prefabs/Hero.prefab
@@ -143,7 +143,6 @@ GameObject:
   - component: {fileID: 3963385185172838639}
   - component: {fileID: 8421911332518481540}
   - component: {fileID: 8749329354619873494}
-  - component: {fileID: 5197636492741234567}
   m_Layer: 7
   m_Name: Hero
   m_TagString: Hero
@@ -406,19 +405,6 @@ CircleCollider2D:
   m_CompositeOrder: 0
   m_Offset: {x: 0, y: 0}
   m_Radius: 0.5
---- !u!114 &5197636492741234567
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1941723749653959437}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c95e0ebea679214db1e1e0303db8363f, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
-  defense: 1
 --- !u!1 &7367172317507442004
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Health.cs
+++ b/Assets/Scripts/Health.cs
@@ -4,9 +4,11 @@ using UnityEngine;
 public class Health : MonoBehaviour, IDamageable
 {
     [SerializeField] private int maxHP = 10;
+    [SerializeField] private int defense = 1;
 
     public  int MaxHP      => maxHP;
     public  int CurrentHP  { get; private set; }
+    public  int Defense    => defense;
 
     public  System.Action            OnDeath;
     public  System.Action<int, int>  OnHealthChanged;   // (current, max)
@@ -21,7 +23,8 @@ public class Health : MonoBehaviour, IDamageable
     {
         if (CurrentHP <= 0) return;
 
-        CurrentHP -= dmg;
+        int actualDamage = Mathf.Max(dmg - defense, 0);
+        CurrentHP -= actualDamage;
         OnHealthChanged?.Invoke(CurrentHP, maxHP);
 
         if (CurrentHP <= 0)

--- a/Assets/Scripts/HeroStats.cs
+++ b/Assets/Scripts/HeroStats.cs
@@ -1,9 +1,0 @@
-using UnityEngine;
-
-/// <summary>Simple container for hero base stats.</summary>
-public class HeroStats : MonoBehaviour
-{
-    [SerializeField] private int defense = 1;
-
-    public int Defense => defense;
-}

--- a/Assets/Scripts/HeroStats.cs.meta
+++ b/Assets/Scripts/HeroStats.cs.meta
@@ -1,3 +1,0 @@
-fileFormatVersion: 2
-guid: c95e0ebea679214db1e1e0303db8363f
-timeCreated: 1749385186

--- a/Assets/Scripts/PartyManager.cs
+++ b/Assets/Scripts/PartyManager.cs
@@ -207,11 +207,11 @@ public class PartyManager : MonoBehaviour
         if (card.heroDamageText && hero.TryGetComponent(out BasicAttackTelegraphed atk))
             card.heroDamageText.text = $"Damage: {atk.BaseDamage}";
 
-        if (card.heroDefenseText && hero.TryGetComponent(out HeroStats stats))
-            card.heroDefenseText.text = $"Defense: {stats.Defense}";
+        var hp = hero.GetComponent<Health>();
+        if (card.heroDefenseText && hp)
+            card.heroDefenseText.text = $"Defense: {hp.Defense}";
 
         /* HP / XP */
-        var hp = hero.GetComponent<Health>();
         var lv = hero.GetComponent<LevelSystem>();
         UpdateHP(idx, hp.CurrentHP, hp.MaxHP);
         UpdateXP(idx, lv.CurrentXP, lv.XPNeeded);


### PR DESCRIPTION
## Summary
- add `defense` field to `Health`
- scale damage taken using defence
- update card display to use new stat
- remove obsolete `HeroStats` script
- clean hero prefab of old component

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68496bcc73f4832ea71494d4bd3088bd