### PR TITLE
Add runtime check for Easy Save manager

### DIFF
--- a/Assets/Scripts/Blindsided/Oracle.cs
+++ b/Assets/Scripts/Blindsided/Oracle.cs
@@ -32,11 +32,26 @@ namespace Blindsided
                 return;
             }
 
+            EnsureEasySaveManager();
+
             _settings = new ES3Settings(_fileName, ES3.Location.Cache)
             {
                 bufferSize = 8192
             };
             ES3.CacheFile(_fileName); // pull existing save into RAM
+        }
+
+        /// <summary>
+        /// Ensures an Easy Save 3 Manager exists so references can be saved.
+        /// </summary>
+        private static void EnsureEasySaveManager()
+        {
+            if (Object.FindFirstObjectByType<ES3ReferenceMgr>() == null)
+            {
+                var mgr = new GameObject("Easy Save 3 Manager");
+                mgr.AddComponent<ES3ReferenceMgr>();
+                mgr.AddComponent<ES3AutoSaveMgr>();
+            }
         }
 
         #endregion


### PR DESCRIPTION
## Summary
- ensure an Easy Save 3 Manager exists on `Oracle` startup

## Testing
- `grep -n "m_EditorVersion" ProjectSettings/ProjectVersion.txt`

------
https://chatgpt.com/codex/tasks/task_e_6859e7591c00832ea110a914d4dba51d