### PR TITLE
Adjust floating text visibility and sizing

### DIFF
--- a/Assets/Scripts/Enemies/Health.cs
+++ b/Assets/Scripts/Enemies/Health.cs
@@ -39,7 +39,8 @@ namespace TimelessEchoes.Enemies
             ColorUtility.TryParseHtmlString("#C69B60", out var orange);
             bool isHero = GetComponent<TimelessEchoes.Hero.HeroController>() != null;
             var colour = isHero ? orange : red;
-            TimelessEchoes.FloatingText.Spawn(Mathf.RoundToInt(amount).ToString(), transform.position + Vector3.up, colour);
+            float fontSize = isHero ? 8f : 6f;
+            TimelessEchoes.FloatingText.Spawn(Mathf.RoundToInt(amount).ToString(), transform.position + Vector3.up, colour, fontSize);
             if (CurrentHealth <= 0f)
             {
                 OnDeath?.Invoke();

--- a/Assets/Scripts/FloatingText.cs
+++ b/Assets/Scripts/FloatingText.cs
@@ -16,14 +16,14 @@ namespace TimelessEchoes
         /// <summary>
         /// Spawns a floating text object displaying the given string.
         /// </summary>
-        public static void Spawn(string text, Vector3 position, Color color)
+        public static void Spawn(string text, Vector3 position, Color color, float fontSize = 8f)
         {
             var obj = new GameObject("FloatingText");
             obj.transform.position = position;
             var ft = obj.AddComponent<FloatingText>();
             ft.tmp = obj.AddComponent<TextMeshPro>();
             ft.tmp.alignment = TextAlignmentOptions.Center;
-            ft.tmp.fontSize = 8f;
+            ft.tmp.fontSize = fontSize;
             ft.tmp.text = text;
             ft.tmp.color = color;
 
@@ -49,7 +49,7 @@ namespace TimelessEchoes
             if (tmp != null)
             {
                 Color c = tmp.color;
-                c.a = Mathf.Lerp(1f, 0f, timer / lifetime);
+                c.a = Mathf.Lerp(1f, 0.5f, timer / lifetime);
                 tmp.color = c;
             }
             if (timer >= lifetime)


### PR DESCRIPTION
## Summary
- add fontSize parameter to FloatingText.Spawn
- fade floating text to 50% opacity instead of invisible
- show smaller damage numbers for enemies

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b4e331e24832eac85ff31fee27712