### PR TITLE
Expose tile references on TilemapChunkGenerator

### DIFF
--- a/Assets/Scripts/MapGeneration/TilemapChunkGenerator.cs
+++ b/Assets/Scripts/MapGeneration/TilemapChunkGenerator.cs
@@ -3,6 +3,7 @@ using Sirenix.OdinInspector;
 using UnityEngine;
 using UnityEngine.Tilemaps;
 using VinTools.BetterRuleTiles;
+using TimelessEchoes.Tasks;
 using Random = System.Random;
 
 namespace TimelessEchoes.MapGeneration
@@ -13,20 +14,16 @@ namespace TimelessEchoes.MapGeneration
         private MapGenerationConfig config;
 
         [Header("Tilemaps")] [TabGroup("References")] [SerializeField]
-        [HideInInspector]
         private Tilemap terrainMap;
 
 
         [Header("Tiles")] [TabGroup("References")] [SerializeField]
-        [HideInInspector]
         private BetterRuleTile waterTile;
 
         [TabGroup("References")] [SerializeField]
-        [HideInInspector]
         private BetterRuleTile sandRuleTile;
 
         [TabGroup("References")] [SerializeField]
-        [HideInInspector]
         private BetterRuleTile grassRuleTile;
 
 
@@ -66,6 +63,8 @@ namespace TimelessEchoes.MapGeneration
         private void Awake()
         {
             ApplyConfig();
+            var taskGen = GetComponent<Tasks.ProceduralTaskGenerator>();
+            AssignTilemaps(taskGen);
             rng = randomizeSeed ? new Random() : new Random(seed);
             prevSandDepth = -1;
             prevGrassDepth = -1;
@@ -75,16 +74,28 @@ namespace TimelessEchoes.MapGeneration
         {
             if (config == null) return;
 
-            terrainMap = config.tilemapChunkSettings.terrainMap;
-            waterTile = config.tilemapChunkSettings.waterTile;
-            sandRuleTile = config.tilemapChunkSettings.sandRuleTile;
-            grassRuleTile = config.tilemapChunkSettings.grassRuleTile;
+            if (terrainMap == null)
+                terrainMap = config.tilemapChunkSettings.terrainMap;
+            if (waterTile == null)
+                waterTile = config.tilemapChunkSettings.waterTile;
+            if (sandRuleTile == null)
+                sandRuleTile = config.tilemapChunkSettings.sandRuleTile;
+            if (grassRuleTile == null)
+                grassRuleTile = config.tilemapChunkSettings.grassRuleTile;
             minAreaWidth = config.tilemapChunkSettings.minAreaWidth;
             edgeWaviness = config.tilemapChunkSettings.edgeWaviness;
             sandDepthRange = config.tilemapChunkSettings.sandDepthRange;
             grassDepthRange = config.tilemapChunkSettings.grassDepthRange;
             seed = config.tilemapChunkSettings.seed;
             randomizeSeed = config.tilemapChunkSettings.randomizeSeed;
+        }
+
+        public void AssignTilemaps(Tasks.ProceduralTaskGenerator generator)
+        {
+            if (generator == null)
+                return;
+
+            generator.SetTilemapReferences(terrainMap, waterTile, sandRuleTile, grassRuleTile);
         }
 
         public void GenerateSegment(Vector2Int offset, Vector2Int segmentSize)

--- a/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
+++ b/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
@@ -95,6 +95,10 @@ namespace TimelessEchoes.Tasks
             if (controller == null)
                 controller = GetComponent<TaskController>();
             ApplyConfig();
+
+            var chunk = GetComponent<TilemapChunkGenerator>();
+            chunk?.AssignTilemaps(this);
+
             EnsureTilemaps();
         }
 
@@ -120,23 +124,18 @@ namespace TimelessEchoes.Tasks
             Gizmos.DrawWireCube(center, size);
         }
 
+        internal void SetTilemapReferences(Tilemap map, BetterRuleTile water, BetterRuleTile sand, BetterRuleTile grass)
+        {
+            terrainMap = map;
+            waterTile = water;
+            sandTile = sand;
+            grassTile = grass;
+        }
+
         private void EnsureTilemaps()
         {
             if (terrainMap != null && waterTile != null && sandTile != null && grassTile != null)
                 return;
-
-            var chunk = GetComponent<TilemapChunkGenerator>();
-            if (chunk != null)
-            {
-                if (terrainMap == null)
-                    terrainMap = chunk.TerrainMap;
-                if (waterTile == null)
-                    waterTile = chunk.WaterTile;
-                if (sandTile == null)
-                    sandTile = chunk.SandTile;
-                if (grassTile == null)
-                    grassTile = chunk.GrassTile;
-            }
 
             if (terrainMap == null)
             {


### PR DESCRIPTION
## Summary
- allow assigning tilemap and tile references directly in `TilemapChunkGenerator`
- don't overwrite inspector values when applying config

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68632370c360832e864ec0322dd082f0