### PR TITLE
Add XP reward on enemy death

### DIFF
--- a/Assets/Scripts/BasicAttackTelegraphed.cs
+++ b/Assets/Scripts/BasicAttackTelegraphed.cs
@@ -108,9 +108,6 @@ public class BasicAttackTelegraphed : MonoBehaviour
             anim.OverrideLookDirection(target.position - transform.position, lookAtDuration);
 
         nextAttackTime = Time.time + attackRate;
-
-        if (CompareTag("Hero") && TryGetComponent(out LevelSystem lvl))
-            lvl.GrantXP(1);
     }
 
     private void FireHeal(Transform target, bool isPlayerAction)

--- a/Assets/Scripts/EnemyAI.cs
+++ b/Assets/Scripts/EnemyAI.cs
@@ -25,6 +25,10 @@ public class EnemyAI : MonoBehaviour
 
     [SerializeField] private float wanderInterval = 3f; // How often to pick a new wander point
 
+    [Header("Rewards")] [SerializeField]
+    private int xpReward = 5;
+    public int XPReward => xpReward;
+
     // --- State & References ---
     public AIState CurrentState { get; private set; } = AIState.Wandering;
     private Transform currentTarget;

--- a/Assets/Scripts/Health.cs
+++ b/Assets/Scripts/Health.cs
@@ -33,8 +33,12 @@ public class Health : MonoBehaviour, IDamageable
 
             if (CompareTag("Enemy") && attacker && attacker.CompareTag("Hero"))
             {
+                int reward = 5;
+                if (TryGetComponent(out EnemyAI enemy))
+                    reward = enemy.XPReward;
+
                 if (attacker.TryGetComponent(out LevelSystem lvl))
-                    lvl.GrantXP(5);
+                    lvl.GrantXP(reward);
             }
         }
     }


### PR DESCRIPTION
## Summary
- remove XP gain from `BasicAttackTelegraphed` auto-attacks
- add `XPReward` field to `EnemyAI` so enemy death XP can be adjusted per enemy
- use the enemy's `XPReward` value when granting XP in `Health`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68496e0c8e50832eafa1172ca91c1a19