### PR TITLE
Fix milestone loading

### DIFF
--- a/Assets/Scripts/Skills/SkillController.cs
+++ b/Assets/Scripts/Skills/SkillController.cs
@@ -128,6 +128,10 @@ namespace TimelessEchoes.Skills
                 {
                     progress[skill] = new SkillProgress { Level = 1, CurrentXP = 0f };
                 }
+
+                // Ensure milestones are reevaluated on load so previously earned
+                // bonuses are applied even if they weren't saved.
+                CheckMilestones(skill, progress[skill]);
             }
         }
 


### PR DESCRIPTION
## Summary
- ensure skill milestones are checked when progress is loaded

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6863a03f3ec4832e82df049cb987a905