### PR TITLE
Decouple hero and enemy balance data

### DIFF
--- a/Assets/Scripts/BasicAttackTelegraphed.cs
+++ b/Assets/Scripts/BasicAttackTelegraphed.cs
@@ -5,7 +5,7 @@ public class BasicAttackTelegraphed : MonoBehaviour
 {
     [Header("General")] [SerializeField] private LayerMask targetMask;
     [SerializeField] private LayerMask allyMask;
-    [SerializeField] private HeroBalanceData balance;
+    [SerializeField] private CharacterBalanceData balance;
 
     private LevelSystem levelSystem;
     private float nextAttackTime;
@@ -17,7 +17,8 @@ public class BasicAttackTelegraphed : MonoBehaviour
         get
         {
             int dmg = balance ? balance.baseDamage + balance.damagePerLevel * (Level - 1) : 0;
-            dmg += KillCodexBuffs.BonusDamage;
+            if (balance is HeroBalanceData)
+                dmg += KillCodexBuffs.BonusDamage;
             return dmg;
         }
     }
@@ -86,7 +87,7 @@ public class BasicAttackTelegraphed : MonoBehaviour
         var firePos = transform.position;
         var finalDamage = isPlayerAttack ? BaseDamage * 2 : BaseDamage;
 
-        float critChance = KillCodexBuffs.BonusCritChance;
+        float critChance = balance is HeroBalanceData ? KillCodexBuffs.BonusCritChance : 0f;
         if (Random.value < critChance) finalDamage *= 2;
 
         if (ProjectilePrefab == null)

--- a/Assets/Scripts/CharacterBalanceData.cs
+++ b/Assets/Scripts/CharacterBalanceData.cs
@@ -1,0 +1,35 @@
+using UnityEngine;
+using Sirenix.OdinInspector;
+
+/// <summary>
+/// Base class for stats that apply to both heroes and enemies.
+/// </summary>
+public class CharacterBalanceData : ScriptableObject
+{
+    [BoxGroup("Stats"), SerializeField] public int baseHealth = 10;
+    [BoxGroup("Stats"), SerializeField] public int healthPerLevel = 0;
+    [BoxGroup("Stats"), SerializeField] public int baseDefense = 1;
+    [BoxGroup("Stats"), SerializeField] public int defensePerLevel = 0;
+
+    [BoxGroup("Combat"), SerializeField] public int baseDamage = 2;
+    [BoxGroup("Combat"), SerializeField] public int damagePerLevel = 1;
+    [BoxGroup("Combat"), SerializeField, Tooltip("Time between attacks in seconds. 0.5 means two attacks per second.")]
+    public float attackRate = 1f;
+    [BoxGroup("Combat"), SerializeField] public float attackRatePerLevel = 0f;
+    [BoxGroup("Combat"), SerializeField] public float attackRange = 4f;
+    [BoxGroup("Combat"), SerializeField] public float attackRangePerLevel = 0f;
+    [BoxGroup("Combat"), SerializeField] public GameObject projectilePrefab;
+    [BoxGroup("Combat"), SerializeField] public float projectileSpeed = 6f;
+    [BoxGroup("Combat"), SerializeField] public float lookAtDuration = 0.2f;
+
+    [BoxGroup("Healing"), SerializeField] public bool canHealAllies = false;
+    [BoxGroup("Healing"), SerializeField, ShowIf("canHealAllies")] public float healRange = 10f;
+    [BoxGroup("Healing"), SerializeField, ShowIf("canHealAllies")] public float healRangePerLevel = 0f;
+    [BoxGroup("Healing"), SerializeField, ShowIf("canHealAllies")] public int healAmount = 2;
+    [BoxGroup("Healing"), SerializeField, ShowIf("canHealAllies")] public int healAmountPerLevel = 0;
+
+    [BoxGroup("AI"), SerializeField] public float visionRange = 20f;
+    [BoxGroup("AI"), SerializeField] public float visionRangePerLevel = 0f;
+    [BoxGroup("AI"), SerializeField] public float safeDistance = 8f;
+    [BoxGroup("AI"), SerializeField] public float safeDistancePerLevel = 0f;
+}

--- a/Assets/Scripts/EnemyBalanceData.cs
+++ b/Assets/Scripts/EnemyBalanceData.cs
@@ -1,0 +1,6 @@
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "EnemyBalance", menuName = "SO/Enemy Balance")]
+public class EnemyBalanceData : CharacterBalanceData
+{
+}

--- a/Assets/Scripts/Health.cs
+++ b/Assets/Scripts/Health.cs
@@ -5,7 +5,7 @@ using System.Collections;
 /// <summary>Simple HP container with change / death events.</summary>
 public class Health : MonoBehaviour, IDamageable
 {
-    [SerializeField] private HeroBalanceData balance;
+    [SerializeField] private CharacterBalanceData balance;
     [SerializeField] private int maxHP = 10;
     [SerializeField] private int defense = 1;
 
@@ -21,7 +21,8 @@ public class Health : MonoBehaviour, IDamageable
     private void Awake()
     {
         levelSystem = GetComponent<LevelSystem>();
-        KillCodexBuffs.BuffsChanged += ApplyBalance;
+        if (balance is HeroBalanceData)
+            KillCodexBuffs.BuffsChanged += ApplyBalance;
     }
 
     private void Start()
@@ -35,7 +36,8 @@ public class Health : MonoBehaviour, IDamageable
     {
         if (levelSystem != null)
             levelSystem.OnLevelUp -= OnLevelChanged;
-        KillCodexBuffs.BuffsChanged -= ApplyBalance;
+        if (balance is HeroBalanceData)
+            KillCodexBuffs.BuffsChanged -= ApplyBalance;
     }
 
     public void TakeDamage(int dmg, GameObject attacker)
@@ -96,16 +98,16 @@ public class Health : MonoBehaviour, IDamageable
         int level = levelSystem ? levelSystem.Level : 1;
         if (balance != null)
         {
-            maxHP = balance.baseHealth + balance.healthPerLevel * (level - 1) + KillCodexBuffs.BonusHealth;
-            defense = balance.baseDefense + balance.defensePerLevel * (level - 1) + KillCodexBuffs.BonusDefense;
+            maxHP = balance.baseHealth + balance.healthPerLevel * (level - 1);
+            defense = balance.baseDefense + balance.defensePerLevel * (level - 1);
         }
-        else
+
+        if (balance is HeroBalanceData)
         {
             maxHP += KillCodexBuffs.BonusHealth;
             defense += KillCodexBuffs.BonusDefense;
         }
 
-        // All heroes share the same codex bonuses
 
         CurrentHP = maxHP;
         OnHealthChanged?.Invoke(CurrentHP, maxHP);

--- a/Assets/Scripts/HeroAI.cs
+++ b/Assets/Scripts/HeroAI.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 [RequireComponent(typeof(HeroClickMover))]
 public class HeroAI : MonoBehaviour
 {
-    [Header("AI Behavior")] [SerializeField] private HeroBalanceData balance;
+    [Header("AI Behavior")] [SerializeField] private CharacterBalanceData balance;
     [SerializeField] private LayerMask enemyLayer;
     [SerializeField] private LayerMask blockingLayer;
 

--- a/Assets/Scripts/HeroBalanceData.cs
+++ b/Assets/Scripts/HeroBalanceData.cs
@@ -1,33 +1,6 @@
 using UnityEngine;
-using Sirenix.OdinInspector;
 
 [CreateAssetMenu(fileName = "HeroBalance", menuName = "SO/Hero Balance")]
-public class HeroBalanceData : ScriptableObject
+public class HeroBalanceData : CharacterBalanceData
 {
-    [BoxGroup("Stats"), SerializeField] public int baseHealth = 10;
-    [BoxGroup("Stats"), SerializeField] public int healthPerLevel = 0;
-    [BoxGroup("Stats"), SerializeField] public int baseDefense = 1;
-    [BoxGroup("Stats"), SerializeField] public int defensePerLevel = 0;
-
-    [BoxGroup("Combat"), SerializeField] public int baseDamage = 2;
-    [BoxGroup("Combat"), SerializeField] public int damagePerLevel = 1;
-    [BoxGroup("Combat"), SerializeField, Tooltip("Time between attacks in seconds. 0.5 means one attack every half second (2 attacks per second).")]
-    public float attackRate = 1f;
-    [BoxGroup("Combat"), SerializeField] public float attackRatePerLevel = 0f;
-    [BoxGroup("Combat"), SerializeField] public float attackRange = 4f;
-    [BoxGroup("Combat"), SerializeField] public float attackRangePerLevel = 0f;
-    [BoxGroup("Combat"), SerializeField] public GameObject projectilePrefab;
-    [BoxGroup("Combat"), SerializeField] public float projectileSpeed = 6f;
-    [BoxGroup("Combat"), SerializeField] public float lookAtDuration = 0.2f;
-
-    [BoxGroup("Healing"), SerializeField] public bool canHealAllies = false;
-    [BoxGroup("Healing"), SerializeField, ShowIf("canHealAllies")] public float healRange = 10f;
-    [BoxGroup("Healing"), SerializeField, ShowIf("canHealAllies")] public float healRangePerLevel = 0f;
-    [BoxGroup("Healing"), SerializeField, ShowIf("canHealAllies")] public int healAmount = 2;
-    [BoxGroup("Healing"), SerializeField, ShowIf("canHealAllies")] public int healAmountPerLevel = 0;
-
-    [BoxGroup("AI"), SerializeField] public float visionRange = 20f;
-    [BoxGroup("AI"), SerializeField] public float visionRangePerLevel = 0f;
-    [BoxGroup("AI"), SerializeField] public float safeDistance = 8f;
-    [BoxGroup("AI"), SerializeField] public float safeDistancePerLevel = 0f;
 }


### PR DESCRIPTION
## Summary
- introduce `CharacterBalanceData` base class with general combat and stat fields
- create `HeroBalanceData` and new `EnemyBalanceData` derived from the base
- update `Health`, `BasicAttackTelegraphed`, and `HeroAI` to use the shared base
- apply codex buffs only when the balance data is a hero type

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ad46a8c5c832e94e1fdbdfdb126ab