### PR TITLE
Implement scalable resource cost for upgrades

### DIFF
--- a/Assets/Scripts/Upgrades/StatUpgrade.cs
+++ b/Assets/Scripts/Upgrades/StatUpgrade.cs
@@ -25,6 +25,7 @@ namespace TimelessEchoes.Upgrades
         {
             public Resource resource;
             public int amount;
+            public int amountIncreasePerLevel = 0;
         }
     }
 }

--- a/Assets/Scripts/Upgrades/StatUpgradeController.cs
+++ b/Assets/Scripts/Upgrades/StatUpgradeController.cs
@@ -39,7 +39,9 @@ namespace TimelessEchoes.Upgrades
             if (threshold == null) return false;
             foreach (var req in threshold.requirements)
             {
-                if (resourceManager != null && resourceManager.GetAmount(req.resource) < req.amount)
+                int lvl = GetLevel(upgrade);
+                int cost = req.amount + Mathf.Max(0, lvl - threshold.minLevel) * req.amountIncreasePerLevel;
+                if (resourceManager != null && resourceManager.GetAmount(req.resource) < cost)
                     return false;
             }
             return true;
@@ -53,7 +55,9 @@ namespace TimelessEchoes.Upgrades
 
             foreach (var req in threshold.requirements)
             {
-                resourceManager?.Spend(req.resource, req.amount);
+                int lvl = GetLevel(upgrade);
+                int cost = req.amount + Mathf.Max(0, lvl - threshold.minLevel) * req.amountIncreasePerLevel;
+                resourceManager?.Spend(req.resource, cost);
             }
 
             levels[upgrade] = GetLevel(upgrade) + 1;


### PR DESCRIPTION
## Summary
- add `amountIncreasePerLevel` to each `ResourceRequirement`
- scale the amount of each resource consumed per level within a threshold

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68593b132f14832eb52e987294923a64