### PR TITLE
Fix mining task cleanup order

### DIFF
--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -356,8 +356,8 @@ namespace TimelessEchoes.Hero
                 TELogger.Log($"Finished mining {miningTask.name}", this);
                 ai.canMove = true;
                 animator?.SetTrigger("StopMining");
-                miningTask.CompleteTask();
                 taskController?.RemoveTask(miningTask);
+                miningTask.CompleteTask();
                 SetTask(null);
                 taskController?.SelectEarliestTask();
                 miningTask = null;


### PR DESCRIPTION
## Summary
- adjust mining completion logic to remove the task before destroying it

## Testing
- `echo "No tests to run"`

------
https://chatgpt.com/codex/tasks/task_e_685b971a2eac832e944cebb4f283b552