### PR TITLE
Add hero defense damage reduction

### DIFF
--- a/Assets/Scripts/Enemies/Health.cs
+++ b/Assets/Scripts/Enemies/Health.cs
@@ -19,6 +19,12 @@ namespace TimelessEchoes.Enemies
         public void TakeDamage(float amount)
         {
             if (CurrentHealth <= 0f) return;
+            var hero = GetComponent<HeroController>();
+            if (hero != null)
+            {
+                float min = amount * 0.1f;
+                amount = Mathf.Max(amount - hero.Defense, min);
+            }
             CurrentHealth -= amount;
             UpdateBar();
 

--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -26,11 +26,13 @@ namespace TimelessEchoes.Hero
         private float baseAttackSpeed = 0f;
         private float baseMoveSpeed = 0f;
         private float baseHealth = 0f;
+        private float baseDefense = 0f;
 
         private float damageBonus = 0f;
         private float attackSpeedBonus = 0f;
         private float moveSpeedBonus = 0f;
         private float healthBonus = 0f;
+        private float defenseBonus = 0f;
 
         private TaskController taskController;
 
@@ -76,6 +78,10 @@ namespace TimelessEchoes.Hero
                     case "Move Speed":
                         baseMoveSpeed = baseVal;
                         moveSpeedBonus = increase;
+                        break;
+                    case "Defense":
+                        baseDefense = baseVal;
+                        defenseBonus = increase;
                         break;
                 }
             }
@@ -180,6 +186,7 @@ namespace TimelessEchoes.Hero
         }
 
         private float CurrentAttackRate => baseAttackSpeed + attackSpeedBonus;
+        public float Defense => baseDefense + defenseBonus;
 
         private void UpdateBehavior()
         {


### PR DESCRIPTION
## Summary
- add base and bonus defense stats in `HeroController`
- parse "Defense" upgrades
- expose `Defense` property
- reduce incoming damage in `Health` using hero's defense

## Testing
- `npm test` *(fails: package.json missing)*
- `dotnet test` *(fails: command not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685b5c332b84832e9d4dab8ee8a5a186