### PR TITLE
Fix hero skipping first enemy

### DIFF
--- a/Assets/Scripts/Tasks/KillEnemyTask.cs
+++ b/Assets/Scripts/Tasks/KillEnemyTask.cs
@@ -16,14 +16,22 @@ namespace TimelessEchoes.Tasks
 
         public void StartTask()
         {
+            // Remove any previous death listener in case this component is reused
+            if (health != null)
+                health.OnDeath -= OnDeath;
+
+            complete = false;
+
             if (target == null)
             {
                 complete = true;
                 return;
             }
+
             health = target.GetComponent<Health>();
             if (health != null)
                 health.OnDeath += OnDeath;
+
             if (health == null || health.CurrentHealth <= 0f)
                 complete = true;
         }


### PR DESCRIPTION
## Summary
- ensure `KillEnemyTask` resets when reused so every assigned enemy is targeted

## Testing
- `echo "No tests configured"`

------
https://chatgpt.com/codex/tasks/task_e_6858c1fff1c0832e8c5a62859b1a09a6