### PR TITLE
Fix vector type mix in Enemy wandering logic

### DIFF
--- a/Assets/Scripts/Enemies/Enemy.cs
+++ b/Assets/Scripts/Enemies/Enemy.cs
@@ -152,10 +152,10 @@ namespace TimelessEchoes.Enemies
             if (!ai.reachedEndOfPath) return;
 
             const int maxAttempts = 5;
-            Vector2 wander = transform.position;
+            Vector2 wander = (Vector2)transform.position;
             for (int i = 0; i < maxAttempts; i++)
             {
-                Vector2 candidate = spawnPos + Random.insideUnitCircle * stats.wanderDistance;
+                Vector2 candidate = (Vector2)spawnPos + Random.insideUnitCircle * stats.wanderDistance;
                 if (Physics2D.OverlapCircle(candidate, 0.2f, blockingMask) == null)
                 {
                     wander = candidate;


### PR DESCRIPTION
## Summary
- cast spawn and wander positions to `Vector2` to avoid operator ambiguity

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b319bee88832e96a4144cab93e1a8