### PR TITLE
Integrate A* scanning during map setup

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -55,6 +55,8 @@ namespace TimelessEchoes
             chunk?.Generate();
             Physics2D.SyncTransforms();
             yield return null;
+            if (taskController.Pathfinder != null)
+                taskController.Pathfinder.Scan();
             var taskGen = taskController.GetComponent<ProceduralTaskGenerator>();
             taskGen?.Generate();
 

--- a/Assets/Scripts/Tasks/TaskController.cs
+++ b/Assets/Scripts/Tasks/TaskController.cs
@@ -45,6 +45,9 @@ namespace TimelessEchoes.Tasks
 
         [SerializeField] private LayerMask enemyMask = ~0;
 
+        [SerializeField] private AstarPath astarPath;
+        public AstarPath Pathfinder => astarPath;
+
         [SerializeField] public Hero.HeroController hero;
         [SerializeField] private CinemachineCamera mapCamera;
         public CinemachineCamera MapCamera => mapCamera;


### PR DESCRIPTION
## Summary
- add an AstarPath reference to `TaskController`
- scan the path when generating a map in `GameManager`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a7e31a8b4832e8a9aa35e083b86fc