### PR TITLE
Spawn move target at hero location

### DIFF
--- a/Assets/Scripts/HeroClickMover.cs
+++ b/Assets/Scripts/HeroClickMover.cs
@@ -28,6 +28,7 @@ public class HeroClickMover : MonoBehaviour
         // personal hidden target ------------------------------------
         var go = new GameObject($"{name}_MoveTarget");
         moveTarget = go.transform;
+        moveTarget.position = transform.position;
         //moveTarget.SetParent(transform);
         dst.target = moveTarget;
         go.hideFlags = HideFlags.HideInHierarchy;


### PR DESCRIPTION
## Summary
- keep heroes from drifting to (0,0) on startup by spawning their move target at the hero's position

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ea5e9f6d4832e97a9afb57b14fdb5