### PR TITLE
Fix AI wandering and task cleanup

### DIFF
--- a/Assets/Scripts/Enemies/Enemy.cs
+++ b/Assets/Scripts/Enemies/Enemy.cs
@@ -125,17 +125,19 @@ namespace TimelessEchoes.Enemies
             if (stats == null)
                 return;
 
+            bool heroInRange = false;
             if (hero != null && hero.gameObject.activeInHierarchy)
             {
                 float hDist = Vector2.Distance(transform.position, hero.position);
                 if (hDist <= stats.visionRange)
                 {
+                    heroInRange = true;
                     setter.target = hero;
                     OnEngage?.Invoke(this);
                 }
             }
 
-            if (IsEngaged)
+            if (heroInRange)
             {
                 if (Time.time >= nextAttack)
                 {
@@ -146,12 +148,16 @@ namespace TimelessEchoes.Enemies
             }
             else
             {
+                if (setter.target == hero)
+                    setter.target = wanderTarget;
                 Wander();
             }
         }
 
         private void Wander()
         {
+            if (setter.target != wanderTarget)
+                setter.target = wanderTarget;
             if (!ai.reachedEndOfPath) return;
 
             const int maxAttempts = 5;

--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -204,9 +204,13 @@ namespace TimelessEchoes.Hero
                 target = nearest;
                 setter.target = nearest;
             }
-            else if (currentTask == null && taskController != null)
+            else
             {
-                taskController.SelectNextTask();
+                if ((currentTask == null || currentTask.IsComplete() || setter.target == null) && taskController != null)
+                {
+                    taskController.SelectNextTask();
+                    target = setter.target;
+                }
             }
 
             if (target == null) return;

--- a/Assets/Scripts/Tasks/TaskController.cs
+++ b/Assets/Scripts/Tasks/TaskController.cs
@@ -129,9 +129,19 @@ namespace TimelessEchoes.Tasks
         /// </summary>
         private void RemoveDeadEnemyTasks()
         {
+            bool removed = false;
             for (int i = tasks.Count - 1; i >= 0; i--)
             {
-                if (tasks[i] is KillEnemyTask kill)
+                var task = tasks[i];
+                if (task == null)
+                {
+                    if (i <= currentIndex)
+                        currentIndex--;
+                    tasks.RemoveAt(i);
+                    removed = true;
+                    continue;
+                }
+                if (task is KillEnemyTask kill)
                 {
                     var health = kill.target != null ? kill.target.GetComponent<Enemies.Health>() : null;
                     if (kill.target == null || health == null || health.CurrentHealth <= 0f)
@@ -141,9 +151,12 @@ namespace TimelessEchoes.Tasks
                         tasks.RemoveAt(i);
                         if (kill != null)
                             Destroy(kill);
+                        removed = true;
                     }
                 }
             }
+            if (removed && hero != null)
+                hero.SetTask(null);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- stop enemies chasing the hero after losing vision and ensure they wander again
- have the hero request a new task whenever the current task is missing or finished
- prune null or dead enemy tasks from the controller and clear the hero's task

## Testing
- `mcs -out:/tmp/test.dll Assets/Scripts/Hero/HeroController.cs` *(fails: missing Unity references)*

------
https://chatgpt.com/codex/tasks/task_e_685b3cc8d4cc832ebad1dfdc48a42a00