### PR TITLE
Enemy range checks & hero task fallback

### DIFF
--- a/Assets/Scripts/Enemies/Enemy.cs
+++ b/Assets/Scripts/Enemies/Enemy.cs
@@ -125,7 +125,7 @@ namespace TimelessEchoes.Enemies
             if (stats == null)
                 return;
 
-            if (hero != null)
+            if (hero != null && hero.gameObject.activeInHierarchy)
             {
                 float hDist = Vector2.Distance(transform.position, hero.position);
                 if (hDist <= stats.visionRange)
@@ -226,7 +226,9 @@ namespace TimelessEchoes.Enemies
         {
             if (other != this && other != null && hero != null)
             {
-                setter.target = hero;
+                float dist = Vector2.Distance(transform.position, other.transform.position);
+                if (dist <= stats.assistRange)
+                    setter.target = hero;
             }
         }
     }

--- a/Assets/Scripts/Enemies/EnemyStats.cs
+++ b/Assets/Scripts/Enemies/EnemyStats.cs
@@ -14,6 +14,10 @@ namespace TimelessEchoes.Enemies
         public float moveSpeed = 3f;
         public float attackSpeed = 1f;
         public float visionRange = 5f;
+        /// <summary>
+        /// Distance within which allies will join an engaged enemy.
+        /// </summary>
+        public float assistRange = 8f;
         public float wanderDistance = 2f;
         public GameObject projectilePrefab;
     }

--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -198,10 +198,15 @@ namespace TimelessEchoes.Hero
                     nearest = h.transform;
                 }
             }
-            if (nearest != null)
+            bool inCombat = nearest != null;
+            if (inCombat)
             {
                 target = nearest;
                 setter.target = nearest;
+            }
+            else if (currentTask == null && taskController != null)
+            {
+                taskController.SelectNextTask();
             }
 
             if (target == null) return;


### PR DESCRIPTION
## Summary
- add assist range stat for enemies
- make enemies only pursue allies if within this range
- have enemies only look for heroes that are active
- let heroes take a new task when not in combat

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b3acf3a0c832e8741756bb5911ac1