### PR TITLE
Enable resource unlock persistence

### DIFF
--- a/Assets/Scripts/Blindsided/Oracle.cs
+++ b/Assets/Scripts/Blindsided/Oracle.cs
@@ -206,6 +206,7 @@ namespace Blindsided
             saveData.HeroStates ??= new Dictionary<string, SaveData.SaveData.HeroState>();
             saveData.GlobalKillCounts ??= new Dictionary<string, int>();
             saveData.ResourceAmounts ??= new Dictionary<Resource, int>();
+            saveData.UnlockedResources ??= new HashSet<Resource>();
         }
 
         public static void AwayForSeconds()

--- a/Assets/Scripts/Blindsided/SaveData/SaveData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/SaveData.cs
@@ -24,6 +24,7 @@ namespace Blindsided.SaveData
         public double PlayTime;
 
         [HideReferenceObjectPicker] public Dictionary<Resource, int> ResourceAmounts = new();
+        [HideReferenceObjectPicker] public HashSet<Resource> UnlockedResources = new();
 
         [TabGroup("Preferences")] public Preferences SavedPreferences = new();
 

--- a/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
+++ b/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
@@ -10,6 +10,7 @@ namespace Blindsided.SaveData
         public static Dictionary<string, int> UpgradeLevels => oracle.saveData.UpgradeLevels;
         public static Dictionary<string, int> GlobalKillCounts => oracle.saveData.GlobalKillCounts;
         public static Dictionary<Resource, int> ResourceAmounts => oracle.saveData.ResourceAmounts;
+        public static HashSet<Resource> UnlockedResources => oracle.saveData.UnlockedResources;
 
         public static int ItemShards
         {

--- a/Assets/Scripts/References/UI/CostResourceUIReferences.cs
+++ b/Assets/Scripts/References/UI/CostResourceUIReferences.cs
@@ -6,6 +6,7 @@ namespace References.UI
 {
     public class CostResourceUIReferences : MonoBehaviour
     {
+        public TimelessEchoes.Upgrades.Resource resource;
         public Image questionMarkImage;
         public Image iconImage;
         public TMP_Text countText;

--- a/Assets/Scripts/Upgrades/ResourceInventoryUI.cs
+++ b/Assets/Scripts/Upgrades/ResourceInventoryUI.cs
@@ -56,21 +56,22 @@ namespace TimelessEchoes.Upgrades
             if (slot == null) return;
 
             int amount = resourceManager ? resourceManager.GetAmount(resource) : 0;
+            bool unlocked = resourceManager && resourceManager.IsUnlocked(resource);
 
             if (slot.iconImage)
             {
                 slot.iconImage.sprite = resource ? resource.icon : null;
-                slot.iconImage.enabled = amount > 0;
+                slot.iconImage.enabled = unlocked;
             }
 
             if (slot.questionMarkImage)
-                slot.questionMarkImage.enabled = amount <= 0;
+                slot.questionMarkImage.enabled = !unlocked;
 
             if (slot.countText)
                 slot.countText.text = amount.ToString();
         }
 
-        private void SelectSlot(int index)
+        public void SelectSlot(int index)
         {
             selectedIndex = index;
             for (int i = 0; i < slots.Count; i++)
@@ -78,6 +79,13 @@ namespace TimelessEchoes.Upgrades
                 if (slots[i] != null && slots[i].selectionImage != null)
                     slots[i].selectionImage.enabled = i == selectedIndex;
             }
+        }
+
+        public void HighlightResource(Resource resource)
+        {
+            int index = resources.IndexOf(resource);
+            if (index >= 0)
+                SelectSlot(index);
         }
     }
 }

--- a/Assets/Scripts/Upgrades/ResourceManager.cs
+++ b/Assets/Scripts/Upgrades/ResourceManager.cs
@@ -8,6 +8,7 @@ namespace TimelessEchoes.Upgrades
     public class ResourceManager : MonoBehaviour
     {
         private Dictionary<Resource, int> amounts = new();
+        private HashSet<Resource> unlocked = new();
 
         private void Awake()
         {
@@ -30,6 +31,7 @@ namespace TimelessEchoes.Upgrades
         public void Add(Resource resource, int amount)
         {
             if (resource == null || amount <= 0) return;
+            unlocked.Add(resource);
             if (amounts.ContainsKey(resource))
                 amounts[resource] += amount;
             else
@@ -45,17 +47,25 @@ namespace TimelessEchoes.Upgrades
             return true;
         }
 
+        public bool IsUnlocked(Resource resource)
+        {
+            return resource != null && unlocked.Contains(resource);
+        }
+
         private void SaveState()
         {
             if (oracle == null) return;
             oracle.saveData.ResourceAmounts = new Dictionary<Resource, int>(amounts);
+            oracle.saveData.UnlockedResources = new HashSet<Resource>(unlocked);
         }
 
         private void LoadState()
         {
             if (oracle == null) return;
             oracle.saveData.ResourceAmounts ??= new Dictionary<Resource, int>();
+            oracle.saveData.UnlockedResources ??= new HashSet<Resource>();
             amounts = new Dictionary<Resource, int>(oracle.saveData.ResourceAmounts);
+            unlocked = new HashSet<Resource>(oracle.saveData.UnlockedResources);
         }
     }
 }


### PR DESCRIPTION
## Summary
- persist unlocked resources in save data
- expose unlocked resources via static references
- initialize unlocked resources in Oracle
- track unlocked resources in `ResourceManager`
- show icons for resources once unlocked
- allow highlighting inventory slots from cost UI

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859dfd45d1c832e9c73c8668a759d2c