### PR TITLE
Fix tilemap cutoff logic

### DIFF
--- a/Assets/Scripts/MapGeneration/TilemapChunkGenerator.cs
+++ b/Assets/Scripts/MapGeneration/TilemapChunkGenerator.cs
@@ -94,8 +94,8 @@ namespace TimelessEchoes.MapGeneration
 
         private void PlaceColumn(int x, int sandDepth, int grassDepth)
         {
-            sandDepth = Mathf.Clamp(sandDepth, sandDepthRange.x, sandDepthRange.y);
-            grassDepth = Mathf.Clamp(grassDepth, grassDepthRange.x, grassDepthRange.y);
+            sandDepth = Mathf.Clamp(sandDepth, 0, sandDepthRange.y);
+            grassDepth = Mathf.Clamp(grassDepth, 0, grassDepthRange.y);
 
             int waterDepth = size.y - sandDepth - grassDepth;
             if (waterDepth < 0)


### PR DESCRIPTION
## Summary
- allow zero depths when placing water/sand/grass columns

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685a4c8adb24832ea4cb95c6a82b64a8