### PR TITLE
Fix UI updates for upgrades

### DIFF
--- a/Assets/Scripts/Upgrades/ResourceInventoryUI.cs
+++ b/Assets/Scripts/Upgrades/ResourceInventoryUI.cs
@@ -46,7 +46,13 @@ namespace TimelessEchoes.Upgrades
                     slots[i].PointerClick += (_, button) =>
                     {
                         if (button == PointerEventData.InputButton.Right && tooltip != null)
+                        {
                             tooltip.gameObject.SetActive(false);
+                            foreach (var s in slots)
+                                if (s != null && s.selectionImage != null)
+                                    s.selectionImage.enabled = false;
+                            selectedIndex = -1;
+                        }
                     };
 
                     slots[i].PointerEnter += _ =>
@@ -82,7 +88,13 @@ namespace TimelessEchoes.Upgrades
         private void Update()
         {
             if (tooltip != null && tooltip.gameObject.activeSelf && Input.GetMouseButtonDown(1))
+            {
                 tooltip.gameObject.SetActive(false);
+                foreach (var s in slots)
+                    if (s != null && s.selectionImage != null)
+                        s.selectionImage.enabled = false;
+                selectedIndex = -1;
+            }
         }
 
         /// <summary>

--- a/Assets/Scripts/Upgrades/StatUpgradeUIManager.cs
+++ b/Assets/Scripts/Upgrades/StatUpgradeUIManager.cs
@@ -60,7 +60,16 @@ namespace TimelessEchoes.Upgrades
         private void Update()
         {
             if (references != null && references.gameObject.activeSelf && Input.GetMouseButtonDown(1))
+            {
                 references.gameObject.SetActive(false);
+                foreach (var selector in statSelectors)
+                    if (selector != null && selector.selectionImage != null)
+                        selector.selectionImage.enabled = false;
+                foreach (var slot in costSlots)
+                    if (slot != null && slot.selectionImage != null)
+                        slot.selectionImage.enabled = false;
+                selectedIndex = -1;
+            }
         }
 
         private void SelectStat(int index)
@@ -161,6 +170,7 @@ namespace TimelessEchoes.Upgrades
             {
                 BuildCostSlots();
                 UpdateUI();
+                resourceInventoryUI?.UpdateSlots();
             }
         }
 


### PR DESCRIPTION
## Summary
- refresh resource inventory when upgrades apply
- hide selection highlights when closing tooltips or upgrade menus

## Testing
- `dotnet --version` *(fails: command not found)*
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6859fda9df58832e90977da0296571cf