### PR TITLE
Fix right-click deselection of UI highlights

### DIFF
--- a/Assets/Scripts/Upgrades/ResourceInventoryUI.cs
+++ b/Assets/Scripts/Upgrades/ResourceInventoryUI.cs
@@ -82,8 +82,20 @@ namespace TimelessEchoes.Upgrades
 
         private void Update()
         {
-            if (tooltip != null && tooltip.gameObject.activeSelf && Input.GetMouseButtonDown(1))
-                tooltip.gameObject.SetActive(false);
+            if (Input.GetMouseButtonDown(1))
+            {
+                if (tooltip != null && tooltip.gameObject.activeSelf)
+                    tooltip.gameObject.SetActive(false);
+                DeselectSlot();
+            }
+        }
+
+        private void DeselectSlot()
+        {
+            selectedIndex = -1;
+            foreach (var slot in slots)
+                if (slot != null && slot.selectionImage != null)
+                    slot.selectionImage.enabled = false;
         }
 
         /// <summary>

--- a/Assets/Scripts/Upgrades/StatUpgradeUIManager.cs
+++ b/Assets/Scripts/Upgrades/StatUpgradeUIManager.cs
@@ -59,8 +59,20 @@ namespace TimelessEchoes.Upgrades
 
         private void Update()
         {
-            if (references != null && references.gameObject.activeSelf && Input.GetMouseButtonDown(1))
-                references.gameObject.SetActive(false);
+            if (Input.GetMouseButtonDown(1))
+            {
+                if (references != null && references.gameObject.activeSelf)
+                    references.gameObject.SetActive(false);
+                DeselectStat();
+            }
+        }
+
+        private void DeselectStat()
+        {
+            selectedIndex = -1;
+            foreach (var selector in statSelectors)
+                if (selector != null && selector.selectionImage != null)
+                    selector.selectionImage.enabled = false;
         }
 
         private void SelectStat(int index)


### PR DESCRIPTION
## Summary
- clear resource and stat selection when player right-clicks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a0211cc10832eb387b04b71d7f36f