### PR TITLE
Enable smallcaps in floating text

### DIFF
--- a/Assets/Scripts/FloatingText.cs
+++ b/Assets/Scripts/FloatingText.cs
@@ -24,6 +24,7 @@ namespace TimelessEchoes
             ft.tmp = obj.AddComponent<TextMeshPro>();
             ft.tmp.alignment = TextAlignmentOptions.Center;
             ft.tmp.fontSize = fontSize;
+            ft.tmp.fontStyle |= FontStyles.SmallCaps;
             ft.tmp.text = text;
             ft.tmp.color = color;
 


### PR DESCRIPTION
## Summary
- show floating text using small caps for consistency with UI style

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685b59605e3c832e9b8986157f109ebe