### PR TITLE
Add random animator offset for enemies

### DIFF
--- a/Assets/Scripts/Enemies/Enemy.cs
+++ b/Assets/Scripts/Enemies/Enemy.cs
@@ -49,6 +49,14 @@ namespace TimelessEchoes.Enemies
         {
             registry = TargetRegistry.Instance;
             registry?.Register(transform);
+
+            // Offset the animator's starting time so enemies don't animate
+            // in perfect sync when spawned simultaneously.
+            if (animator != null)
+            {
+                var state = animator.GetCurrentAnimatorStateInfo(0);
+                animator.Play(state.fullPathHash, 0, Random.value);
+            }
         }
 
         private void OnDisable()


### PR DESCRIPTION
## Summary
- prevent enemy animations from syncing by randomizing start time on enable

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858af284274832e94f3b462e30268f7