### PR TITLE
Update gear drop stats when hero changes

### DIFF
--- a/Assets/Scripts/Gear/GearDrop.cs
+++ b/Assets/Scripts/Gear/GearDrop.cs
@@ -16,6 +16,16 @@ namespace Gear
         [SerializeField] private DropReferences references;
         private Image timerFill;
 
+        private void OnEnable()
+        {
+            PartyManager.ActiveHeroChanged += OnHeroChanged;
+        }
+
+        private void OnDisable()
+        {
+            PartyManager.ActiveHeroChanged -= OnHeroChanged;
+        }
+
         private void Update()
         {
             if (timer > 0f)
@@ -53,6 +63,12 @@ namespace Gear
 
             if (references.rarityImage)
                 references.rarityImage.OutlineColor = GetRarityColor(item.rarity);
+        }
+
+        private void OnHeroChanged(GameObject hero)
+        {
+            if (references && references.statsText)
+                references.statsText.text = BuildStatList();
         }
 
         private string BuildStatList()

--- a/Assets/Scripts/PartyManager.cs
+++ b/Assets/Scripts/PartyManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 using TimelessEchoes.Attacks;
@@ -26,6 +27,9 @@ public class PartyManager : MonoBehaviour
 
     /// <summary>The currently active hero or null if none.</summary>
     public GameObject ActiveHero => IsValidIndex(activeIdx) ? heroes[activeIdx] : null;
+
+    /// <summary>Fires whenever the active hero changes. Parameter is the new hero GameObject.</summary>
+    public static Action<GameObject> ActiveHeroChanged;
 
     // stored delegates so we can unsubscribe on destroy
     private readonly List<System.Action<int, int>> hpChangedDelegates = new();
@@ -189,6 +193,8 @@ public class PartyManager : MonoBehaviour
         SnapCameraToActiveHero();
 
         RefreshCardVisuals(index);
+
+        ActiveHeroChanged?.Invoke(ActiveHero);
     }
 
     /* ─── Camera helpers ─── */


### PR DESCRIPTION
## Summary
- add `ActiveHeroChanged` event to `PartyManager`
- invoke event whenever the active hero changes
- refresh ground gear stat comparison when hero is swapped

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684ff5e10c4c832eb2abd29bec24603d