### PR TITLE
Add Farming skill and task

### DIFF
--- a/Assets/Scriptables/Skills/Farming.asset
+++ b/Assets/Scriptables/Skills/Farming.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6bed9e7c469d52d4ca3dc74d8b1834a8, type: 3}
+  m_Name: Farming
+  m_EditorClassIdentifier:
+  skillName: Farming
+  skillIcon: {fileID: 6744079922437306869, guid: 61614b6dea4e6254e853eb57bbf5ef3b, type: 3}
+  xpForFirstLevel: 10
+  xpLevelMultiplier: 1.5
+  milestones: []

--- a/Assets/Scriptables/Skills/Farming.asset.meta
+++ b/Assets/Scriptables/Skills/Farming.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f3b9fce6557e44d4ac8a2a064e3b0b9b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Tasks/FarmingTask.cs
+++ b/Assets/Scripts/Tasks/FarmingTask.cs
@@ -1,0 +1,78 @@
+using System.Reflection;
+using TimelessEchoes.Hero;
+using UnityEngine;
+
+namespace TimelessEchoes.Tasks
+{
+    /// <summary>
+    /// Task for watering crops. The sprite swaps through growth stages
+    /// and is disabled once complete, leaving the object intact.
+    /// </summary>
+    public class FarmingTask : ContinuousTask
+    {
+        [SerializeField] private SpriteRenderer spriteRenderer;
+        [SerializeField] private Sprite[] growthStages = new Sprite[3];
+        [SerializeField] private Transform wateringPoint;
+
+        private float localTimer;
+        private float duration;
+        private int currentStage;
+
+        protected override string AnimationName => "Water";
+        protected override string InterruptTriggerName => "StopWatering";
+
+        public override Transform Target => wateringPoint != null ? wateringPoint : transform;
+
+        public override void StartTask()
+        {
+            base.StartTask();
+            if (spriteRenderer == null)
+                spriteRenderer = GetComponent<SpriteRenderer>();
+            localTimer = 0f;
+            currentStage = 0;
+            duration = GetTaskDuration();
+            if (spriteRenderer != null && spriteRenderer.enabled == false)
+                spriteRenderer.enabled = true;
+        }
+
+        public override void Tick(HeroController hero)
+        {
+            base.Tick(hero);
+            localTimer += Time.deltaTime;
+
+            if (spriteRenderer != null && growthStages.Length >= 3)
+            {
+                float quarter = duration > 0f ? duration / 4f : 0f;
+                int newStage = 0;
+                if (localTimer >= 3f * quarter)
+                    newStage = 3;
+                else if (localTimer >= 2f * quarter)
+                    newStage = 2;
+                else if (localTimer >= quarter)
+                    newStage = 1;
+
+                if (newStage != currentStage)
+                {
+                    currentStage = newStage;
+                    if (newStage > 0 && newStage - 1 < growthStages.Length)
+                    {
+                        var s = growthStages[newStage - 1];
+                        if (s != null)
+                            spriteRenderer.sprite = s;
+                    }
+                }
+            }
+
+            if (IsComplete() && spriteRenderer != null && spriteRenderer.enabled)
+            {
+                spriteRenderer.enabled = false;
+            }
+        }
+
+        private float GetTaskDuration()
+        {
+            var field = typeof(ContinuousTask).GetField("taskDuration", BindingFlags.NonPublic | BindingFlags.Instance);
+            return field != null ? (float)field.GetValue(this) : 0f;
+        }
+    }
+}

--- a/Assets/Scripts/Tasks/TaskController.cs
+++ b/Assets/Scripts/Tasks/TaskController.cs
@@ -319,6 +319,8 @@ namespace TimelessEchoes.Tasks
                         Destroy(obj.GetComponent<OpenChestTask>());
                     else if (task is WoodcuttingTask)
                         Destroy(obj.GetComponent<WoodcuttingTask>());
+                    else if (task is FarmingTask)
+                        Destroy(obj.GetComponent<FarmingTask>());
                     else
                         Destroy(obj.gameObject);
                 }
@@ -328,6 +330,8 @@ namespace TimelessEchoes.Tasks
                 if (task is OpenChestTask)
                     Destroy(mb);
                 else if (task is WoodcuttingTask)
+                    Destroy(mb);
+                else if (task is FarmingTask)
                     Destroy(mb);
                 else
                     Destroy(mb.gameObject);


### PR DESCRIPTION
## Summary
- add `FarmingTask` for watering crops with progressive sprite stages
- register `FarmingTask` removal in `TaskController`
- create `Farming` skill asset

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686126d2d1d8832eb66c9f7f695731d0