### PR TITLE
Fix MiningTask cleanup

### DIFF
--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -343,6 +343,8 @@ namespace TimelessEchoes.Hero
                 animator?.SetTrigger("StopMining");
                 miningTask.CompleteTask();
                 taskController?.RemoveTask(miningTask);
+                SetTask(null);
+                taskController?.SelectEarliestTask();
                 miningTask = null;
                 state = State.Idle;
             }


### PR DESCRIPTION
## Summary
- when finishing a mining task, clear the hero's current task before selecting the next task

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685b91829068832e8de55bea82dbde0d