### PR TITLE
Fix deprecated API usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,3 +5,4 @@ When making changes to this Unity project:
 - Consult the official Unity documentation at <https://docs.unity3d.com> to confirm APIs and best practices.
 - Ensure compatibility with **Unity 6000.1.6f1**, the version used by Timeless Echoes.
 - Do not create or commit `.meta` files.
+- Avoid using obsolete Unity API calls. For example, replace `Object.FindObjectOfType` with `Object.FindFirstObjectByType` or `Object.FindAnyObjectByType`.

--- a/Assets/Scripts/Gear/GearDrop.cs
+++ b/Assets/Scripts/Gear/GearDrop.cs
@@ -57,7 +57,7 @@ namespace Gear
 
         private string BuildStatList()
         {
-            var hero = FindObjectOfType<PartyManager>()?.ActiveHero;
+            var hero = FindFirstObjectByType<PartyManager>()?.ActiveHero;
             GearItem equipped = null;
             if (hero && hero.TryGetComponent(out BalanceHolder holder))
             {
@@ -123,7 +123,7 @@ namespace Gear
 
         private void Equip()
         {
-            var hero = FindObjectOfType<PartyManager>()?.ActiveHero;
+            var hero = FindFirstObjectByType<PartyManager>()?.ActiveHero;
             if (hero && hero.TryGetComponent(out BalanceHolder holder))
             {
                 var gear = holder.Gear;


### PR DESCRIPTION
## Summary
- replace deprecated `FindObjectOfType` with `FindFirstObjectByType`
- document modern API use in AGENTS instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ff29e1350832e9ea2f7c9d3fd434a