### PR TITLE
Fix ProceduralTaskGenerator editor generation

### DIFF
--- a/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
+++ b/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
@@ -58,11 +58,11 @@ namespace TimelessEchoes.Tasks
         [SerializeField] private LayerMask blockingMask;
 
         [TitleGroup("Generation")]
-        [ListDrawerSettings(Expanded = true)]
+        [ListDrawerSettings(ShowFoldout = true)]
         [SerializeField] private List<WeightedSpawn> enemies = new();
 
         [TitleGroup("Generation")]
-        [ListDrawerSettings(Expanded = true)]
+        [ListDrawerSettings(ShowFoldout = true)]
         [SerializeField] private List<WeightedSpawn> otherTasks = new();
 
         private TaskController controller;
@@ -95,6 +95,8 @@ namespace TimelessEchoes.Tasks
         [Button]
         public void Generate()
         {
+            if (controller == null)
+                controller = GetComponent<TaskController>();
             if (controller == null)
                 return;
 


### PR DESCRIPTION
## Summary
- avoid obsolete `Expanded` property in `ProceduralTaskGenerator`
- assign task controller when generating tasks from the editor

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a50fa5ad4832eab9ad991242fcd40