### PR TITLE
Refactor slot selection logic into reusable manager

### DIFF
--- a/Assets/Scripts/References/UI/ISelectableSlot.cs
+++ b/Assets/Scripts/References/UI/ISelectableSlot.cs
@@ -1,0 +1,18 @@
+using System;
+using UnityEngine;
+using UnityEngine.UI;
+using UnityEngine.EventSystems;
+
+namespace References.UI
+{
+    public interface ISelectableSlot
+    {
+        Button SelectButton { get; }
+        Image SelectionImage { get; }
+        Transform Transform { get; }
+
+        event Action<ISelectableSlot> PointerEnter;
+        event Action<ISelectableSlot> PointerExit;
+        event Action<ISelectableSlot, PointerEventData.InputButton> PointerClick;
+    }
+}

--- a/Assets/Scripts/References/UI/ResourceUIReferences.cs
+++ b/Assets/Scripts/References/UI/ResourceUIReferences.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
@@ -6,7 +7,7 @@ using UnityEngine.EventSystems;
 
 namespace References.UI
 {
-    public class ResourceUIReferences : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler, IPointerClickHandler
+    public class ResourceUIReferences : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler, IPointerClickHandler, ISelectableSlot
     {
         private static readonly List<ResourceUIReferences> instances = new();
         public Image questionMarkImage;
@@ -15,9 +16,13 @@ namespace References.UI
         public Image selectionImage;
         public Button selectButton;
 
-        public event System.Action<ResourceUIReferences> PointerEnter;
-        public event System.Action<ResourceUIReferences> PointerExit;
-        public event System.Action<ResourceUIReferences, PointerEventData.InputButton> PointerClick;
+        public event Action<ISelectableSlot> PointerEnter;
+        public event Action<ISelectableSlot> PointerExit;
+        public event Action<ISelectableSlot, PointerEventData.InputButton> PointerClick;
+
+        Button ISelectableSlot.SelectButton => selectButton;
+        Image ISelectableSlot.SelectionImage => selectionImage;
+        Transform ISelectableSlot.Transform => transform;
 
         private void Awake()
         {

--- a/Assets/Scripts/References/UI/SelectableSlotManager.cs
+++ b/Assets/Scripts/References/UI/SelectableSlotManager.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+namespace References.UI
+{
+    /// <summary>
+    /// Handles selection logic and tooltip display for a group of selectable slots.
+    /// </summary>
+    public class SelectableSlotManager : MonoBehaviour
+    {
+        [SerializeField] private List<MonoBehaviour> slotBehaviours = new();
+        [SerializeField] private TooltipUIReferences tooltip;
+        [SerializeField] private bool showTooltipOnHover = false;
+        [SerializeField] private Vector2 tooltipOffset = Vector2.zero;
+
+        private readonly List<ISelectableSlot> slots = new();
+        private int selectedIndex = -1;
+
+        /// <summary>Invoked when a tooltip needs content for the given slot index.</summary>
+        public event Action<int> TooltipRequested;
+        /// <summary>Invoked when a slot is selected.</summary>
+        public event Action<int> Selected;
+        /// <summary>Invoked when selection is cleared.</summary>
+        public event Action Deselected;
+
+        /// <summary>Currently selected index or -1.</summary>
+        public int SelectedIndex => selectedIndex;
+        /// <summary>Access to the underlying slots.</summary>
+        public IReadOnlyList<ISelectableSlot> Slots => slots;
+        /// <summary>The tooltip reference used by this manager.</summary>
+        public TooltipUIReferences Tooltip => tooltip;
+
+        private void Awake()
+        {
+            if (slotBehaviours.Count == 0)
+                slotBehaviours.AddRange(GetComponentsInChildren<MonoBehaviour>(true));
+
+            foreach (var beh in slotBehaviours)
+                if (beh is ISelectableSlot slot)
+                    slots.Add(slot);
+
+            for (int i = 0; i < slots.Count; i++)
+                RegisterSlot(i);
+        }
+
+        private void RegisterSlot(int index)
+        {
+            var slot = slots[index];
+            if (slot.SelectButton != null)
+                slot.SelectButton.onClick.AddListener(() => Select(index));
+
+            slot.PointerClick += (_, button) =>
+            {
+                if (button == PointerEventData.InputButton.Right)
+                    Deselect();
+            };
+
+            slot.PointerEnter += _ => { if (showTooltipOnHover) ShowTooltip(index); };
+            slot.PointerExit += _ => { if (showTooltipOnHover) HideTooltip(); };
+        }
+
+        private void Update()
+        {
+            if (Input.GetMouseButtonDown(1))
+                Deselect();
+        }
+
+        /// <summary>Select the slot at the given index.</summary>
+        public void Select(int index)
+        {
+            selectedIndex = index;
+            for (int i = 0; i < slots.Count; i++)
+                if (slots[i].SelectionImage != null)
+                    slots[i].SelectionImage.enabled = i == selectedIndex;
+            ShowTooltip(selectedIndex);
+            Selected?.Invoke(index);
+        }
+
+        /// <summary>Clear selection and hide any tooltip.</summary>
+        public void Deselect()
+        {
+            selectedIndex = -1;
+            foreach (var slot in slots)
+                if (slot.SelectionImage != null)
+                    slot.SelectionImage.enabled = false;
+            HideTooltip();
+            Deselected?.Invoke();
+        }
+
+        private void ShowTooltip(int index)
+        {
+            if (tooltip == null)
+                return;
+            if (index < 0 || index >= slots.Count)
+            {
+                HideTooltip();
+                return;
+            }
+            tooltip.transform.position = slots[index].Transform.position + (Vector3)tooltipOffset;
+            TooltipRequested?.Invoke(index);
+            tooltip.gameObject.SetActive(true);
+        }
+
+        /// <summary>Hide the tooltip if active.</summary>
+        public void HideTooltip()
+        {
+            if (tooltip != null)
+                tooltip.gameObject.SetActive(false);
+        }
+
+        /// <summary>Remove all tracked slots.</summary>
+        public void ClearSlots()
+        {
+            slotBehaviours.Clear();
+            slots.Clear();
+            selectedIndex = -1;
+            HideTooltip();
+        }
+
+        /// <summary>Add a slot at runtime.</summary>
+        public void AddSlot(MonoBehaviour behaviour)
+        {
+            if (behaviour is ISelectableSlot slot)
+            {
+                slotBehaviours.Add(behaviour);
+                slots.Add(slot);
+                RegisterSlot(slots.Count - 1);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/References/UI/StatUIReferences.cs
+++ b/Assets/Scripts/References/UI/StatUIReferences.cs
@@ -1,14 +1,24 @@
+using System;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
+using UnityEngine.EventSystems;
 
 namespace References.UI
 {
-    public class StatUIReferences : MonoBehaviour
+    public class StatUIReferences : MonoBehaviour, ISelectableSlot
     {
         public Image iconImage;
         public TMP_Text countText;
         public Image selectionImage;
         public Button selectButton;
+
+        public event Action<ISelectableSlot> PointerEnter;
+        public event Action<ISelectableSlot> PointerExit;
+        public event Action<ISelectableSlot, PointerEventData.InputButton> PointerClick;
+
+        Button ISelectableSlot.SelectButton => selectButton;
+        Image ISelectableSlot.SelectionImage => selectionImage;
+        Transform ISelectableSlot.Transform => transform;
     }
 }

--- a/Assets/Scripts/Upgrades/RunDropUI.cs
+++ b/Assets/Scripts/Upgrades/RunDropUI.cs
@@ -1,8 +1,6 @@
 using System.Collections.Generic;
 using References.UI;
 using UnityEngine;
-using UnityEngine.EventSystems;
-using TimelessEchoes.Upgrades;
 
 namespace TimelessEchoes.Upgrades
 {
@@ -14,26 +12,25 @@ namespace TimelessEchoes.Upgrades
         [SerializeField] private ResourceManager resourceManager;
         [SerializeField] private ResourceUIReferences slotPrefab;
         [SerializeField] private Transform slotParent;
-        [SerializeField] private TooltipUIReferences tooltip;
         [SerializeField] private GameObject displayObject;
-        [SerializeField] private bool showTooltipOnHover = false;
-        [SerializeField] private Vector2 tooltipOffset = Vector2.zero;
+        [SerializeField] private SelectableSlotManager slotManager;
 
         private readonly List<Resource> resources = new();
         private readonly List<ResourceUIReferences> slots = new();
         private readonly Dictionary<Resource, double> amounts = new();
-        private int selectedIndex = -1;
 
         private void Awake()
         {
             if (resourceManager == null)
                 resourceManager = FindFirstObjectByType<ResourceManager>();
-            if (tooltip == null)
-                tooltip = FindFirstObjectByType<TooltipUIReferences>();
             if (slotParent == null)
                 slotParent = transform;
             if (displayObject == null)
                 displayObject = gameObject;
+            if (slotManager == null)
+                slotManager = GetComponent<SelectableSlotManager>();
+            if (slotManager != null)
+                slotManager.TooltipRequested += ShowTooltip;
             ClearDrops();
         }
 
@@ -50,16 +47,6 @@ namespace TimelessEchoes.Upgrades
                 resourceManager.OnResourceAdded -= OnResourceAdded;
         }
 
-        private void Update()
-        {
-            if (Input.GetMouseButtonDown(1))
-            {
-                if (tooltip != null && tooltip.gameObject.activeSelf)
-                    tooltip.gameObject.SetActive(false);
-                DeselectSlot();
-            }
-        }
-
         private void ClearDrops()
         {
             foreach (var slot in slots)
@@ -68,17 +55,9 @@ namespace TimelessEchoes.Upgrades
             resources.Clear();
             slots.Clear();
             amounts.Clear();
-            selectedIndex = -1;
+            slotManager?.ClearSlots();
             if (displayObject != null)
                 displayObject.SetActive(false);
-        }
-
-        private void DeselectSlot()
-        {
-            selectedIndex = -1;
-            foreach (var slot in slots)
-                if (slot != null && slot.selectionImage != null)
-                    slot.selectionImage.enabled = false;
         }
 
         private void OnResourceAdded(Resource resource, double amount)
@@ -89,20 +68,8 @@ namespace TimelessEchoes.Upgrades
                 amounts[resource] = amount;
                 resources.Add(resource);
                 var slot = Instantiate(slotPrefab, slotParent);
-                int index = slots.Count;
                 slots.Add(slot);
-                if (slot != null && slot.selectButton != null)
-                    slot.selectButton.onClick.AddListener(() => SelectSlot(index));
-                if (slot != null)
-                {
-                    slot.PointerClick += (_, button) =>
-                    {
-                        if (button == PointerEventData.InputButton.Right && tooltip != null)
-                            tooltip.gameObject.SetActive(false);
-                    };
-                    slot.PointerEnter += _ => { if (showTooltipOnHover) ShowTooltip(index); };
-                    slot.PointerExit += _ => { if (showTooltipOnHover && tooltip != null) tooltip.gameObject.SetActive(false); };
-                }
+                slotManager?.AddSlot(slot);
             }
             else
             {
@@ -130,41 +97,32 @@ namespace TimelessEchoes.Upgrades
             if (slot.countText)
                 slot.countText.gameObject.SetActive(false);
             if (slot.selectionImage)
-                slot.selectionImage.enabled = index == selectedIndex;
+                slot.selectionImage.enabled = index == (slotManager ? slotManager.SelectedIndex : -1);
 
-            if (selectedIndex == index && tooltip != null && tooltip.gameObject.activeSelf)
+            if (slotManager != null && slotManager.SelectedIndex == index && slotManager.Tooltip != null && slotManager.Tooltip.gameObject.activeSelf)
                 ShowTooltip(index);
         }
 
-        private void SelectSlot(int index)
-        {
-            selectedIndex = index;
-            for (int i = 0; i < slots.Count; i++)
-                if (slots[i] != null && slots[i].selectionImage != null)
-                    slots[i].selectionImage.enabled = i == selectedIndex;
-            ShowTooltip(selectedIndex);
-        }
 
         private void ShowTooltip(int index)
         {
-            if (tooltip == null)
+            if (slotManager == null || slotManager.Tooltip == null)
                 return;
             if (index < 0 || index >= slots.Count || index >= resources.Count)
             {
-                tooltip.gameObject.SetActive(false);
+                slotManager.HideTooltip();
                 return;
             }
             var slot = slots[index];
             var resource = resources[index];
-            tooltip.transform.position = slot.transform.position + (Vector3)tooltipOffset;
-            if (tooltip.resourceNameText)
-                tooltip.resourceNameText.text = resource ? resource.name : string.Empty;
-            if (tooltip.resourceCountText)
+            slotManager.Tooltip.transform.position = slot.transform.position;
+            if (slotManager.Tooltip.resourceNameText)
+                slotManager.Tooltip.resourceNameText.text = resource ? resource.name : string.Empty;
+            if (slotManager.Tooltip.resourceCountText)
             {
                 double count = amounts.TryGetValue(resource, out var val) ? val : 0;
-                tooltip.resourceCountText.text = count.ToString();
+                slotManager.Tooltip.resourceCountText.text = count.ToString();
             }
-            tooltip.gameObject.SetActive(true);
         }
     }
 }

--- a/Assets/Scripts/Upgrades/StatUpgradeUIManager.cs
+++ b/Assets/Scripts/Upgrades/StatUpgradeUIManager.cs
@@ -13,15 +13,15 @@ namespace TimelessEchoes.Upgrades
         [SerializeField] private ResourceManager resourceManager;
         [SerializeField] private ResourceInventoryUI resourceInventoryUI;
         [SerializeField] private List<StatUIReferences> statSelectors = new();
+        [SerializeField] private SelectableSlotManager slotManager;
         [SerializeField] private List<StatUpgrade> upgrades = new();
         [SerializeField] private StatUpgradeUIReferences references;
 
         private readonly List<CostResourceUIReferences> costSlots = new();
 
-        private int selectedIndex = -1;
-
         private StatUpgrade CurrentUpgrade =>
-            selectedIndex >= 0 && selectedIndex < upgrades.Count ? upgrades[selectedIndex] : null;
+            slotManager != null && slotManager.SelectedIndex >= 0 && slotManager.SelectedIndex < upgrades.Count ?
+                upgrades[slotManager.SelectedIndex] : null;
 
         private void Awake()
         {
@@ -36,11 +36,19 @@ namespace TimelessEchoes.Upgrades
             if (statSelectors.Count == 0)
                 statSelectors.AddRange(GetComponentsInChildren<StatUIReferences>(true));
 
-            for (var i = 0; i < statSelectors.Count; i++)
+            if (slotManager == null)
+                slotManager = GetComponent<SelectableSlotManager>();
+            if (slotManager != null)
             {
-                var index = i;
-                if (statSelectors[i] != null && statSelectors[i].selectButton != null)
-                    statSelectors[i].selectButton.onClick.AddListener(() => SelectStat(index));
+                slotManager.ClearSlots();
+                foreach (var s in statSelectors)
+                    slotManager.AddSlot(s);
+                slotManager.Selected += SelectStat;
+                slotManager.Deselected += () =>
+                {
+                    if (references != null)
+                        references.gameObject.SetActive(false);
+                };
             }
 
             if (references.upgradeButton != null)
@@ -53,51 +61,29 @@ namespace TimelessEchoes.Upgrades
 
         private void OnEnable()
         {
-            if (selectedIndex < 0)
+            if (slotManager != null && slotManager.SelectedIndex >= 0)
+            {
+                UpdateUI();
+            }
+            else
             {
                 DeselectStat();
                 if (references != null)
                     references.gameObject.SetActive(false);
             }
-            else
-            {
-                UpdateUI();
-            }
-        }
-
-        private void Update()
-        {
-            if (Input.GetMouseButtonDown(1))
-            {
-                if (references != null && references.gameObject.activeSelf)
-                    references.gameObject.SetActive(false);
-                DeselectStat();
-            }
         }
 
         private void DeselectStat()
         {
-            selectedIndex = -1;
-            foreach (var selector in statSelectors)
-                if (selector != null && selector.selectionImage != null)
-                    selector.selectionImage.enabled = false;
+            slotManager?.Deselect();
         }
 
         private void SelectStat(int index)
         {
-            selectedIndex = Mathf.Clamp(index, 0, statSelectors.Count - 1);
-
-            for (var i = 0; i < statSelectors.Count; i++)
-            {
-                var selector = statSelectors[i];
-                if (selector != null && selector.selectionImage != null)
-                    selector.selectionImage.enabled = i == selectedIndex;
-            }
-
-            if (references != null && selectedIndex >= 0 && selectedIndex < statSelectors.Count)
+            if (references != null && index >= 0 && index < statSelectors.Count)
             {
                 var pos = references.transform.position;
-                var target = statSelectors[selectedIndex].transform.position;
+                var target = statSelectors[index].transform.position;
                 references.transform.position = new Vector3(pos.x, target.y, pos.z);
                 references.gameObject.SetActive(true);
             }


### PR DESCRIPTION
## Summary
- add `SelectableSlotManager` component and `ISelectableSlot` interface
- update slot reference classes to implement `ISelectableSlot`
- refactor resource inventory, run drop and stat upgrade UIs to use the new manager

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b8158d9e8832eaffa7c7b4538c9f7