### PR TITLE
Update RunDropUI tooltip count logic

### DIFF
--- a/Assets/Scripts/Upgrades/RunDropUI.cs
+++ b/Assets/Scripts/Upgrades/RunDropUI.cs
@@ -128,13 +128,12 @@ namespace TimelessEchoes.Upgrades
             if (slot.questionMarkImage)
                 slot.questionMarkImage.enabled = false;
             if (slot.countText)
-            {
-                double count = amounts.TryGetValue(resource, out var val) ? val : 0;
-                slot.countText.text = count.ToString();
-                slot.countText.gameObject.SetActive(true);
-            }
+                slot.countText.gameObject.SetActive(false);
             if (slot.selectionImage)
                 slot.selectionImage.enabled = index == selectedIndex;
+
+            if (selectedIndex == index && tooltip != null && tooltip.gameObject.activeSelf)
+                ShowTooltip(index);
         }
 
         private void SelectSlot(int index)


### PR DESCRIPTION
## Summary
- hide count labels on RunDropUI slots
- refresh tooltip counts when the selected slot is updated

## Testing
- `echo "No tests to run"`

------
https://chatgpt.com/codex/tasks/task_e_685a911146bc832eb7987ba4e454094f