### PR TITLE
Centralize hero balance data and add debug gizmos

### DIFF
--- a/Assets/Scripts/BalanceGizmos.cs
+++ b/Assets/Scripts/BalanceGizmos.cs
@@ -1,0 +1,51 @@
+using UnityEngine;
+
+#if UNITY_EDITOR
+/// <summary>
+/// Draws gizmos representing the ranges defined in <see cref="CharacterBalanceData"/>.
+/// Attach alongside <see cref="BalanceHolder"/> on the same GameObject.
+/// </summary>
+[ExecuteAlways]
+public class BalanceGizmos : MonoBehaviour
+{
+    private BalanceHolder holder;
+    private LevelSystem levelSystem;
+
+    private void Awake()
+    {
+        holder = GetComponent<BalanceHolder>();
+        levelSystem = GetComponent<LevelSystem>();
+    }
+
+    private void OnDrawGizmosSelected()
+    {
+        if (holder == null) holder = GetComponent<BalanceHolder>();
+        if (levelSystem == null) levelSystem = GetComponent<LevelSystem>();
+
+        var balance = holder ? holder.Balance : null;
+        if (balance == null) return;
+
+        var level = levelSystem ? levelSystem.Level : 1;
+
+        float attackRange = balance.attackRange + balance.attackRangePerLevel * (level - 1);
+        float healRange = balance.canHealAllies ? balance.healRange + balance.healRangePerLevel * (level - 1) : 0f;
+        float visionRange = balance.visionRange + balance.visionRangePerLevel * (level - 1);
+        float safeDistance = balance.safeDistance + balance.safeDistancePerLevel * (level - 1);
+
+        Gizmos.color = Color.yellow;
+        Gizmos.DrawWireSphere(transform.position, attackRange);
+
+        if (balance.canHealAllies)
+        {
+            Gizmos.color = Color.green;
+            Gizmos.DrawWireSphere(transform.position, healRange);
+        }
+
+        Gizmos.color = Color.red;
+        Gizmos.DrawWireSphere(transform.position, safeDistance);
+
+        Gizmos.color = Color.cyan;
+        Gizmos.DrawWireSphere(transform.position, visionRange);
+    }
+}
+#endif

--- a/Assets/Scripts/BalanceHolder.cs
+++ b/Assets/Scripts/BalanceHolder.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+/// <summary>
+/// Holds a reference to <see cref="CharacterBalanceData"/> so other
+/// components can access it without each needing a serialized field.
+/// </summary>
+public class BalanceHolder : MonoBehaviour
+{
+    [SerializeField] private CharacterBalanceData balance;
+
+    public CharacterBalanceData Balance => balance;
+}

--- a/Assets/Scripts/BasicAttackTelegraphed.cs
+++ b/Assets/Scripts/BasicAttackTelegraphed.cs
@@ -8,7 +8,8 @@ public class BasicAttack : MonoBehaviour
 {
     [Header("General")] [SerializeField] private LayerMask targetMask;
     [SerializeField] private LayerMask allyMask;
-    [SerializeField] private CharacterBalanceData balance;
+    private CharacterBalanceData balance;
+    private BalanceHolder balanceHolder;
 
     private LevelSystem levelSystem;
     private float nextAttackTime;
@@ -39,6 +40,8 @@ public class BasicAttack : MonoBehaviour
     private void Awake()
     {
         levelSystem = GetComponent<LevelSystem>();
+        balanceHolder = GetComponent<BalanceHolder>();
+        balance = balanceHolder ? balanceHolder.Balance : null;
     }
 
     private void Update()

--- a/Assets/Scripts/Health.cs
+++ b/Assets/Scripts/Health.cs
@@ -5,7 +5,8 @@ using System.Collections;
 /// <summary>Simple HP container with change / death events.</summary>
 public class Health : MonoBehaviour, IDamageable
 {
-    [SerializeField] private CharacterBalanceData balance;
+    private CharacterBalanceData balance;
+    private BalanceHolder balanceHolder;
     [SerializeField] private int maxHP = 10;
     [SerializeField] private int defense = 1;
 
@@ -21,6 +22,8 @@ public class Health : MonoBehaviour, IDamageable
     private void Awake()
     {
         levelSystem = GetComponent<LevelSystem>();
+        balanceHolder = GetComponent<BalanceHolder>();
+        balance = balanceHolder ? balanceHolder.Balance : null;
         if (balance is HeroBalanceData)
             KillCodexBuffs.BuffsChanged += ApplyBalance;
     }

--- a/Assets/Scripts/HeroAI.cs
+++ b/Assets/Scripts/HeroAI.cs
@@ -6,7 +6,8 @@ using TimelessEchoes.Attacks;
 [RequireComponent(typeof(HeroClickMover))]
 public class HeroAI : MonoBehaviour
 {
-    [Header("AI Behavior")] [SerializeField] private CharacterBalanceData balance;
+    [Header("AI Behavior")] private CharacterBalanceData balance;
+    private BalanceHolder balanceHolder;
     [SerializeField] private LayerMask enemyLayer;
     [SerializeField] private LayerMask blockingLayer;
 
@@ -39,6 +40,8 @@ public class HeroAI : MonoBehaviour
         mover = GetComponent<HeroClickMover>();
         attacker = GetComponent<BasicAttack>();
         levelSystem = GetComponent<LevelSystem>();
+        balanceHolder = GetComponent<BalanceHolder>();
+        balance = balanceHolder ? balanceHolder.Balance : null;
         enemyFilter = new ContactFilter2D { layerMask = enemyLayer, useLayerMask = true, useTriggers = false };
         blockingFilter = new ContactFilter2D { layerMask = blockingLayer, useLayerMask = true, useTriggers = false };
 


### PR DESCRIPTION
## Summary
- add **BalanceHolder** to store CharacterBalanceData on one component
- fetch balance from `BalanceHolder` in Health, BasicAttack and HeroAI
- add **BalanceGizmos** to draw ranges from balance data

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684ea0486328832eb725704b02cb0549