### PR TITLE
Fill sand tilemap to top

### DIFF
--- a/Assets/Scripts/MapGeneration/TilemapChunkGenerator.cs
+++ b/Assets/Scripts/MapGeneration/TilemapChunkGenerator.cs
@@ -84,7 +84,8 @@ namespace TimelessEchoes.MapGeneration
             for (int y = 0; y < waterDepth; y++)
                 waterMap.SetTile(new Vector3Int(x, y, 0), waterTile);
 
-            for (int y = waterDepth; y < waterDepth + sandDepth && y < size.y; y++)
+            // Fill the sand map all the way to the top of the chunk
+            for (int y = waterDepth; y < size.y; y++)
                 sandMap.SetTile(new Vector3Int(x, y, 0), sandRuleTile);
 
             for (int y = waterDepth + sandDepth; y < waterDepth + sandDepth + grassDepth && y < size.y; y++)


### PR DESCRIPTION
## Summary
- ensure sand tiles extend to the top of the chunk in `TilemapChunkGenerator`

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_685a3c6cfb24832ea8a81cd9583187d1