### PR TITLE
Add basic enemy system

### DIFF
--- a/Assets/Scripts/Enemies/Enemy.cs
+++ b/Assets/Scripts/Enemies/Enemy.cs
@@ -1,0 +1,100 @@
+using UnityEngine;
+using Pathfinding;
+
+namespace TimelessEchoes.Enemies
+{
+    [RequireComponent(typeof(AIPath))]
+    [RequireComponent(typeof(AIDestinationSetter))]
+    [RequireComponent(typeof(RVOController))]
+    [RequireComponent(typeof(Health))]
+    public class Enemy : MonoBehaviour
+    {
+        [SerializeField] private EnemyStats stats;
+        [SerializeField] private Animator animator;
+        [SerializeField] private SpriteRenderer spriteRenderer;
+        [SerializeField] private Transform projectileOrigin;
+
+        private AIPath ai;
+        private AIDestinationSetter setter;
+        private Health health;
+        private Transform startTarget;
+        private Vector3 spawnPos;
+        private float nextAttack;
+
+        private void Awake()
+        {
+            ai = GetComponent<AIPath>();
+            setter = GetComponent<AIDestinationSetter>();
+            health = GetComponent<Health>();
+            spawnPos = transform.position;
+            if (stats != null)
+            {
+                ai.maxSpeed = stats.moveSpeed;
+                health.Init(stats.maxHealth);
+            }
+            startTarget = setter.target;
+        }
+
+        private void Update()
+        {
+            UpdateAnimation();
+            UpdateBehavior();
+        }
+
+        private void UpdateAnimation()
+        {
+            Vector2 vel = ai.desiredVelocity;
+            Vector2 dir = vel;
+            if (Mathf.Abs(dir.x) >= Mathf.Abs(dir.y)) dir.y = 0f; else dir.x = 0f;
+            animator.SetFloat("MoveX", dir.x);
+            animator.SetFloat("MoveY", dir.y);
+            animator.SetFloat("MoveMagnitude", vel.magnitude);
+            if (spriteRenderer != null)
+                spriteRenderer.flipX = vel.x < 0f;
+        }
+
+        private void UpdateBehavior()
+        {
+            if (setter.target == null || stats == null)
+            {
+                Wander();
+                return;
+            }
+
+            float dist = Vector2.Distance(transform.position, setter.target.position);
+            if (dist <= stats.visionRange)
+            {
+                ai.destination = setter.target.position;
+                if (Time.time >= nextAttack)
+                {
+                    nextAttack = Time.time + 1f / Mathf.Max(stats.attackSpeed, 0.01f);
+                    animator.SetTrigger("Attack");
+                    FireProjectile();
+                }
+            }
+            else
+            {
+                Wander();
+            }
+        }
+
+        private void Wander()
+        {
+            if (ai.reachedEndOfPath)
+            {
+                Vector2 wander = spawnPos + (Vector3)Random.insideUnitCircle * stats.wanderDistance;
+                ai.destination = wander;
+            }
+        }
+
+        private void FireProjectile()
+        {
+            if (stats.projectilePrefab == null || setter.target == null) return;
+            Transform origin = projectileOrigin ? projectileOrigin : transform;
+            var projObj = Instantiate(stats.projectilePrefab, origin.position, Quaternion.identity);
+            var proj = projObj.GetComponent<Projectile>();
+            if (proj != null)
+                proj.Init(setter.target, stats.damage);
+        }
+    }
+}

--- a/Assets/Scripts/Enemies/EnemyBalanceWindow.cs
+++ b/Assets/Scripts/Enemies/EnemyBalanceWindow.cs
@@ -1,0 +1,23 @@
+#if UNITY_EDITOR
+using Sirenix.OdinInspector.Editor;
+using UnityEditor;
+
+namespace TimelessEchoes.Enemies
+{
+    public class EnemyBalanceWindow : OdinMenuEditorWindow
+    {
+        [MenuItem("Tools/Enemy Balance")]
+        private static void Open()
+        {
+            GetWindow<EnemyBalanceWindow>();
+        }
+
+        protected override OdinMenuTree BuildMenuTree()
+        {
+            var tree = new OdinMenuTree();
+            tree.AddAllAssetsAtPath("Enemies", "Assets", typeof(EnemyStats), true);
+            return tree;
+        }
+    }
+}
+#endif

--- a/Assets/Scripts/Enemies/EnemyStats.cs
+++ b/Assets/Scripts/Enemies/EnemyStats.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+using Blindsided.Utilities;
+
+namespace TimelessEchoes.Enemies
+{
+    [ManageableData]
+    [CreateAssetMenu(fileName = "EnemyStats", menuName = "SO/Enemy Stats")]
+    public class EnemyStats : ScriptableObject
+    {
+        public int maxHealth = 10;
+        public int experience = 10;
+        [Range(0f, 1f)] public float gearDropChance = 0.1f;
+        public int defense = 0;
+        public int damage = 1;
+        public float moveSpeed = 3f;
+        public float attackSpeed = 1f;
+        public float visionRange = 5f;
+        public float wanderDistance = 2f;
+        public GameObject projectilePrefab;
+    }
+}

--- a/Assets/Scripts/Enemies/Health.cs
+++ b/Assets/Scripts/Enemies/Health.cs
@@ -1,0 +1,47 @@
+using System;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TimelessEchoes.Enemies
+{
+    public class Health : MonoBehaviour, IDamageable, IHasHealth
+    {
+        [SerializeField] private int maxHealth = 10;
+        [SerializeField] private Image healthBar;
+
+        public float CurrentHealth { get; private set; }
+        public float MaxHealth => maxHealth;
+
+        public event Action OnDeath;
+
+        private void Awake()
+        {
+            CurrentHealth = maxHealth;
+            UpdateBar();
+        }
+
+        public void Init(int hp)
+        {
+            maxHealth = hp;
+            CurrentHealth = hp;
+            UpdateBar();
+        }
+
+        public void TakeDamage(float amount)
+        {
+            if (CurrentHealth <= 0f) return;
+            CurrentHealth -= amount;
+            UpdateBar();
+            if (CurrentHealth <= 0f)
+            {
+                OnDeath?.Invoke();
+            }
+        }
+
+        private void UpdateBar()
+        {
+            if (healthBar != null)
+                healthBar.fillAmount = CurrentHealth / MaxHealth;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `EnemyStats` ScriptableObject for configuring enemies
- implement `Health` component with UI bar
- implement `Enemy` behaviour using AIPath pathfinding
- add `EnemyBalanceWindow` editor for Odin-based balancing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858923cd4b8832eb95d6aa6d740e65e