### PR TITLE
Add camera clamp extension

### DIFF
--- a/Assets/Scripts/CameraClampExtension.cs
+++ b/Assets/Scripts/CameraClampExtension.cs
@@ -1,0 +1,33 @@
+using Cinemachine;
+using UnityEngine;
+
+namespace TimelessEchoes
+{
+    /// <summary>
+    /// Cinemachine extension that clamps the camera to a fixed Y level and
+    /// prevents the X position from going below a minimum value.
+    /// Attach this component to a CinemachineVirtualCamera.
+    /// </summary>
+    [SaveDuringPlay]
+    [AddComponentMenu("")]
+    public class CameraClampExtension : CinemachineExtension
+    {
+        [SerializeField] private float yLevel = 0f;
+        [SerializeField] private float minX = 0f;
+
+        protected override void PostPipelineStageCallback(
+            CinemachineVirtualCameraBase vcam,
+            CinemachineCore.Stage stage,
+            ref CameraState state,
+            float deltaTime)
+        {
+            if (stage == CinemachineCore.Stage.Body)
+            {
+                var pos = state.RawPosition;
+                pos.y = yLevel;
+                pos.x = Mathf.Max(minX, pos.x);
+                state.RawPosition = pos;
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ The game continues to run maps while closed. When you return, the results of the
 ## Playing
 Open the `Main` scene in `Assets/Scenes` and press **Play**.
 
+## Camera
+The scene uses a **Cinemachine Virtual Camera** to follow the hero. Add the
+`CameraClampExtension` component to the virtual camera to keep its Y position
+locked at zero and prevent the camera from moving left of `x = 0`.
+
 ## Tasks
 Task scripts can be found under `Assets/Scripts/Tasks`. Add any of the
 provided tasks to a `TaskController` component and assign entry and exit


### PR DESCRIPTION
## Summary
- add `CameraClampExtension` script to lock y and clamp x for Cinemachine
- document camera setup in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859130886d0832ebe326a8e02292017