### PR TITLE
Fix tooltip visibility and floating text sorting

### DIFF
--- a/Assets/Scripts/FloatingText.cs
+++ b/Assets/Scripts/FloatingText.cs
@@ -26,6 +26,14 @@ namespace TimelessEchoes
             ft.tmp.fontSize = 4f;
             ft.tmp.text = text;
             ft.tmp.color = color;
+
+            // Ensure the floating text renders in front of other objects.
+            var renderer = ft.tmp.GetComponent<Renderer>();
+            if (renderer != null)
+            {
+                renderer.sortingLayerName = "Canvas";
+                renderer.sortingOrder = 10;
+            }
         }
 
         private void Awake()

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using TimelessEchoes.Tasks;
 using TimelessEchoes.Hero;
 using TimelessEchoes.MapGeneration;
+using References.UI;
 
 namespace TimelessEchoes
 {
@@ -30,6 +31,13 @@ namespace TimelessEchoes
         private HeroController hero;
         private CinemachineCamera mapCamera;
 
+        private void HideTooltip()
+        {
+            var tooltip = FindFirstObjectByType<TooltipUIReferences>();
+            if (tooltip != null)
+                tooltip.gameObject.SetActive(false);
+        }
+
         private void Awake()
         {
             if (startRunButton != null)
@@ -40,6 +48,7 @@ namespace TimelessEchoes
 
         private void StartRun()
         {
+            HideTooltip();
             StartCoroutine(StartRunRoutine());
         }
 
@@ -110,6 +119,7 @@ namespace TimelessEchoes
 
         private void ReturnToTavern()
         {
+            HideTooltip();
             CleanupMap();
             if (tavernCamera != null)
                 tavernCamera.gameObject.SetActive(true);


### PR DESCRIPTION
## Summary
- ensure floating text shows on top of everything
- hide resource tooltip whenever a run starts or when returning to the tavern

## Testing
- `npm test` *(fails: package.json missing)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a92043458832ea4b685e03e760420