### PR TITLE
Add floating text for combat

### DIFF
--- a/Assets/Scripts/Enemies/Enemy.cs
+++ b/Assets/Scripts/Enemies/Enemy.cs
@@ -158,7 +158,10 @@ namespace TimelessEchoes.Enemies
                 t *= t; // bias towards lower values
                 int count = Mathf.Clamp(Mathf.FloorToInt(Mathf.Lerp(min, max + 1, t)), min, max);
                 if (count > 0)
+                {
                     resourceManager.Add(drop.resource, count);
+                    TimelessEchoes.FloatingText.Spawn($"{drop.resource.name} x{count}", transform.position + Vector3.up, Color.yellow);
+                }
             }
         }
 

--- a/Assets/Scripts/Enemies/Health.cs
+++ b/Assets/Scripts/Enemies/Health.cs
@@ -33,6 +33,13 @@ namespace TimelessEchoes.Enemies
             if (CurrentHealth <= 0f) return;
             CurrentHealth -= amount;
             UpdateBar();
+
+            // Show floating damage text
+            ColorUtility.TryParseHtmlString("#C56260", out var red);
+            ColorUtility.TryParseHtmlString("#C69B60", out var orange);
+            bool isHero = GetComponent<TimelessEchoes.Hero.HeroController>() != null;
+            var colour = isHero ? orange : red;
+            TimelessEchoes.FloatingText.Spawn(Mathf.RoundToInt(amount).ToString(), transform.position + Vector3.up, colour);
             if (CurrentHealth <= 0f)
             {
                 OnDeath?.Invoke();

--- a/Assets/Scripts/FloatingText.cs
+++ b/Assets/Scripts/FloatingText.cs
@@ -1,0 +1,51 @@
+using TMPro;
+using UnityEngine;
+
+namespace TimelessEchoes
+{
+    /// <summary>
+    /// Simple floating text that rises and fades out.
+    /// </summary>
+    public class FloatingText : MonoBehaviour
+    {
+        [SerializeField] private float speed = 1f;
+        [SerializeField] private float lifetime = 1f;
+        private TMP_Text tmp;
+        private float timer;
+
+        /// <summary>
+        /// Spawns a floating text object displaying the given string.
+        /// </summary>
+        public static void Spawn(string text, Vector3 position, Color color)
+        {
+            var obj = new GameObject("FloatingText");
+            obj.transform.position = position;
+            var ft = obj.AddComponent<FloatingText>();
+            ft.tmp = obj.AddComponent<TextMeshPro>();
+            ft.tmp.alignment = TextAlignmentOptions.Center;
+            ft.tmp.fontSize = 4f;
+            ft.tmp.text = text;
+            ft.tmp.color = color;
+        }
+
+        private void Awake()
+        {
+            if (tmp == null)
+                tmp = GetComponent<TMP_Text>();
+        }
+
+        private void Update()
+        {
+            transform.position += Vector3.up * speed * Time.deltaTime;
+            timer += Time.deltaTime;
+            if (tmp != null)
+            {
+                Color c = tmp.color;
+                c.a = Mathf.Lerp(1f, 0f, timer / lifetime);
+                tmp.color = c;
+            }
+            if (timer >= lifetime)
+                Destroy(gameObject);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `FloatingText` to display moving text in the world
- show damage popups when the hero or enemies take damage
- display resource drop text when enemies die

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a8cf73894832e8034249f27eb4fca