### PR TITLE
Fix UI default selection and tooltip

### DIFF
--- a/Assets/Scripts/Upgrades/ResourceInventoryUI.cs
+++ b/Assets/Scripts/Upgrades/ResourceInventoryUI.cs
@@ -105,6 +105,9 @@ namespace TimelessEchoes.Upgrades
         {
             for (int i = 0; i < slots.Count && i < resources.Count; i++)
                 UpdateSlot(i);
+
+            if (selectedIndex >= 0 && tooltip != null && tooltip.gameObject.activeSelf)
+                ShowTooltip(selectedIndex);
         }
 
         private void UpdateSlot(int index)

--- a/Assets/Scripts/Upgrades/StatUpgradeUIManager.cs
+++ b/Assets/Scripts/Upgrades/StatUpgradeUIManager.cs
@@ -46,15 +46,23 @@ namespace TimelessEchoes.Upgrades
             if (references.upgradeButton != null)
                 references.upgradeButton.onClick.AddListener(ApplyUpgrade);
 
-            SelectStat(0);
+            DeselectStat();
+            if (references != null)
+                references.gameObject.SetActive(false);
         }
 
         private void OnEnable()
         {
-            if (selectedIndex < 0 && statSelectors.Count > 0)
-                SelectStat(0);
+            if (selectedIndex < 0)
+            {
+                DeselectStat();
+                if (references != null)
+                    references.gameObject.SetActive(false);
+            }
             else
+            {
                 UpdateUI();
+            }
         }
 
         private void Update()


### PR DESCRIPTION
## Summary
- avoid selecting attack on start by default
- refresh resource tooltip when spending resources

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685a04913da4832e91e19a2b7fc2da06