### PR TITLE
Hide unneeded fields in map generation window

### DIFF
--- a/Assets/Scripts/MapGeneration/MapGenerationConfig.cs
+++ b/Assets/Scripts/MapGeneration/MapGenerationConfig.cs
@@ -60,8 +60,6 @@ namespace TimelessEchoes.MapGeneration
         public class SegmentedMapSettings
         {
             public Vector2Int segmentSize = new(64, 18);
-            public Transform segmentParent;
-            public AstarPath pathfinder;
         }
     }
 }

--- a/Assets/Scripts/MapGeneration/SegmentedMapGenerator.cs
+++ b/Assets/Scripts/MapGeneration/SegmentedMapGenerator.cs
@@ -17,9 +17,9 @@ namespace TimelessEchoes.MapGeneration
         [SerializeField]
         private MapGenerationConfig config;
 
-        [SerializeField] [HideInInspector] private Vector2Int segmentSize = new(64, 18);
-        [SerializeField] [HideInInspector] private Transform segmentParent;
-        [SerializeField] [HideInInspector] private AstarPath pathfinder;
+        [SerializeField] private Vector2Int segmentSize = new(64, 18);
+        [SerializeField] private Transform segmentParent;
+        [SerializeField] private AstarPath pathfinder;
 
         private TilemapChunkGenerator chunkGenerator;
         private ProceduralTaskGenerator taskGenerator;
@@ -50,8 +50,6 @@ namespace TimelessEchoes.MapGeneration
             if (config == null) return;
 
             segmentSize = config.segmentedMapSettings.segmentSize;
-            segmentParent = config.segmentedMapSettings.segmentParent;
-            pathfinder = config.segmentedMapSettings.pathfinder;
         }
 
         private IEnumerator Start()


### PR DESCRIPTION
## Summary
- remove `segmentParent` and `pathfinder` from `SegmentedMapSettings`
- expose `segmentParent` and `pathfinder` fields on `SegmentedMapGenerator`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6863378e5070832ead9e9db0c142a37b