### PR TITLE
Add EnemyBalanceHolder and update dropper

### DIFF
--- a/Assets/Scripts/EnemyBalanceHolder.cs
+++ b/Assets/Scripts/EnemyBalanceHolder.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+/// <summary>
+/// Holds a reference to <see cref="EnemyBalanceData"/> so enemy
+/// components can access it without each needing a serialized field.
+/// </summary>
+public class EnemyBalanceHolder : MonoBehaviour
+{
+    [SerializeField] private EnemyBalanceData balance;
+
+    public EnemyBalanceData Balance => balance;
+}

--- a/Assets/Scripts/Gear/EnemyDropper.cs
+++ b/Assets/Scripts/Gear/EnemyDropper.cs
@@ -7,8 +7,8 @@ public class EnemyDropper : MonoBehaviour
 
     private void Awake()
     {
-        var holder = GetComponent<BalanceHolder>();
-        balance = holder ? holder.Balance as EnemyBalanceData : null;
+        var holder = GetComponent<EnemyBalanceHolder>();
+        balance = holder ? holder.Balance : null;
         GetComponent<Health>().OnDeath += SpawnDrop;
     }
 


### PR DESCRIPTION
## Summary
- add EnemyBalanceHolder to store EnemyBalanceData on enemy objects
- update EnemyDropper to use EnemyBalanceHolder

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684fcc4b82ec832e88a7e4328888ccf5