### PR TITLE
Fix skipping first enemy in TaskController

### DIFF
--- a/Assets/Scripts/Tasks/TaskController.cs
+++ b/Assets/Scripts/Tasks/TaskController.cs
@@ -52,6 +52,10 @@ namespace TimelessEchoes.Tasks
                 var enemy = obj.GetComponent<Enemies.Enemy>();
                 if (enemy != null)
                 {
+                    // Ensure the enemy's health is initialized before tasks start
+                    var hp = enemy.GetComponent<Enemies.Health>();
+                    if (hp != null)
+                        hp.Init((int)hp.MaxHealth);
                     var kill = enemy.GetComponent<KillEnemyTask>();
                     if (kill == null)
                         kill = enemy.gameObject.AddComponent<KillEnemyTask>();


### PR DESCRIPTION
## Summary
- ensure enemy health is initialized before adding `KillEnemyTask`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858c452ed48832eaaaf28936ea339fc