### PR TITLE
Refactor hero task logic

### DIFF
--- a/Assets/Scripts/Tasks/MiningTask.cs
+++ b/Assets/Scripts/Tasks/MiningTask.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using Pathfinding;
 using UnityEngine;
 using TimelessEchoes.Upgrades;
 using Blindsided.Utilities;
@@ -7,11 +6,11 @@ using Blindsided.Utilities;
 namespace TimelessEchoes.Tasks
 {
     /// <summary>
-    /// Task for mining a rock and collecting resources.
+    ///     Data container for a mining objective. The hero now handles
+    ///     movement and timing logic when assigned this task.
     /// </summary>
     public class MiningTask : MonoBehaviour, ITask
     {
-
         [SerializeField] private float mineTime = 2f;
         [SerializeField] private SlicedFilledImage progressBar;
         [SerializeField] private Transform leftPoint;
@@ -21,20 +20,17 @@ namespace TimelessEchoes.Tasks
         [SerializeField] private List<ResourceDrop> resourceDrops = new();
 
         private ResourceManager resourceManager;
-        private Hero.HeroController hero;
-        private AIPath heroAI;
-        private AIDestinationSetter heroSetter;
-        private float timer;
-        private bool mining;
         private bool complete;
-        private Transform currentPoint;
+
+        public float MineTime => mineTime;
+        public IList<ResourceDrop> Drops => resourceDrops;
+        public SlicedFilledImage ProgressBar => progressBar;
 
         public Transform Target
         {
             get
             {
-                if (hero == null)
-                    hero = FindFirstObjectByType<Hero.HeroController>();
+                var hero = FindFirstObjectByType<Hero.HeroController>();
                 if (hero == null)
                     return leftPoint != null ? leftPoint : transform;
                 return GetNearestPoint(hero.transform);
@@ -44,7 +40,7 @@ namespace TimelessEchoes.Tasks
         private Transform GetNearestPoint(Transform tr)
         {
             Transform[] points = { leftPoint, rightPoint, upPoint, downPoint };
-            Transform best = transform;
+            var best = transform;
             float bestDist = float.PositiveInfinity;
             foreach (var p in points)
             {
@@ -62,8 +58,6 @@ namespace TimelessEchoes.Tasks
         public void StartTask()
         {
             complete = false;
-            mining = false;
-            timer = 0f;
             if (progressBar != null)
             {
                 progressBar.fillAmount = 1f;
@@ -71,72 +65,14 @@ namespace TimelessEchoes.Tasks
             }
             if (resourceManager == null)
                 resourceManager = FindFirstObjectByType<ResourceManager>();
-            if (hero == null)
-                hero = FindFirstObjectByType<Hero.HeroController>();
-            if (hero != null)
-            {
-                heroAI = hero.GetComponent<AIPath>();
-                heroSetter = hero.GetComponent<AIDestinationSetter>();
-                currentPoint = GetNearestPoint(hero.transform);
-                hero.SetDestination(currentPoint);
-            }
         }
 
-        private void Update()
+        public void CompleteTask()
         {
-            if (complete || hero == null)
-                return;
-
-            if (!mining)
-            {
-                if (currentPoint == null)
-                    currentPoint = GetNearestPoint(hero.transform);
-                if (heroAI != null && heroAI.reachedDestination)
-                {
-                    BeginMining();
-                }
-            }
-            else
-            {
-                timer += Time.deltaTime;
-                if (progressBar != null)
-                    progressBar.fillAmount = Mathf.Clamp01((mineTime - timer) / mineTime);
-                if (timer >= mineTime)
-                {
-                    FinishMining();
-                }
-            }
-        }
-
-        private void BeginMining()
-        {
-            mining = true;
-            if (heroAI != null)
-                heroAI.canMove = false;
-            if (heroSetter != null)
-                heroSetter.target = transform;
-            if (progressBar != null)
-            {
-                progressBar.gameObject.SetActive(true);
-                progressBar.fillAmount = 1f;
-            }
-            var anim = hero != null ? hero.GetComponentInChildren<Animator>() : null;
-            anim?.Play("Mining");
-        }
-
-        private void FinishMining()
-        {
-            mining = false;
+            if (complete) return;
             complete = true;
-            if (heroAI != null)
-                heroAI.canMove = true;
-            if (heroSetter != null)
-                heroSetter.target = null;
             if (progressBar != null)
                 progressBar.gameObject.SetActive(false);
-            var anim = hero != null ? hero.GetComponentInChildren<Animator>() : null;
-            anim?.SetTrigger("StopMining");
-
             if (resourceManager == null)
                 resourceManager = FindFirstObjectByType<ResourceManager>();
             if (resourceManager != null)
@@ -159,7 +95,6 @@ namespace TimelessEchoes.Tasks
                     }
                 }
             }
-
             Destroy(gameObject);
         }
 


### PR DESCRIPTION
## Summary
- move task handling to a simple hero state machine
- simplify `MiningTask` into a data container
- update `TaskController` to drop completed tasks and always select the earliest available one

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685b8e0c8190832e8025a31f7b57aa58