### PR TITLE
Fix PickEntry tuple return mismatch

### DIFF
--- a/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
+++ b/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
@@ -491,7 +491,7 @@ namespace TimelessEchoes.Tasks
 
             var totalWeight = enemyTotalWeight + otherTasksTotalWeight + waterTasksTotalWeight + grassTasksTotalWeight + sandTasksTotalWeight;
             if (totalWeight <= 0f)
-                return (null, false, false, false);
+                return (null, false, false, false, false);
 
             var r = Random.value * totalWeight;
 
@@ -501,7 +501,7 @@ namespace TimelessEchoes.Tasks
                 {
                     r -= e.GetWeight(worldX);
                     if (r <= 0f)
-                        return (e, true, false, false);
+                        return (e, true, false, false, false);
                 }
             }
             else


### PR DESCRIPTION
## Summary
- correct return tuples in `PickEntry` so they match the 5-element return type

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686311835854832e9a186d3317d41ec2