### PR TITLE
Add attack range property and enlarge floating text

### DIFF
--- a/Assets/Scriptables/SmallSlime_Green.asset
+++ b/Assets/Scriptables/SmallSlime_Green.asset
@@ -18,6 +18,7 @@ MonoBehaviour:
   damage: 1
   moveSpeed: 3
   attackSpeed: 1
+  attackRange: 5
   visionRange: 5
   wanderDistance: 2
   projectilePrefab: {fileID: 5086888241769898753, guid: 16c7aba8affac87478feae7df4c5e22e, type: 3}

--- a/Assets/Scriptables/Warrior.asset
+++ b/Assets/Scriptables/Warrior.asset
@@ -16,5 +16,6 @@ MonoBehaviour:
   damage: 1
   moveSpeed: 3
   attackSpeed: 1
+  attackRange: 1
   visionRange: 1
   projectilePrefab: {fileID: 5086888241769898753, guid: 7f6445b853984454f8c435355f99d025, type: 3}

--- a/Assets/Scripts/Enemies/Enemy.cs
+++ b/Assets/Scripts/Enemies/Enemy.cs
@@ -130,21 +130,22 @@ namespace TimelessEchoes.Enemies
             if (stats == null)
                 return;
 
-            bool heroInRange = false;
+            bool heroInVision = false;
+            float heroDistance = float.PositiveInfinity;
             if (hero != null && hero.gameObject.activeInHierarchy)
             {
-                float hDist = Vector2.Distance(transform.position, hero.position);
-                if (hDist <= stats.visionRange)
+                heroDistance = Vector2.Distance(transform.position, hero.position);
+                if (heroDistance <= stats.visionRange)
                 {
-                    heroInRange = true;
+                    heroInVision = true;
                     setter.target = hero;
                     OnEngage?.Invoke(this);
                 }
             }
 
-            if (heroInRange)
+            if (heroInVision)
             {
-                if (Time.time >= nextAttack)
+                if (heroDistance <= stats.attackRange && Time.time >= nextAttack)
                 {
                     nextAttack = Time.time + 1f / Mathf.Max(stats.attackSpeed, 0.01f);
                     animator.Play("Attack");

--- a/Assets/Scripts/Enemies/EnemyStats.cs
+++ b/Assets/Scripts/Enemies/EnemyStats.cs
@@ -13,6 +13,10 @@ namespace TimelessEchoes.Enemies
         public int damage = 1;
         public float moveSpeed = 3f;
         public float attackSpeed = 1f;
+        /// <summary>
+        /// Distance within which the enemy can perform attacks.
+        /// </summary>
+        public float attackRange = 1f;
         public float visionRange = 5f;
         /// <summary>
         /// Distance within which allies will join an engaged enemy.

--- a/Assets/Scripts/FloatingText.cs
+++ b/Assets/Scripts/FloatingText.cs
@@ -23,7 +23,7 @@ namespace TimelessEchoes
             var ft = obj.AddComponent<FloatingText>();
             ft.tmp = obj.AddComponent<TextMeshPro>();
             ft.tmp.alignment = TextAlignmentOptions.Center;
-            ft.tmp.fontSize = 4f;
+            ft.tmp.fontSize = 8f;
             ft.tmp.text = text;
             ft.tmp.color = color;
 


### PR DESCRIPTION
## Summary
- add new `attackRange` field to `EnemyStats`
- check attack distance separately from vision distance in `Enemy`
- double floating text font size for better visibility
- update enemy stat assets with new field

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685b4a60c728832e9b8e795bb7dc3cb7