### PR TITLE
Create shared ResourceDrop type

### DIFF
--- a/Assets/Scripts/Enemies/Enemy.cs
+++ b/Assets/Scripts/Enemies/Enemy.cs
@@ -12,13 +12,6 @@ namespace TimelessEchoes.Enemies
     [RequireComponent(typeof(Health))]
     public class Enemy : MonoBehaviour
     {
-        [System.Serializable]
-        public class ResourceDrop
-        {
-            public Resource resource;
-            public Vector2Int dropRange = new Vector2Int(1, 1);
-            [Range(0f, 1f)] public float dropChance = 1f;
-        }
         [SerializeField] private EnemyStats stats;
         [SerializeField] private Animator animator;
         [SerializeField] private SpriteRenderer spriteRenderer;

--- a/Assets/Scripts/Tasks/MiningTask.cs
+++ b/Assets/Scripts/Tasks/MiningTask.cs
@@ -11,13 +11,6 @@ namespace TimelessEchoes.Tasks
     /// </summary>
     public class MiningTask : MonoBehaviour, ITask
     {
-        [System.Serializable]
-        public class ResourceDrop
-        {
-            public Resource resource;
-            public Vector2Int dropRange = new Vector2Int(1, 1);
-            [Range(0f, 1f)] public float dropChance = 1f;
-        }
 
         [SerializeField] private float mineTime = 2f;
         [SerializeField] private SlicedFilledImage progressBar;

--- a/Assets/Scripts/Upgrades/ResourceDrop.cs
+++ b/Assets/Scripts/Upgrades/ResourceDrop.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+namespace TimelessEchoes.Upgrades
+{
+    [System.Serializable]
+    public class ResourceDrop
+    {
+        public Resource resource;
+        public Vector2Int dropRange = new Vector2Int(1, 1);
+        [Range(0f, 1f)] public float dropChance = 1f;
+    }
+}


### PR DESCRIPTION
## Summary
- add a serializable `ResourceDrop` class in the Upgrades folder
- use the new class for enemy and mining drops

## Testing
- `echo "No tests to run"`

------
https://chatgpt.com/codex/tasks/task_e_685b7c1c48a4832e9ed146b26fbd6f76