### PR TITLE
Add tooltip offset and tweak upgrade info

### DIFF
--- a/Assets/Scripts/Upgrades/ResourceInventoryUI.cs
+++ b/Assets/Scripts/Upgrades/ResourceInventoryUI.cs
@@ -18,6 +18,7 @@ namespace TimelessEchoes.Upgrades
         [SerializeField] private List<ResourceUIReferences> slots = new();
         [SerializeField] private TooltipUIReferences tooltip;
         [SerializeField] private bool showTooltipOnHover = false;
+        [SerializeField] private Vector2 tooltipOffset = Vector2.zero;
 
         private int selectedIndex = -1;
 
@@ -148,7 +149,7 @@ namespace TimelessEchoes.Upgrades
             var slot = slots[index];
             var resource = resources[index];
 
-            tooltip.transform.position = slot.transform.position;
+            tooltip.transform.position = slot.transform.position + (Vector3)tooltipOffset;
 
             bool unlocked = resourceManager && resourceManager.IsUnlocked(resource);
             if (tooltip.resourceNameText)

--- a/Assets/Scripts/Upgrades/StatUpgradeUIManager.cs
+++ b/Assets/Scripts/Upgrades/StatUpgradeUIManager.cs
@@ -152,7 +152,7 @@ namespace TimelessEchoes.Upgrades
             var lvl = controller ? controller.GetLevel(upgrade) : 0;
             var current = 1f + lvl * upgrade.statIncreasePerLevel;
             var next = current + upgrade.statIncreasePerLevel;
-            references.statUpgradeInfoText.text = $"{upgrade.name} {current:0.###} -> {next:0.###}";
+            references.statUpgradeInfoText.text = $"{current:0.###} -> {next:0.###}";
         }
 
         private void ApplyUpgrade()


### PR DESCRIPTION
## Summary
- allow offsetting of resource tooltip in `ResourceInventoryUI`
- simplify upgrade info text to only show numbers

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6859ff262660832e9b54925a476ba3d1