### PR TITLE
Fix LevelSystem event namespace

### DIFF
--- a/Assets/Scripts/LevelSystem.cs
+++ b/Assets/Scripts/LevelSystem.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 using System;
 using System.Collections.Generic;
 using Blindsided.SaveData;
+using EventHandler = Blindsided.EventHandler;
 using static Blindsided.Oracle;
 
 /// <summary>Tracks XP / level and fires events when either changes.</summary>


### PR DESCRIPTION
## Summary
- fix `EventHandler` namespace conflict so LevelSystem can subscribe to save events

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68497866e5e4832eb6a8703581939f03