### PR TITLE
Add frame delay between map and task generation

### DIFF
--- a/Assets/Scripts/MapGeneration/MapGenerateButton.cs
+++ b/Assets/Scripts/MapGeneration/MapGenerateButton.cs
@@ -1,5 +1,6 @@
 using Sirenix.OdinInspector;
 using UnityEngine;
+using System.Collections;
 using TimelessEchoes.Tasks;
 
 namespace TimelessEchoes.MapGeneration
@@ -29,7 +30,22 @@ namespace TimelessEchoes.MapGeneration
             if (taskGenerator == null)
                 taskGenerator = GetComponent<ProceduralTaskGenerator>();
 
+#if UNITY_EDITOR
+            if (!Application.isPlaying)
+            {
+                chunkGenerator?.Generate();
+                taskGenerator?.Generate();
+                return;
+            }
+#endif
+
+            StartCoroutine(GenerateMapRoutine());
+        }
+
+        private IEnumerator GenerateMapRoutine()
+        {
             chunkGenerator?.Generate();
+            yield return null;
             taskGenerator?.Generate();
         }
 


### PR DESCRIPTION
## Summary
- insert a one-frame delay before generating tasks so map generation can finish
- keep editor workflow by directly generating in edit mode

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a72acc7d0832e9b1f06885cb691f8