### PR TITLE
Add hover tooltip for inventory slots

### DIFF
--- a/Assets/Scripts/References/UI/ResourceUIReferences.cs
+++ b/Assets/Scripts/References/UI/ResourceUIReferences.cs
@@ -2,10 +2,11 @@ using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
+using UnityEngine.EventSystems;
 
 namespace References.UI
 {
-    public class ResourceUIReferences : MonoBehaviour
+    public class ResourceUIReferences : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler, IPointerClickHandler
     {
         private static readonly List<ResourceUIReferences> instances = new();
         public Image questionMarkImage;
@@ -13,6 +14,10 @@ namespace References.UI
         public TMP_Text countText;
         public Image selectionImage;
         public Button selectButton;
+
+        public event System.Action<ResourceUIReferences> PointerEnter;
+        public event System.Action<ResourceUIReferences> PointerExit;
+        public event System.Action<ResourceUIReferences, PointerEventData.InputButton> PointerClick;
 
         private void Awake()
         {
@@ -33,6 +38,21 @@ namespace References.UI
             foreach (var inst in instances)
                 if (inst != null && inst.selectionImage != null)
                     inst.selectionImage.enabled = ReferenceEquals(inst, this);
+        }
+
+        public void OnPointerEnter(PointerEventData eventData)
+        {
+            PointerEnter?.Invoke(this);
+        }
+
+        public void OnPointerExit(PointerEventData eventData)
+        {
+            PointerExit?.Invoke(this);
+        }
+
+        public void OnPointerClick(PointerEventData eventData)
+        {
+            PointerClick?.Invoke(this, eventData.button);
         }
     }
 }

--- a/Assets/Scripts/Upgrades/ResourceInventoryUI.cs
+++ b/Assets/Scripts/Upgrades/ResourceInventoryUI.cs
@@ -3,6 +3,8 @@ using References.UI;
 using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
+using UnityEngine.EventSystems;
+using Blindsided.Utilities;
 
 namespace TimelessEchoes.Upgrades
 {
@@ -15,6 +17,7 @@ namespace TimelessEchoes.Upgrades
         [SerializeField] private List<Resource> resources = new();
         [SerializeField] private List<ResourceUIReferences> slots = new();
         [SerializeField] private TooltipUIReferences tooltip;
+        [SerializeField] private bool showTooltipOnHover = false;
 
         private int selectedIndex = -1;
 
@@ -34,6 +37,27 @@ namespace TimelessEchoes.Upgrades
                 var index = i;
                 if (slots[i] != null && slots[i].selectButton != null)
                     slots[i].selectButton.onClick.AddListener(() => SelectSlot(index));
+
+                if (slots[i] != null)
+                {
+                    slots[i].PointerClick += (_, button) =>
+                    {
+                        if (button == PointerEventData.InputButton.Right && tooltip != null)
+                            tooltip.gameObject.SetActive(false);
+                    };
+
+                    slots[i].PointerEnter += _ =>
+                    {
+                        if (showTooltipOnHover)
+                            ShowTooltip(index);
+                    };
+
+                    slots[i].PointerExit += _ =>
+                    {
+                        if (showTooltipOnHover && tooltip != null)
+                            tooltip.gameObject.SetActive(false);
+                    };
+                }
             }
 
             UpdateSlots();
@@ -80,7 +104,7 @@ namespace TimelessEchoes.Upgrades
                 slot.questionMarkImage.enabled = !unlocked;
 
             if (slot.countText)
-                slot.countText.text = amount.ToString();
+                slot.countText.text = CalcUtils.FormatNumber(amount, true);
         }
 
         public void SelectSlot(int index)
@@ -124,7 +148,7 @@ namespace TimelessEchoes.Upgrades
 
             double amount = resourceManager ? resourceManager.GetAmount(resource) : 0;
             if (tooltip.resourceCountText)
-                tooltip.resourceCountText.text = amount.ToString();
+                tooltip.resourceCountText.text = CalcUtils.FormatNumber(amount, true);
 
             tooltip.gameObject.SetActive(true);
         }


### PR DESCRIPTION
## Summary
- implement pointer interfaces in `ResourceUIReferences`
- add optional tooltip on hover and right-click dismiss behaviour
- format inventory amounts using `CalcUtils.FormatNumber`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859f9fe95a0832e9277489dacfbc1c4