### PR TITLE
Fix enemy spawn over blocking tiles

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using UnityEngine.UI;
 using Unity.Cinemachine;
+using System.Collections;
 using TimelessEchoes.Tasks;
 using TimelessEchoes.Hero;
 using TimelessEchoes.MapGeneration;
@@ -39,14 +40,21 @@ namespace TimelessEchoes
 
         private void StartRun()
         {
+            StartCoroutine(StartRunRoutine());
+        }
+
+        private IEnumerator StartRunRoutine()
+        {
             CleanupMap();
             currentMap = Instantiate(mapPrefab);
             taskController = currentMap.GetComponentInChildren<TaskController>();
             if (taskController == null)
-                return;
+                yield break;
 
             var chunk = taskController.GetComponent<TilemapChunkGenerator>();
             chunk?.Generate();
+            Physics2D.SyncTransforms();
+            yield return null;
             var taskGen = taskController.GetComponent<ProceduralTaskGenerator>();
             taskGen?.Generate();
 


### PR DESCRIPTION
## Summary
- ensure colliders update before procedural tasks are spawned
- spawn routine now waits a frame and syncs transforms

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a76c8492c832e9c4440f9e43cb9c3