### PR TITLE
Fix Cinemachine clamp extension

### DIFF
--- a/Assets/Scripts/CameraClampExtension.cs
+++ b/Assets/Scripts/CameraClampExtension.cs
@@ -1,4 +1,4 @@
-using Cinemachine;
+using Unity.Cinemachine;
 using UnityEngine;
 
 namespace TimelessEchoes
@@ -23,10 +23,10 @@ namespace TimelessEchoes
         {
             if (stage == CinemachineCore.Stage.Finalize)
             {
-                var pos = state.FinalPosition;
+                var pos = state.GetFinalPosition();
                 pos.y = yLevel;
                 pos.x = Mathf.Max(minX, pos.x);
-                state.PositionCorrection += pos - state.FinalPosition;
+                state.PositionCorrection += pos - state.GetFinalPosition();
             }
         }
     }


### PR DESCRIPTION
## Summary
- update namespace to `Unity.Cinemachine`
- replace removed `FinalPosition` property with `GetFinalPosition()`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859203b8c1c832e895ca9f32253a94e