### PR TITLE
Add kill codex bonuses

### DIFF
--- a/Assets/Scripts/BasicAttackTelegraphed.cs
+++ b/Assets/Scripts/BasicAttackTelegraphed.cs
@@ -12,7 +12,8 @@ public class BasicAttackTelegraphed : MonoBehaviour
 
     private int Level => levelSystem ? levelSystem.Level : 1;
 
-    public int BaseDamage => balance ? balance.baseDamage + balance.damagePerLevel * (Level - 1) : 0;
+    public int BaseDamage
+        => (balance ? balance.baseDamage + balance.damagePerLevel * (Level - 1) : 0) + KillCodexBuffs.BonusDamage;
     public float AttackRange => balance ? balance.attackRange + balance.attackRangePerLevel * (Level - 1) : 0f;
     private float AttackRate => balance ? balance.attackRate + balance.attackRatePerLevel * (Level - 1) : 1f;
     private bool CanHealAllies => balance && balance.canHealAllies;

--- a/Assets/Scripts/Health.cs
+++ b/Assets/Scripts/Health.cs
@@ -19,6 +19,7 @@ public class Health : MonoBehaviour, IDamageable
     private void Awake()
     {
         levelSystem = GetComponent<LevelSystem>();
+        KillCodexBuffs.BuffsChanged += ApplyBalance;
     }
 
     private void Start()
@@ -32,6 +33,7 @@ public class Health : MonoBehaviour, IDamageable
     {
         if (levelSystem != null)
             levelSystem.OnLevelUp -= OnLevelChanged;
+        KillCodexBuffs.BuffsChanged -= ApplyBalance;
     }
 
     public void TakeDamage(int dmg, GameObject attacker)
@@ -73,8 +75,13 @@ public class Health : MonoBehaviour, IDamageable
         int level = levelSystem ? levelSystem.Level : 1;
         if (balance != null)
         {
-            maxHP = balance.baseHealth + balance.healthPerLevel * (level - 1);
-            defense = balance.baseDefense + balance.defensePerLevel * (level - 1);
+            maxHP = balance.baseHealth + balance.healthPerLevel * (level - 1) + KillCodexBuffs.BonusHealth;
+            defense = balance.baseDefense + balance.defensePerLevel * (level - 1) + KillCodexBuffs.BonusDefense;
+        }
+        else
+        {
+            maxHP += KillCodexBuffs.BonusHealth;
+            defense += KillCodexBuffs.BonusDefense;
         }
 
         CurrentHP = maxHP;

--- a/Assets/Scripts/KillCodexBuffs.cs
+++ b/Assets/Scripts/KillCodexBuffs.cs
@@ -1,0 +1,32 @@
+using System;
+
+/// <summary>
+/// Global bonuses granted from the kill codex. Other systems update these
+/// values when certain kill thresholds are met and notify listeners via
+/// <see cref="BuffsChanged"/>.
+/// </summary>
+public static class KillCodexBuffs
+{
+    public static int BonusHealth { get; private set; }
+    public static int BonusDefense { get; private set; }
+    public static int BonusDamage { get; private set; }
+
+    /// <summary>
+    /// Invoked whenever any buff value changes.
+    /// </summary>
+    public static event Action BuffsChanged;
+
+    /// <summary>
+    /// Set new buff values and notify listeners if anything changed.
+    /// </summary>
+    public static void SetBuffs(int health, int defense, int damage)
+    {
+        if (BonusHealth == health && BonusDefense == defense && BonusDamage == damage)
+            return;
+
+        BonusHealth = health;
+        BonusDefense = defense;
+        BonusDamage = damage;
+        BuffsChanged?.Invoke();
+    }
+}


### PR DESCRIPTION
## Summary
- add new `KillCodexBuffs` static class to track global combat bonuses
- include kill codex bonuses when applying health and defense stats
- factor kill codex damage bonus into basic attack damage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684abdf1d384832e8dc95d29d98b6883