### PR TITLE
Cache MiningTask target

### DIFF
--- a/Assets/Scripts/Tasks/MiningTask.cs
+++ b/Assets/Scripts/Tasks/MiningTask.cs
@@ -19,6 +19,8 @@ namespace TimelessEchoes.Tasks
         [SerializeField] private Transform downPoint;
         [SerializeField] private List<ResourceDrop> resourceDrops = new();
 
+        private Transform cachedTarget;
+
         private ResourceManager resourceManager;
         private bool complete;
 
@@ -30,10 +32,14 @@ namespace TimelessEchoes.Tasks
         {
             get
             {
+                if (cachedTarget != null)
+                    return cachedTarget;
+
                 var hero = FindFirstObjectByType<Hero.HeroController>();
-                if (hero == null)
-                    return leftPoint != null ? leftPoint : transform;
-                return GetNearestPoint(hero.transform);
+                cachedTarget = hero == null
+                    ? (leftPoint != null ? leftPoint : transform)
+                    : GetNearestPoint(hero.transform);
+                return cachedTarget;
             }
         }
 
@@ -58,6 +64,8 @@ namespace TimelessEchoes.Tasks
         public void StartTask()
         {
             complete = false;
+            if (cachedTarget == null)
+                _ = Target;
             if (progressBar != null)
             {
                 progressBar.fillAmount = 1f;


### PR DESCRIPTION
## Summary
- cache a mining target instead of recomputing every time
- prime the cached target when the task starts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ba7d78c14832eb73ad5a50c0132d3