### PR TITLE
Fix hero first attack delay

### DIFF
--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -62,6 +62,7 @@ namespace TimelessEchoes.Hero
                 animator.Play(state.fullPathHash, 0, Random.value);
             }
             currentTask = null;
+            lastAttack = Time.time - 1f / CurrentAttackRate;
         }
 
 


### PR DESCRIPTION
## Summary
- set the hero's last attack time when enabled so the first roll is properly timed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685910cf2020832e910f7f13e2dffd54