### PR TITLE
Fix ES3 resource save

### DIFF
--- a/Assets/Scripts/Blindsided/Oracle.cs
+++ b/Assets/Scripts/Blindsided/Oracle.cs
@@ -205,8 +205,7 @@ namespace Blindsided
         {
             saveData.HeroStates ??= new Dictionary<string, SaveData.SaveData.HeroState>();
             saveData.GlobalKillCounts ??= new Dictionary<string, int>();
-            saveData.ResourceAmounts ??= new Dictionary<Resource, int>();
-            saveData.UnlockedResources ??= new HashSet<Resource>();
+            saveData.Resources ??= new Dictionary<string, SaveData.SaveData.ResourceEntry>();
         }
 
         public static void AwayForSeconds()

--- a/Assets/Scripts/Blindsided/SaveData/SaveData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/SaveData.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using Sirenix.OdinInspector;
-using TimelessEchoes.Upgrades;
+
 
 namespace Blindsided.SaveData
 {
@@ -23,8 +23,8 @@ namespace Blindsided.SaveData
         public double OfflineTimeScaleMultiplier = 2f;
         public double PlayTime;
 
-        [HideReferenceObjectPicker] public Dictionary<Resource, int> ResourceAmounts = new();
-        [HideReferenceObjectPicker] public HashSet<Resource> UnlockedResources = new();
+        [HideReferenceObjectPicker]
+        public Dictionary<string, ResourceEntry> Resources = new();
 
         [TabGroup("Preferences")] public Preferences SavedPreferences = new();
 
@@ -36,6 +36,13 @@ namespace Blindsided.SaveData
 
         [HideReferenceObjectPicker] [TabGroup("UpgradeSystem")]
         public Dictionary<string, int> UpgradeLevels = new();
+
+        [HideReferenceObjectPicker]
+        public class ResourceEntry
+        {
+            public bool Earned;
+            public double Amount;
+        }
 
         [HideReferenceObjectPicker]
         public class Preferences

--- a/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
+++ b/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using TimelessEchoes.Upgrades;
 using static Blindsided.Oracle;
 using static Blindsided.SaveData.SaveData;
 
@@ -9,8 +8,7 @@ namespace Blindsided.SaveData
     {
         public static Dictionary<string, int> UpgradeLevels => oracle.saveData.UpgradeLevels;
         public static Dictionary<string, int> GlobalKillCounts => oracle.saveData.GlobalKillCounts;
-        public static Dictionary<Resource, int> ResourceAmounts => oracle.saveData.ResourceAmounts;
-        public static HashSet<Resource> UnlockedResources => oracle.saveData.UnlockedResources;
+        public static Dictionary<string, ResourceEntry> Resources => oracle.saveData.Resources;
 
         public static int ItemShards
         {

--- a/Assets/Scripts/Upgrades/ResourceInventoryUI.cs
+++ b/Assets/Scripts/Upgrades/ResourceInventoryUI.cs
@@ -55,7 +55,7 @@ namespace TimelessEchoes.Upgrades
             var resource = resources[index];
             if (slot == null) return;
 
-            int amount = resourceManager ? resourceManager.GetAmount(resource) : 0;
+            double amount = resourceManager ? resourceManager.GetAmount(resource) : 0;
             bool unlocked = resourceManager && resourceManager.IsUnlocked(resource);
 
             if (slot.iconImage)


### PR DESCRIPTION
## Summary
- restructure save data to store resources without Unity object references
- update ResourceManager to map resource names to ScriptableObjects
- adjust related UI and helper classes

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859e9dba6e8832eafc347a359b52d9e