### PR TITLE
Fix debug resource persistence

### DIFF
--- a/Assets/Scripts/Upgrades/ResourceManager.cs
+++ b/Assets/Scripts/Upgrades/ResourceManager.cs
@@ -19,13 +19,17 @@ namespace TimelessEchoes.Upgrades
         private void AddDebugResource()
         {
             Add(debugResource, debugAmount);
+            SaveState();
         }
 
         [Button]
         private void UnlockDebugResource()
         {
             if (debugResource != null)
+            {
                 unlocked.Add(debugResource);
+                SaveState();
+            }
         }
 
         private void Awake()


### PR DESCRIPTION
## Summary
- ensure debug resources persist by saving state in ResourceManager

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859e52177d8832eb357b730eafdee29