### PR TITLE
Fix hero orientation and task startup

### DIFF
--- a/Assets/Scripts/Tasks/TaskController.cs
+++ b/Assets/Scripts/Tasks/TaskController.cs
@@ -16,6 +16,9 @@ namespace TimelessEchoes.Tasks
         [SerializeField] private Transform entryPoint;
         [SerializeField] private Transform exitPoint;
 
+        public Transform EntryPoint => entryPoint;
+        public Transform ExitPoint => exitPoint;
+
         [SerializeField] private LayerMask enemyMask = ~0;
 
         [SerializeField] private Hero.HeroController hero;
@@ -23,6 +26,12 @@ namespace TimelessEchoes.Tasks
         [SerializeField] private string currentTaskName;
 
         private int currentIndex = -1;
+
+        private void Awake()
+        {
+            if (hero == null)
+                hero = GetComponent<Hero.HeroController>();
+        }
 
         private void OnEnable()
         {


### PR DESCRIPTION
## Summary
- add automatic TaskController and last move direction in HeroController
- maintain animation direction during attacks
- expose entry/exit points via property and grab HeroController automatically

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858c083f4ac832e8f6055866d86943e