### PR TITLE
Manual task order and enemy cleanup

### DIFF
--- a/Assets/Scripts/Enemies/Health.cs
+++ b/Assets/Scripts/Enemies/Health.cs
@@ -36,6 +36,10 @@ namespace TimelessEchoes.Enemies
             if (CurrentHealth <= 0f)
             {
                 OnDeath?.Invoke();
+
+                // Automatically remove enemies when their health reaches zero
+                if (GetComponent<Enemy>() != null)
+                    Destroy(gameObject);
             }
         }
 

--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -85,7 +85,12 @@ namespace TimelessEchoes.Hero
         public void SetTask(ITask task)
         {
             currentTask = task;
-            setter.target = task != null ? task.Target : null;
+            // Ensure the destination setter is initialized even if Awake has not run yet
+            if (setter == null)
+                setter = GetComponent<AIDestinationSetter>();
+
+            if (setter != null)
+                setter.target = task != null ? task.Target : null;
         }
 
         public void SetDestination(Transform dest)

--- a/Assets/Scripts/Tasks/TaskController.cs
+++ b/Assets/Scripts/Tasks/TaskController.cs
@@ -33,13 +33,35 @@ namespace TimelessEchoes.Tasks
         {
             currentIndex = -1;
             tasks.Clear();
-            GatherEnemyTasks();
+
+            // Build the task list in the order provided by the editor
             foreach (var obj in taskObjects)
             {
-                if (obj is ITask task && !tasks.Contains(task))
-                    tasks.Add(task);
+                if (obj == null) continue;
+
+                // If an enemy component is supplied, ensure it has a KillEnemyTask
+                var enemy = obj.GetComponent<Enemies.Enemy>();
+                if (enemy != null)
+                {
+                    var kill = enemy.GetComponent<KillEnemyTask>();
+                    if (kill == null)
+                        kill = enemy.gameObject.AddComponent<KillEnemyTask>();
+                    kill.target = enemy.transform;
+                    tasks.Add(kill);
+                    continue;
+                }
+
+                if (obj is ITask existing)
+                {
+                    tasks.Add(existing);
+                    continue;
+                }
+
+                var compTask = obj.GetComponent<ITask>();
+                if (compTask != null)
+                    tasks.Add(compTask);
             }
-            SortTasksByDistance();
+
             hero?.SetTask(null);
             hero?.SetDestination(entryPoint);
             SelectNextTask();


### PR DESCRIPTION
## Summary
- allow manual task ordering in `TaskController`
- ensure enemies with no health are destroyed
- handle uninitialized hero destination setter

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6858bdf37de8832ebacdcdb2d70d1914