### PR TITLE
Add chest open spot targeting

### DIFF
--- a/Assets/Scripts/Tasks/OpenChestTask.cs
+++ b/Assets/Scripts/Tasks/OpenChestTask.cs
@@ -1,4 +1,7 @@
+using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
+using TimelessEchoes.Upgrades;
 
 namespace TimelessEchoes.Tasks
 {
@@ -8,19 +11,75 @@ namespace TimelessEchoes.Tasks
     public class OpenChestTask : BaseTask
     {
         [SerializeField] private Transform chest;
+        [SerializeField] private Animator chestAnimator;
+        [SerializeField] private Transform openPoint;
+        [SerializeField] private List<ResourceDrop> resourceDrops = new();
+
+        private Transform cachedTarget;
+        private ResourceManager resourceManager;
         private bool opened;
 
-        public override Transform Target => chest;
+        public IList<ResourceDrop> Drops => resourceDrops;
+
+        public override Transform Target
+        {
+            get
+            {
+                if (cachedTarget != null)
+                    return cachedTarget;
+
+                cachedTarget = openPoint != null ? openPoint : transform;
+                return cachedTarget;
+            }
+        }
 
         public override void StartTask()
         {
             opened = false;
+            cachedTarget = null;
+            if (resourceManager == null)
+                resourceManager = FindFirstObjectByType<ResourceManager>();
         }
 
         public void Open()
         {
+            if (opened) return;
+            if (chestAnimator != null)
+                chestAnimator.SetTrigger("Open");
+            StartCoroutine(DelayedLoot());
+        }
+
+        private IEnumerator DelayedLoot()
+        {
+            yield return new WaitForSeconds(0.5f);
+            GiveLoot();
             opened = true;
         }
+
+        private void GiveLoot()
+        {
+            if (resourceManager == null)
+                resourceManager = FindFirstObjectByType<ResourceManager>();
+            if (resourceManager == null) return;
+            foreach (var drop in resourceDrops)
+            {
+                if (drop.resource == null) continue;
+                if (Random.value > drop.dropChance) continue;
+
+                var min = drop.dropRange.x;
+                var max = drop.dropRange.y;
+                if (max < min) max = min;
+                var t = Random.value;
+                t *= t;
+                var count = Mathf.Clamp(Mathf.FloorToInt(Mathf.Lerp(min, max + 1, t)), min, max);
+                if (count > 0)
+                {
+                    resourceManager.Add(drop.resource, count);
+                    FloatingText.Spawn($"{drop.resource.name} x{count}", transform.position + Vector3.up, Color.blue);
+                }
+            }
+        }
+
 
         public override bool IsComplete()
         {

--- a/Assets/Scripts/Tasks/TaskController.cs
+++ b/Assets/Scripts/Tasks/TaskController.cs
@@ -254,11 +254,19 @@ namespace TimelessEchoes.Tasks
                 taskObjects.Remove(obj);
                 taskMap.Remove(task);
                 if (obj != null)
-                    Destroy(obj.gameObject);
+                {
+                    if (task is OpenChestTask)
+                        Destroy(obj.GetComponent<OpenChestTask>());
+                    else
+                        Destroy(obj.gameObject);
+                }
             }
             else if (task is MonoBehaviour mb)
             {
-                Destroy(mb.gameObject);
+                if (task is OpenChestTask)
+                    Destroy(mb);
+                else
+                    Destroy(mb.gameObject);
             }
 
             if (index <= currentIndex)


### PR DESCRIPTION
## Summary
- simplify chest targeting to a single `openPoint`
- keep chests in the scene after the task component is removed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685cf25837c4832e95fb12eee8f2509b