### PR TITLE
Rename tile fields and hide in inspectors

### DIFF
--- a/Assets/Scripts/MapGeneration/MapGenerationConfig.cs
+++ b/Assets/Scripts/MapGeneration/MapGenerationConfig.cs
@@ -5,6 +5,7 @@ using Sirenix.OdinInspector;
 using TimelessEchoes.Tasks;
 using UnityEngine;
 using UnityEngine.Tilemaps;
+using UnityEngine.Serialization;
 using VinTools.BetterRuleTiles;
 
 namespace TimelessEchoes.MapGeneration
@@ -19,10 +20,14 @@ namespace TimelessEchoes.MapGeneration
         [Serializable]
         public class TilemapChunkSettings
         {
+            [HideInInspector]
             public Tilemap terrainMap;
-            public BetterRuleTile waterTile;
-            public BetterRuleTile sandRuleTile;
-            public BetterRuleTile grassRuleTile;
+            [FormerlySerializedAs("waterTile")]
+            public BetterRuleTile waterBetterRuleTile;
+            [FormerlySerializedAs("sandRuleTile")]
+            public BetterRuleTile sandBetterRuleTile;
+            [FormerlySerializedAs("grassRuleTile")]
+            public BetterRuleTile grassBetterRuleTile;
 
             [Min(2)] public int minAreaWidth = 2;
             [Min(0)] public int edgeWaviness = 1;

--- a/Assets/Scripts/MapGeneration/TilemapChunkGenerator.cs
+++ b/Assets/Scripts/MapGeneration/TilemapChunkGenerator.cs
@@ -2,6 +2,7 @@ using System;
 using Sirenix.OdinInspector;
 using UnityEngine;
 using UnityEngine.Tilemaps;
+using UnityEngine.Serialization;
 using VinTools.BetterRuleTiles;
 using TimelessEchoes.Tasks;
 using Random = System.Random;
@@ -18,13 +19,19 @@ namespace TimelessEchoes.MapGeneration
 
 
         [Header("Tiles")] [TabGroup("References")] [SerializeField]
-        private BetterRuleTile waterTile;
+        [FormerlySerializedAs("waterTile")]
+        [HideInInspector]
+        private BetterRuleTile waterBetterRuleTile;
 
         [TabGroup("References")] [SerializeField]
-        private BetterRuleTile sandRuleTile;
+        [FormerlySerializedAs("sandRuleTile")]
+        [HideInInspector]
+        private BetterRuleTile sandBetterRuleTile;
 
         [TabGroup("References")] [SerializeField]
-        private BetterRuleTile grassRuleTile;
+        [FormerlySerializedAs("grassRuleTile")]
+        [HideInInspector]
+        private BetterRuleTile grassBetterRuleTile;
 
 
         [Header("Generation Settings")] [TabGroup("Settings")] [SerializeField] [Min(2)]
@@ -56,9 +63,9 @@ namespace TimelessEchoes.MapGeneration
         private int prevSandDepth = -1;
         private int prevGrassDepth = -1;
         public Tilemap TerrainMap => terrainMap;
-        public BetterRuleTile WaterTile => waterTile;
-        public BetterRuleTile SandTile => sandRuleTile;
-        public BetterRuleTile GrassTile => grassRuleTile;
+        public BetterRuleTile WaterBetterRuleTile => waterBetterRuleTile;
+        public BetterRuleTile SandBetterRuleTile => sandBetterRuleTile;
+        public BetterRuleTile GrassBetterRuleTile => grassBetterRuleTile;
 
         private void Awake()
         {
@@ -76,12 +83,12 @@ namespace TimelessEchoes.MapGeneration
 
             if (terrainMap == null)
                 terrainMap = config.tilemapChunkSettings.terrainMap;
-            if (waterTile == null)
-                waterTile = config.tilemapChunkSettings.waterTile;
-            if (sandRuleTile == null)
-                sandRuleTile = config.tilemapChunkSettings.sandRuleTile;
-            if (grassRuleTile == null)
-                grassRuleTile = config.tilemapChunkSettings.grassRuleTile;
+            if (waterBetterRuleTile == null)
+                waterBetterRuleTile = config.tilemapChunkSettings.waterBetterRuleTile;
+            if (sandBetterRuleTile == null)
+                sandBetterRuleTile = config.tilemapChunkSettings.sandBetterRuleTile;
+            if (grassBetterRuleTile == null)
+                grassBetterRuleTile = config.tilemapChunkSettings.grassBetterRuleTile;
             minAreaWidth = config.tilemapChunkSettings.minAreaWidth;
             edgeWaviness = config.tilemapChunkSettings.edgeWaviness;
             sandDepthRange = config.tilemapChunkSettings.sandDepthRange;
@@ -95,7 +102,7 @@ namespace TimelessEchoes.MapGeneration
             if (generator == null)
                 return;
 
-            generator.SetTilemapReferences(terrainMap, waterTile, sandRuleTile, grassRuleTile);
+            generator.SetTilemapReferences(terrainMap, waterBetterRuleTile, sandBetterRuleTile, grassBetterRuleTile);
         }
 
         public void GenerateSegment(Vector2Int offset, Vector2Int segmentSize)
@@ -147,14 +154,14 @@ namespace TimelessEchoes.MapGeneration
                 var waterDepth = Mathf.Max(0, segmentSize.y - sandDepth - grassDepth);
 
                 for (var y = 0; y < waterDepth; y++)
-                    terrainMap.SetTile(new Vector3Int(offset.x + x, offset.y + y, 0), waterTile);
+                    terrainMap.SetTile(new Vector3Int(offset.x + x, offset.y + y, 0), waterBetterRuleTile);
 
                 for (var y = waterDepth; y < waterDepth + sandDepth; y++)
-                    terrainMap.SetTile(new Vector3Int(offset.x + x, offset.y + y, 0), sandRuleTile);
+                    terrainMap.SetTile(new Vector3Int(offset.x + x, offset.y + y, 0), sandBetterRuleTile);
 
                 for (var y = waterDepth + sandDepth; y < waterDepth + sandDepth + grassDepth; y++)
                     if (y < segmentSize.y)
-                        terrainMap.SetTile(new Vector3Int(offset.x + x, offset.y + y, 0), grassRuleTile);
+                        terrainMap.SetTile(new Vector3Int(offset.x + x, offset.y + y, 0), grassBetterRuleTile);
 
                 for (var y = 0; y < waterDepth; y++)
                 {
@@ -200,7 +207,7 @@ namespace TimelessEchoes.MapGeneration
                         continue;
 
                     var pos = new Vector3Int(offset.x + x, offset.y + y, 0);
-                    if (terrainMap.GetTile(pos) == grassRuleTile) continue;
+                    if (terrainMap.GetTile(pos) == grassBetterRuleTile) continue;
 
                 }
 


### PR DESCRIPTION
## Summary
- rename water, sand, and grass tiles to `WaterBetterRuleTile`, `SandBetterRuleTile`, and `GrassBetterRuleTile`
- show these tiles only in MapGenerationWindow via `MapGenerationConfig`
- hide Terrain map from the window but keep it visible on `TilemapChunkGenerator`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863346cd168832e8ceab8a446801c5d