### PR TITLE
Add HeroBalance script for hero stats

### DIFF
--- a/Assets/Scripts/BasicAttackTelegraphed.cs
+++ b/Assets/Scripts/BasicAttackTelegraphed.cs
@@ -23,6 +23,24 @@ public class BasicAttackTelegraphed : MonoBehaviour
     [SerializeField] private float projectileSpeed = 6f;
     [SerializeField] private float lookAtDuration = 0.2f;
 
+    /// <summary>
+    /// Called by <see cref="HeroBalance"/> to apply balance values.
+    /// </summary>
+    public void InitializeStats(int dmg, float rate, float range, float projSpeed,
+        float lookDuration, GameObject projPrefab, bool healAllies, float hRange,
+        int hAmount)
+    {
+        baseDamage = dmg;
+        attackRate = rate;
+        attackRange = range;
+        projectileSpeed = projSpeed;
+        lookAtDuration = lookDuration;
+        projectilePrefab = projPrefab;
+        canHealAllies = healAllies;
+        healRange = hRange;
+        healAmount = hAmount;
+    }
+
     public bool IsPlayerControlled { get; set; }
     private LevelSystem levelSystem;
     private float nextAttackTime;
@@ -160,16 +178,4 @@ public class BasicAttackTelegraphed : MonoBehaviour
         return false;
     }
 
-#if UNITY_EDITOR
-    private void OnDrawGizmosSelected()
-    {
-        Gizmos.color = new Color(1f, 0f, 0f, 0.3f);
-        Gizmos.DrawWireSphere(transform.position, attackRange);
-        if (canHealAllies)
-        {
-            Gizmos.color = new Color(0f, 1f, 0f, 0.3f);
-            Gizmos.DrawWireSphere(transform.position, healRange);
-        }
-    }
-#endif
 }

--- a/Assets/Scripts/Health.cs
+++ b/Assets/Scripts/Health.cs
@@ -49,4 +49,15 @@ public class Health : MonoBehaviour, IDamageable
         CurrentHP = Mathf.Min(CurrentHP + amount, maxHP);
         OnHealthChanged?.Invoke(CurrentHP, maxHP);
     }
+
+    /// <summary>
+    /// Sets base health and defense at runtime.
+    /// </summary>
+    public void SetBaseStats(int hp, int def)
+    {
+        maxHP = hp;
+        defense = def;
+        CurrentHP = maxHP;
+        OnHealthChanged?.Invoke(CurrentHP, maxHP);
+    }
 }

--- a/Assets/Scripts/HeroAI.cs
+++ b/Assets/Scripts/HeroAI.cs
@@ -5,15 +5,15 @@ using UnityEngine;
 [RequireComponent(typeof(HeroClickMover))]
 public class HeroAI : MonoBehaviour
 {
-    [Header("AI Behavior")] [SerializeField]
-    private float visionRange = 20f;
-
-    [SerializeField] private float safeDistance = 8f;
+    [Header("AI Behavior")] private float visionRange = 20f;
+    private float safeDistance = 8f;
     [SerializeField] private LayerMask enemyLayer;
     [SerializeField] private LayerMask blockingLayer;
 
     public Transform currentTarget;
     public bool isPlayerOverridden;
+    public float VisionRange => visionRange;
+    public float SafeDistance => safeDistance;
 
     // Player issued destination to return to after combat
     public Vector3 lastPlayerDestination;
@@ -29,6 +29,15 @@ public class HeroAI : MonoBehaviour
 
     private ContactFilter2D enemyFilter;
     private ContactFilter2D blockingFilter;
+
+    /// <summary>
+    /// Called by <see cref="HeroBalance"/> to apply AI balance values.
+    /// </summary>
+    public void InitializeStats(float vision, float safeDist)
+    {
+        visionRange = vision;
+        safeDistance = safeDist;
+    }
 
 
     private void Awake()
@@ -213,20 +222,4 @@ public class HeroAI : MonoBehaviour
         hasReturnDestination = true;
     }
 
-#if UNITY_EDITOR
-    private void OnDrawGizmosSelected()
-    {
-        Gizmos.color = Color.cyan;
-        Gizmos.DrawWireSphere(transform.position, visionRange);
-
-        if (attacker != null)
-        {
-            Gizmos.color = Color.yellow;
-            Gizmos.DrawWireSphere(transform.position, attacker.AttackRange);
-        }
-
-        Gizmos.color = Color.red;
-        Gizmos.DrawWireSphere(transform.position, safeDistance);
-    }
-#endif
 }

--- a/Assets/Scripts/HeroBalance.cs
+++ b/Assets/Scripts/HeroBalance.cs
@@ -1,0 +1,68 @@
+using Sirenix.OdinInspector;
+using UnityEngine;
+
+[RequireComponent(typeof(Health))]
+[RequireComponent(typeof(BasicAttackTelegraphed))]
+[RequireComponent(typeof(HeroAI))]
+public class HeroBalance : MonoBehaviour
+{
+    [BoxGroup("Stats"), SerializeField]
+    private int baseHealth = 10;
+    [BoxGroup("Stats"), SerializeField]
+    private int baseDefense = 1;
+    [BoxGroup("Combat"), SerializeField]
+    private int baseDamage = 2;
+    [BoxGroup("Combat"), SerializeField]
+    private float attackRate = 1f;
+    [BoxGroup("Combat"), SerializeField]
+    private float attackRange = 4f;
+    [BoxGroup("Combat"), SerializeField]
+    private GameObject projectilePrefab;
+    [BoxGroup("Combat"), SerializeField]
+    private float projectileSpeed = 6f;
+    [BoxGroup("Combat"), SerializeField]
+    private float lookAtDuration = 0.2f;
+
+    [BoxGroup("Healing"), SerializeField]
+    private bool canHealAllies = false;
+    [BoxGroup("Healing"), SerializeField, ShowIf("canHealAllies")]
+    private float healRange = 10f;
+    [BoxGroup("Healing"), SerializeField, ShowIf("canHealAllies")]
+    private int healAmount = 2;
+
+    [BoxGroup("AI"), SerializeField]
+    private float visionRange = 20f;
+    [BoxGroup("AI"), SerializeField]
+    private float safeDistance = 8f;
+
+    private void Start()
+    {
+        var hp = GetComponent<Health>();
+        if (hp != null) hp.SetBaseStats(baseHealth, baseDefense);
+
+        var atk = GetComponent<BasicAttackTelegraphed>();
+        if (atk != null)
+            atk.InitializeStats(baseDamage, attackRate, attackRange, projectileSpeed,
+                lookAtDuration, projectilePrefab, canHealAllies, healRange, healAmount);
+
+        var ai = GetComponent<HeroAI>();
+        if (ai != null) ai.InitializeStats(visionRange, safeDistance);
+    }
+
+#if UNITY_EDITOR
+    private void OnDrawGizmosSelected()
+    {
+        Gizmos.color = Color.cyan;
+        Gizmos.DrawWireSphere(transform.position, visionRange);
+        Gizmos.color = Color.yellow;
+        Gizmos.DrawWireSphere(transform.position, attackRange);
+        Gizmos.color = Color.red;
+        Gizmos.DrawWireSphere(transform.position, safeDistance);
+        if (canHealAllies)
+        {
+            Gizmos.color = Color.green;
+            Gizmos.DrawWireSphere(transform.position, healRange);
+        }
+    }
+#endif
+}


### PR DESCRIPTION
## Summary
- introduce new **HeroBalance** component
- centralize hero stats and gizmo drawing
- update `Health` with `SetBaseStats` helper
- allow `HeroAI` and `BasicAttackTelegraphed` to receive values from `HeroBalance`
- remove gizmo code from hero-related scripts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a1ab58468832e9d75a9cdd657db6e