### PR TITLE
Fix camera transition and enemy spawning

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using UnityEngine;
 using UnityEngine.UI;
 using Unity.Cinemachine;
@@ -23,6 +24,9 @@ namespace TimelessEchoes
 
         [Header("Cameras")]
         [SerializeField] private CinemachineCamera tavernCamera;
+        [SerializeField] private float cameraTransitionTime = 1f;
+
+        private Coroutine cameraRoutine;
 
         private GameObject currentMap;
         private TaskController taskController;
@@ -63,10 +67,11 @@ namespace TimelessEchoes
             }
 
             mapCamera = taskController.MapCamera;
-            if (tavernCamera != null)
-                tavernCamera.gameObject.SetActive(false);
             if (mapCamera != null)
                 mapCamera.gameObject.SetActive(true);
+            if (cameraRoutine != null)
+                StopCoroutine(cameraRoutine);
+            cameraRoutine = StartCoroutine(SwitchCamera(tavernCamera, mapCamera));
 
             tavernUI?.SetActive(false);
             mapUI?.SetActive(true);
@@ -103,6 +108,22 @@ namespace TimelessEchoes
             }
             if (hero != null)
                 hero.gameObject.SetActive(false);
+        }
+
+        private IEnumerator SwitchCamera(CinemachineCamera from, CinemachineCamera to)
+        {
+            if (to != null)
+            {
+                to.Priority = 10;
+                to.gameObject.SetActive(true);
+            }
+            if (from != null)
+                from.Priority = 0;
+
+            yield return new WaitForSeconds(cameraTransitionTime);
+
+            if (from != null)
+                from.gameObject.SetActive(false);
         }
     }
 }

--- a/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
+++ b/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
@@ -45,24 +45,22 @@ namespace TimelessEchoes.Tasks
             }
         }
 
-        [TitleGroup("Area Settings")]
+        [TabGroup("Settings", "Area")]
         [SerializeField] private float minX;
-        [TitleGroup("Area Settings")]
+        [TabGroup("Settings", "Area")]
         [SerializeField] private float maxX = 990f;
-        [TitleGroup("Area Settings")]
+        [TabGroup("Settings", "Area")]
         [SerializeField] private float height = 18f;
-        [TitleGroup("Area Settings")]
+        [TabGroup("Settings", "Area")]
         [SerializeField] private float density = 0.1f;
 
-        [TitleGroup("Generation")]
+        [TabGroup("Settings", "Generation")]
         [SerializeField] private LayerMask blockingMask;
 
-        [TitleGroup("Generation")]
-        [ListDrawerSettings(ShowFoldout = true)]
+        [TabGroup("Settings", "Generation")]
         [SerializeField] private List<WeightedSpawn> enemies = new();
 
-        [TitleGroup("Generation")]
-        [ListDrawerSettings(ShowFoldout = true)]
+        [TabGroup("Settings", "Generation")]
         [SerializeField] private List<WeightedSpawn> otherTasks = new();
 
         private TaskController controller;
@@ -71,7 +69,6 @@ namespace TimelessEchoes.Tasks
         private void Awake()
         {
             controller = GetComponent<TaskController>();
-            Generate();
         }
 
         private void ClearSpawnedObjects()


### PR DESCRIPTION
## Summary
- slow camera transition when starting a run
- delay task generation until map is ready
- remove Odin headers from ProceduralTaskGenerator and group settings in tabs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a622d0738832eb188c97bbac93895