### PR TITLE
Switch to single global codex buffs

### DIFF
--- a/Assets/Scripts/BasicAttackTelegraphed.cs
+++ b/Assets/Scripts/BasicAttackTelegraphed.cs
@@ -6,7 +6,6 @@ public class BasicAttackTelegraphed : MonoBehaviour
     [Header("General")] [SerializeField] private LayerMask targetMask;
     [SerializeField] private LayerMask allyMask;
     [SerializeField] private HeroBalanceData balance;
-    [SerializeField] private string heroId = "";
 
     private LevelSystem levelSystem;
     private float nextAttackTime;
@@ -19,11 +18,6 @@ public class BasicAttackTelegraphed : MonoBehaviour
         {
             int dmg = balance ? balance.baseDamage + balance.damagePerLevel * (Level - 1) : 0;
             dmg += KillCodexBuffs.BonusDamage;
-            if (KillCodexManager.Instance != null && !string.IsNullOrEmpty(heroId))
-            {
-                var bonus = KillCodexManager.Instance.GetHeroBonuses(heroId);
-                if (bonus != null) dmg += bonus.bonusDamage;
-            }
             return dmg;
         }
     }
@@ -41,8 +35,6 @@ public class BasicAttackTelegraphed : MonoBehaviour
     private void Awake()
     {
         levelSystem = GetComponent<LevelSystem>();
-        if (string.IsNullOrEmpty(heroId) && TryGetComponent(out HeroCodexInfo info))
-            heroId = info.HeroId;
     }
 
     private void Update()
@@ -95,11 +87,6 @@ public class BasicAttackTelegraphed : MonoBehaviour
         var finalDamage = isPlayerAttack ? BaseDamage * 2 : BaseDamage;
 
         float critChance = KillCodexBuffs.BonusCritChance;
-        if (KillCodexManager.Instance != null && !string.IsNullOrEmpty(heroId))
-        {
-            var bonus = KillCodexManager.Instance.GetHeroBonuses(heroId);
-            if (bonus != null) critChance += bonus.bonusCritChance;
-        }
         if (Random.value < critChance) finalDamage *= 2;
 
         if (ProjectilePrefab == null)

--- a/Assets/Scripts/Codex/KillCodexDatabase.cs
+++ b/Assets/Scripts/Codex/KillCodexDatabase.cs
@@ -23,11 +23,4 @@ public class CodexThreshold
 {
     [MinValue(1)] public int killCount = 1;
     [InlineProperty] public CodexBonusStats globalBonus = new();
-    [TableList] public List<HeroBonus> heroBonuses = new();
-}
-
-[Serializable]
-public class HeroBonus : CodexBonusStats
-{
-    public string heroId;
 }

--- a/Assets/Scripts/Codex/KillCodexManager.cs
+++ b/Assets/Scripts/Codex/KillCodexManager.cs
@@ -9,11 +9,7 @@ public class KillCodexManager : MonoBehaviour
     [SerializeField] private KillCodexDatabase database;
 
     private readonly Dictionary<string, int> killCounts = new();
-    private readonly Dictionary<string, CodexBonusStats> heroBonuses = new();
-
     public static KillCodexManager Instance { get; private set; }
-
-    public static event System.Action HeroBuffsChanged;
 
     private void Awake()
     {
@@ -43,31 +39,8 @@ public class KillCodexManager : MonoBehaviour
         foreach (var threshold in entry.thresholds)
         {
             if (newCount == threshold.killCount)
-            {
                 KillCodexBuffs.AddBuffs(threshold.globalBonus);
-
-                foreach (var heroBonus in threshold.heroBonuses)
-                {
-                    if (!heroBonuses.TryGetValue(heroBonus.heroId, out var stats))
-                    {
-                        stats = new CodexBonusStats();
-                        heroBonuses[heroBonus.heroId] = stats;
-                    }
-
-                    stats.bonusHealth += heroBonus.bonusHealth;
-                    stats.bonusDefense += heroBonus.bonusDefense;
-                    stats.bonusDamage += heroBonus.bonusDamage;
-                    stats.bonusCritChance += heroBonus.bonusCritChance;
-                }
-
-                HeroBuffsChanged?.Invoke();
-            }
         }
     }
 
-    public CodexBonusStats GetHeroBonuses(string heroId)
-    {
-        heroBonuses.TryGetValue(heroId, out var stats);
-        return stats;
-    }
 }

--- a/Assets/Scripts/Health.cs
+++ b/Assets/Scripts/Health.cs
@@ -4,7 +4,6 @@ using UnityEngine;
 public class Health : MonoBehaviour, IDamageable
 {
     [SerializeField] private HeroBalanceData balance;
-    [SerializeField] private string heroId = "";
     [SerializeField] private int maxHP = 10;
     [SerializeField] private int defense = 1;
 
@@ -20,8 +19,6 @@ public class Health : MonoBehaviour, IDamageable
     private void Awake()
     {
         levelSystem = GetComponent<LevelSystem>();
-        if (string.IsNullOrEmpty(heroId) && TryGetComponent(out HeroCodexInfo info))
-            heroId = info.HeroId;
         KillCodexBuffs.BuffsChanged += ApplyBalance;
     }
 
@@ -90,15 +87,7 @@ public class Health : MonoBehaviour, IDamageable
             defense += KillCodexBuffs.BonusDefense;
         }
 
-        if (KillCodexManager.Instance != null && !string.IsNullOrEmpty(heroId))
-        {
-            var bonus = KillCodexManager.Instance.GetHeroBonuses(heroId);
-            if (bonus != null)
-            {
-                maxHP += bonus.bonusHealth;
-                defense += bonus.bonusDefense;
-            }
-        }
+        // All heroes share the same codex bonuses
 
         CurrentHP = maxHP;
         OnHealthChanged?.Invoke(CurrentHP, maxHP);


### PR DESCRIPTION
## Summary
- drop hero-specific codex entries
- simplify KillCodexManager to only track global buffs
- remove hero-specific logic from `BasicAttackTelegraphed` and `Health`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684ace1a8650832e8cab7d27a1e251de