### PR TITLE
Remove camera coroutine

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using UnityEngine;
 using UnityEngine.UI;
 using Unity.Cinemachine;
@@ -24,9 +23,6 @@ namespace TimelessEchoes
 
         [Header("Cameras")]
         [SerializeField] private CinemachineCamera tavernCamera;
-        [SerializeField] private float cameraTransitionTime = 1f;
-
-        private Coroutine cameraRoutine;
 
         private GameObject currentMap;
         private TaskController taskController;
@@ -79,9 +75,13 @@ namespace TimelessEchoes
                     mapCamera.ForceCameraPosition(camPos, mapCamera.transform.rotation);
                 }
             }
-            if (cameraRoutine != null)
-                StopCoroutine(cameraRoutine);
-            SwitchCameraImmediate(tavernCamera, mapCamera);
+            if (tavernCamera != null)
+                tavernCamera.gameObject.SetActive(false);
+            if (mapCamera != null)
+            {
+                mapCamera.Priority = 10;
+                mapCamera.gameObject.SetActive(true);
+            }
 
             tavernUI?.SetActive(false);
             mapUI?.SetActive(true);
@@ -120,34 +120,6 @@ namespace TimelessEchoes
                 hero.gameObject.SetActive(false);
         }
 
-        private IEnumerator SwitchCamera(CinemachineCamera from, CinemachineCamera to)
-        {
-            if (to != null)
-            {
-                to.Priority = 10;
-                to.gameObject.SetActive(true);
-            }
-            if (from != null)
-                from.Priority = 0;
-
-            yield return new WaitForSeconds(cameraTransitionTime);
-
-            if (from != null)
-                from.gameObject.SetActive(false);
-        }
-
-        private void SwitchCameraImmediate(CinemachineCamera from, CinemachineCamera to)
-        {
-            if (to != null)
-            {
-                to.Priority = 10;
-                to.gameObject.SetActive(true);
-            }
-            if (from != null)
-            {
-                from.Priority = 0;
-                from.gameObject.SetActive(false);
-            }
-        }
+        
     }
 }


### PR DESCRIPTION
## Summary
- remove unused camera coroutine in `GameManager`
- transition between cameras by disabling the tavern camera then enabling the map camera

## Testing
- `echo "No tests"`

------
https://chatgpt.com/codex/tasks/task_e_685a6f719f80832eb5063804ed0c9ffc