### PR TITLE
Fix drop initialization in EnemyDropper

### DIFF
--- a/Assets/Scripts/Gear/EnemyDropper.cs
+++ b/Assets/Scripts/Gear/EnemyDropper.cs
@@ -23,7 +23,14 @@ namespace Gear
             if (dropPrefab)
             {
                 var drop = Instantiate(dropPrefab, transform.position, Quaternion.identity);
-                drop.Init(gear);
+                if (drop)
+                {
+                    drop.Init(gear);
+                }
+                else
+                {
+                    Debug.LogWarning("EnemyDropper: dropPrefab is missing GearDrop component", this);
+                }
             }
             else
             {


### PR DESCRIPTION
## Summary
- guard against missing GearDrop component when instantiating enemy drop prefab

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684fe40b90e0832ebf5f89b7ccd90587