### PR TITLE
Implement resource tracking

### DIFF
--- a/Assets/Scripts/Blindsided/Oracle.cs
+++ b/Assets/Scripts/Blindsided/Oracle.cs
@@ -6,6 +6,7 @@ using Sirenix.OdinInspector;
 using Sirenix.Serialization;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using TimelessEchoes.Upgrades;
 
 namespace Blindsided
 {
@@ -204,6 +205,7 @@ namespace Blindsided
         {
             saveData.HeroStates ??= new Dictionary<string, SaveData.SaveData.HeroState>();
             saveData.GlobalKillCounts ??= new Dictionary<string, int>();
+            saveData.ResourceAmounts ??= new Dictionary<Resource, int>();
         }
 
         public static void AwayForSeconds()

--- a/Assets/Scripts/Blindsided/SaveData/SaveData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/SaveData.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using TimelessEchoes.Gear;
+using TimelessEchoes.Upgrades;
 using Sirenix.OdinInspector;
 
 namespace Blindsided.SaveData
@@ -36,6 +37,9 @@ namespace Blindsided.SaveData
 
         [HideReferenceObjectPicker] [TabGroup("UpgradeSystem")]
         public Dictionary<string, int> UpgradeLevels = new();
+
+        [HideReferenceObjectPicker]
+        public Dictionary<Resource, int> ResourceAmounts = new();
 
         [HideReferenceObjectPicker]
         public class Preferences

--- a/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
+++ b/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using static Blindsided.Oracle;
 using static Blindsided.SaveData.SaveData;
+using TimelessEchoes.Upgrades;
 
 namespace Blindsided.SaveData
 {
@@ -10,6 +11,7 @@ namespace Blindsided.SaveData
         public static Dictionary<string, int> UpgradeLevels => oracle.saveData.UpgradeLevels;
         public static Dictionary<string, int> GlobalKillCounts => oracle.saveData.GlobalKillCounts;
         public static Dictionary<string, SaveData.HeroGearState> HeroGear => oracle.saveData.HeroGear;
+        public static Dictionary<Resource, int> ResourceAmounts => oracle.saveData.ResourceAmounts;
         public static int ItemShards
         {
             get => oracle.saveData.ItemShards;

--- a/Assets/Scripts/Upgrades/Resource.cs
+++ b/Assets/Scripts/Upgrades/Resource.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+using Blindsided.Utilities;
+
+namespace TimelessEchoes.Upgrades
+{
+    [ManageableData]
+    [CreateAssetMenu(fileName = "Resource", menuName = "SO/Upgrade Resource")]
+    public class Resource : ScriptableObject
+    {
+        public Sprite icon;
+    }
+}

--- a/Assets/Scripts/Upgrades/ResourceManager.cs
+++ b/Assets/Scripts/Upgrades/ResourceManager.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using UnityEngine;
+using static Blindsided.EventHandler;
+using static Blindsided.Oracle;
+
+namespace TimelessEchoes.Upgrades
+{
+    public class ResourceManager : MonoBehaviour
+    {
+        private Dictionary<Resource, int> amounts = new();
+
+        private void Awake()
+        {
+            LoadState();
+            OnSaveData += SaveState;
+            OnLoadData += LoadState;
+        }
+
+        private void OnDestroy()
+        {
+            OnSaveData -= SaveState;
+            OnLoadData -= LoadState;
+        }
+
+        public int GetAmount(Resource resource)
+        {
+            return amounts.TryGetValue(resource, out var value) ? value : 0;
+        }
+
+        public void Add(Resource resource, int amount)
+        {
+            if (resource == null || amount <= 0) return;
+            if (amounts.ContainsKey(resource))
+                amounts[resource] += amount;
+            else
+                amounts[resource] = amount;
+        }
+
+        public bool Spend(Resource resource, int amount)
+        {
+            if (resource == null || amount <= 0) return true;
+            var current = GetAmount(resource);
+            if (current < amount) return false;
+            amounts[resource] = current - amount;
+            return true;
+        }
+
+        private void SaveState()
+        {
+            if (oracle == null) return;
+            oracle.saveData.ResourceAmounts = new Dictionary<Resource, int>(amounts);
+        }
+
+        private void LoadState()
+        {
+            if (oracle == null) return;
+            oracle.saveData.ResourceAmounts ??= new Dictionary<Resource, int>();
+            amounts = new Dictionary<Resource, int>(oracle.saveData.ResourceAmounts);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add upgrade `Resource` scriptable object
- track upgrade resources in `SaveData`
- ensure `Oracle` initializes new resource data
- expose `ResourceAmounts` in `StaticReferences`
- implement `ResourceManager` for adding and spending resources

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68592e3b8290832e901c228c6640e399