### PR TITLE
Fix tilemap generator RNG and add Odin button

### DIFF
--- a/Assets/Scripts/MapGeneration/TilemapChunkGenerator.cs
+++ b/Assets/Scripts/MapGeneration/TilemapChunkGenerator.cs
@@ -1,6 +1,7 @@
 using System;
 using UnityEngine;
 using UnityEngine.Tilemaps;
+using Sirenix.OdinInspector;
 
 namespace TimelessEchoes.MapGeneration
 {
@@ -39,6 +40,7 @@ namespace TimelessEchoes.MapGeneration
         }
 
         [ContextMenu("Generate Chunk")]
+        [Button]
         public void Generate()
         {
             ClearMaps();
@@ -73,6 +75,9 @@ namespace TimelessEchoes.MapGeneration
 
         private int RandomRange(int minInclusive, int maxExclusive)
         {
+            if (rng == null)
+                rng = randomizeSeed ? new System.Random() : new System.Random(seed);
+
             return rng.Next(minInclusive, maxExclusive);
         }
 


### PR DESCRIPTION
## Summary
- prevent null reference error when generating chunks
- expose generation with an Odin Inspector button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a3859e080832eac247548160b4fa0