### PR TITLE
Fix camera snapping on hero swap

### DIFF
--- a/Assets/Scripts/PartyManager.cs
+++ b/Assets/Scripts/PartyManager.cs
@@ -190,7 +190,8 @@ public class PartyManager : MonoBehaviour
                 mover.SetSelected(on);
         }
 
-        SnapCameraToActiveHero();
+        if (followActiveHero)
+            SnapCameraToActiveHero();
 
         RefreshCardVisuals(index);
 


### PR DESCRIPTION
## Summary
- avoid unneeded camera reposition when changing the active hero

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ffc7f4e58832ea9dbc58b4ccf1cde