### PR TITLE
Add custom editor for resource preview

### DIFF
--- a/Assets/Editor/ResourceEditor.cs
+++ b/Assets/Editor/ResourceEditor.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Reflection;
+using UnityEditor;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace TimelessEchoes.Upgrades
+{
+    [CustomEditor(typeof(Resource))]
+    public class ResourceEditor : Editor
+    {
+        private Resource item { get { return target as Resource; } }
+
+        public override Texture2D RenderStaticPreview(string assetPath, Object[] subAssets, int width, int height)
+        {
+            if (item.icon != null)
+            {
+                Type t = GetType("UnityEditor.SpriteUtility");
+                if (t != null)
+                {
+                    MethodInfo method = t.GetMethod("RenderStaticPreview", new[] { typeof(Sprite), typeof(Color), typeof(int), typeof(int) });
+                    if (method != null)
+                    {
+                        object ret = method.Invoke("RenderStaticPreview", new object[] { item.icon, Color.white, width, height });
+                        if (ret is Texture2D tex)
+                            return tex;
+                    }
+                }
+            }
+            return base.RenderStaticPreview(assetPath, subAssets, width, height);
+        }
+
+        private static Type GetType(string typeName)
+        {
+            var type = Type.GetType(typeName);
+            if (type != null)
+                return type;
+
+            var currentAssembly = Assembly.GetExecutingAssembly();
+            var referencedAssemblies = currentAssembly.GetReferencedAssemblies();
+            foreach (var assemblyName in referencedAssemblies)
+            {
+                var assembly = Assembly.Load(assemblyName);
+                if (assembly != null)
+                {
+                    type = assembly.GetType(typeName);
+                    if (type != null)
+                        return type;
+                }
+            }
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `ResourceEditor` that renders icon previews for `Resource` scriptable objects

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68594cf963ac832eb8b56f83fe1d0639