### PR TITLE
Fix task removal and improve mining logic

### DIFF
--- a/Assets/Scripts/Tasks/MiningTask.cs
+++ b/Assets/Scripts/Tasks/MiningTask.cs
@@ -128,7 +128,7 @@ namespace TimelessEchoes.Tasks
                 progressBar.gameObject.SetActive(true);
                 progressBar.fillAmount = 1f;
             }
-            var anim = hero.GetComponent<Animator>();
+            var anim = hero != null ? hero.GetComponentInChildren<Animator>() : null;
             anim?.Play("Mining");
         }
 
@@ -142,7 +142,7 @@ namespace TimelessEchoes.Tasks
                 heroSetter.target = null;
             if (progressBar != null)
                 progressBar.gameObject.SetActive(false);
-            var anim = hero.GetComponent<Animator>();
+            var anim = hero != null ? hero.GetComponentInChildren<Animator>() : null;
             anim?.SetTrigger("StopMining");
 
             if (resourceManager == null)


### PR DESCRIPTION
## Summary
- map tasks to source objects in `TaskController` so removal updates the inspector
- clear the mapping when task objects are cleared
- delete removed tasks from both lists when enemies die
- ensure mining plays the proper animation by searching child animators

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b79fd24d8832eb8d25ca415d8c6db