### PR TITLE
Add manual destination reached override

### DIFF
--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using Pathfinding;
 using Pathfinding.RVO;
+using Sirenix.OdinInspector;
 using UnityEngine;
 using TimelessEchoes;
 using TimelessEchoes.Tasks;
@@ -221,6 +222,7 @@ namespace TimelessEchoes.Hero
         /// Manually flag that the hero has reached its destination.
         /// This bypasses the built-in pathfinding checks in <see cref="IsAtDestination"/>.
         /// </summary>
+        [Button("Mark Destination Reached")]
         public void SetDestinationReached()
         {
             destinationOverride = true;


### PR DESCRIPTION
## Summary
- add a flag in `HeroController` for manual destination reached
- reset the flag on enable and when setting a new destination
- expose `SetDestinationReached` to allow scripts to force destination completion
- respect override in `IsAtDestination`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685bb7bd330c832ea4f672fb1a611524