### PR TITLE
Enhance enemy activation logic and add map reset controls

### DIFF
--- a/Assets/Scripts/MapGeneration/MapGenerateButton.cs
+++ b/Assets/Scripts/MapGeneration/MapGenerateButton.cs
@@ -9,8 +9,14 @@ namespace TimelessEchoes.MapGeneration
     /// </summary>
     public class MapGenerateButton : MonoBehaviour
     {
-        [SerializeField] private TilemapChunkGenerator chunkGenerator;
-        [SerializeField] private ProceduralTaskGenerator taskGenerator;
+        private TilemapChunkGenerator chunkGenerator;
+        private ProceduralTaskGenerator taskGenerator;
+
+        private void Awake()
+        {
+            chunkGenerator = GetComponent<TilemapChunkGenerator>();
+            taskGenerator = GetComponent<ProceduralTaskGenerator>();
+        }
 
         /// <summary>
         /// Generate the tilemap and tasks using the referenced generators.
@@ -25,6 +31,21 @@ namespace TimelessEchoes.MapGeneration
 
             chunkGenerator?.Generate();
             taskGenerator?.Generate();
+        }
+
+        /// <summary>
+        /// Clear the currently generated map and tasks.
+        /// </summary>
+        [Button(ButtonSizes.Large)]
+        public void ClearMap()
+        {
+            if (chunkGenerator == null)
+                chunkGenerator = GetComponent<TilemapChunkGenerator>();
+            if (taskGenerator == null)
+                taskGenerator = GetComponent<ProceduralTaskGenerator>();
+
+            chunkGenerator?.Clear();
+            taskGenerator?.Clear();
         }
     }
 }

--- a/Assets/Scripts/MapGeneration/TilemapChunkGenerator.cs
+++ b/Assets/Scripts/MapGeneration/TilemapChunkGenerator.cs
@@ -142,5 +142,13 @@ namespace TimelessEchoes.MapGeneration
             sandMap.ClearAllTiles();
             grassMap.ClearAllTiles();
         }
+
+        /// <summary>
+        /// Remove all tiles from the chunk's tilemaps.
+        /// </summary>
+        public void Clear()
+        {
+            ClearMaps();
+        }
     }
 }

--- a/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
+++ b/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
@@ -90,6 +90,18 @@ namespace TimelessEchoes.Tasks
         }
 
         /// <summary>
+        /// Clear all spawned task objects and remove them from the controller.
+        /// </summary>
+        public void Clear()
+        {
+            if (controller == null)
+                controller = GetComponent<TaskController>();
+
+            ClearSpawnedObjects();
+            controller?.ClearTaskObjects();
+        }
+
+        /// <summary>
         /// Generate and assign tasks based on the configured settings.
         /// </summary>
         [Button]

--- a/Assets/Scripts/Tasks/TaskController.cs
+++ b/Assets/Scripts/Tasks/TaskController.cs
@@ -105,16 +105,33 @@ namespace TimelessEchoes.Tasks
 
         private void Update()
         {
+            EngageNearbyEnemies();
+
             if (currentIndex < 0 || currentIndex >= tasks.Count)
                 return;
 
             var active = tasks[currentIndex];
 
-            if (active is KillEnemyTask kill && hero != null)
+            if (active.IsComplete())
+                SelectNextTask();
+        }
+
+        /// <summary>
+        /// Check all enemy tasks and activate any enemies near the hero.
+        /// </summary>
+        private void EngageNearbyEnemies()
+        {
+            if (hero == null)
+                return;
+
+            foreach (var task in tasks)
             {
-                var target = kill.target;
-                if (target != null)
+                if (task is KillEnemyTask kill)
                 {
+                    var target = kill.target;
+                    if (target == null)
+                        continue;
+
                     float dist = Vector3.Distance(hero.transform.position, target.position);
                     if (dist <= engageRange)
                     {
@@ -124,9 +141,6 @@ namespace TimelessEchoes.Tasks
                     }
                 }
             }
-
-            if (active.IsComplete())
-                SelectNextTask();
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- automatically cache chunk and task generators on `MapGenerateButton`
- expose `Clear()` method for `TilemapChunkGenerator` and `ProceduralTaskGenerator`
- add `ClearMap()` button for quick map resets
- engage all nearby enemies based on hero proximity

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a563a45d4832eb08f2ae7e48da1ab