### PR TITLE
Add two-directional animation option and sliced health

### DIFF
--- a/Assets/Scripts/Enemies/Enemy.cs
+++ b/Assets/Scripts/Enemies/Enemy.cs
@@ -13,6 +13,7 @@ namespace TimelessEchoes.Enemies
         [SerializeField] private EnemyStats stats;
         [SerializeField] private Animator animator;
         [SerializeField] private SpriteRenderer spriteRenderer;
+        [SerializeField] private bool fourDirectional = true;
         [SerializeField] private Transform projectileOrigin;
 
         private AIPath ai;
@@ -58,7 +59,17 @@ namespace TimelessEchoes.Enemies
         {
             Vector2 vel = ai.desiredVelocity;
             Vector2 dir = vel;
-            if (Mathf.Abs(dir.x) >= Mathf.Abs(dir.y)) dir.y = 0f; else dir.x = 0f;
+            if (fourDirectional)
+            {
+                if (Mathf.Abs(dir.x) >= Mathf.Abs(dir.y))
+                    dir.y = 0f;
+                else
+                    dir.x = 0f;
+            }
+            else
+            {
+                dir.y = 0f;
+            }
             animator.SetFloat("MoveX", dir.x);
             animator.SetFloat("MoveY", dir.y);
             animator.SetFloat("MoveMagnitude", vel.magnitude);

--- a/Assets/Scripts/Enemies/Health.cs
+++ b/Assets/Scripts/Enemies/Health.cs
@@ -1,13 +1,14 @@
 using System;
 using UnityEngine;
 using UnityEngine.UI;
+using Blindsided.Utilities;
 
 namespace TimelessEchoes.Enemies
 {
     public class Health : MonoBehaviour, IDamageable, IHasHealth
     {
         [SerializeField] private int maxHealth = 10;
-        [SerializeField] private Image healthBar;
+        [SerializeField] private SlicedFilledImage healthBar;
 
         public float CurrentHealth { get; private set; }
         public float MaxHealth => maxHealth;


### PR DESCRIPTION
## Summary
- add toggle for 2- or 4-directional enemy animations
- switch health bar to use `SlicedFilledImage`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858a942f324832e94d25bc363c4d9ac