### PR TITLE
Extend kill count tracking

### DIFF
--- a/Assets/Scripts/Blindsided/Oracle.cs
+++ b/Assets/Scripts/Blindsided/Oracle.cs
@@ -203,6 +203,8 @@ namespace Blindsided
         private void NullCheckers()
         {
             saveData.HeroStates ??= new Dictionary<string, SaveData.SaveData.HeroState>();
+            saveData.HeroKillCounts ??= new Dictionary<string, Dictionary<string, int>>();
+            saveData.GlobalKillCounts ??= new Dictionary<string, int>();
         }
 
         public static void AwayForSeconds()

--- a/Assets/Scripts/Blindsided/SaveData/SaveData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/SaveData.cs
@@ -29,6 +29,12 @@ namespace Blindsided.SaveData
         [HideReferenceObjectPicker] [TabGroup("Heroes")]
         public Dictionary<string, HeroState> HeroStates = new();
 
+        [HideReferenceObjectPicker] [TabGroup("Codex")]
+        public Dictionary<string, Dictionary<string, int>> HeroKillCounts = new();
+
+        [HideReferenceObjectPicker] [TabGroup("Codex")]
+        public Dictionary<string, int> GlobalKillCounts = new();
+
         [HideReferenceObjectPicker]
         public class Preferences
         {

--- a/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
+++ b/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
@@ -8,6 +8,8 @@ namespace Blindsided.SaveData
     {
         
         public static Dictionary<string, int> UpgradeLevels => oracle.saveData.UpgradeLevels;
+        public static Dictionary<string, Dictionary<string, int>> HeroKillCounts => oracle.saveData.HeroKillCounts;
+        public static Dictionary<string, int> GlobalKillCounts => oracle.saveData.GlobalKillCounts;
 
 
         public static BuyMode PurchaseMode


### PR DESCRIPTION
## Summary
- add `HeroKillCounts` and `GlobalKillCounts` to `SaveData`
- expose the new kill count dictionaries through `StaticReferences`
- initialise them when loading save data in `Oracle.NullCheckers`

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684abde0888c832e9328487b1ee2a55a