### PR TITLE
Ensure enemies reference hero via TaskController

### DIFF
--- a/Assets/Scripts/Enemies/Enemy.cs
+++ b/Assets/Scripts/Enemies/Enemy.cs
@@ -48,7 +48,10 @@ namespace TimelessEchoes.Enemies
             setter = GetComponent<AIDestinationSetter>();
             health = GetComponent<Health>();
             spawnPos = transform.position;
-            hero = FindFirstObjectByType<TimelessEchoes.Hero.HeroController>()?.transform;
+
+            var controller = GetComponentInParent<TimelessEchoes.Tasks.TaskController>();
+            if (controller != null)
+                hero = controller.hero != null ? controller.hero.transform : null;
             wanderTarget = new GameObject("WanderTarget").transform;
             wanderTarget.hideFlags = HideFlags.HideInHierarchy;
             wanderTarget.position = transform.position;


### PR DESCRIPTION
## Summary
- remove global hero fallback in `Enemy` so it only gets the hero from its `TaskController`
- confirm `ProceduralTaskGenerator` instantiates objects as children of the generator

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685b3701140c832e9296bbea7e469814