### PR TITLE
Update attack flow and task control

### DIFF
--- a/Assets/Scripts/Enemies/Enemy.cs
+++ b/Assets/Scripts/Enemies/Enemy.cs
@@ -19,7 +19,6 @@ namespace TimelessEchoes.Enemies
         private AIPath ai;
         private Health health;
         private float nextAttack;
-        private TargetRegistry registry;
         private AIDestinationSetter setter;
         private Vector3 spawnPos;
         private Transform startTarget;
@@ -47,8 +46,7 @@ namespace TimelessEchoes.Enemies
 
         private void OnEnable()
         {
-            registry = TargetRegistry.Instance;
-            registry?.Register(transform);
+            
 
             // Offset the animator's starting time so enemies don't animate
             // in perfect sync when spawned simultaneously.
@@ -59,10 +57,6 @@ namespace TimelessEchoes.Enemies
             }
         }
 
-        private void OnDisable()
-        {
-            registry?.Unregister(transform);
-        }
 
         private void UpdateAnimation()
         {
@@ -102,7 +96,7 @@ namespace TimelessEchoes.Enemies
                 if (Time.time >= nextAttack)
                 {
                     nextAttack = Time.time + 1f / Mathf.Max(stats.attackSpeed, 0.01f);
-                    animator.SetTrigger("Attack");
+                    animator.Play("Attack");
                     FireProjectile();
                 }
             }


### PR DESCRIPTION
## Summary
- play `Attack` animation directly for hero and enemies
- show current task name on the `TaskController`
- have the `TaskController` assign tasks and destinations to the hero
- assign hero to enemies when in range instead of using `TargetRegistry`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858bb269a6c832ea47b8d82a7d86e13