### PR TITLE
Add persistent NPC dialog tasks

### DIFF
--- a/Assets/Scripts/Blindsided/Oracle.cs
+++ b/Assets/Scripts/Blindsided/Oracle.cs
@@ -206,6 +206,7 @@ namespace Blindsided
             saveData.Resources ??= new Dictionary<string, GameData.ResourceEntry>();
             saveData.SkillData ??= new Dictionary<string, GameData.SkillProgress>();
             saveData.EnemyKills ??= new Dictionary<string, double>();
+            saveData.CompletedNpcTasks ??= new HashSet<string>();
         }
 
         public static void AwayForSeconds()

--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -24,6 +24,9 @@ namespace Blindsided.SaveData
         [HideReferenceObjectPicker] public Dictionary<string, ResourceEntry> Resources = new();
         [HideReferenceObjectPicker] public Dictionary<string, double> EnemyKills = new();
 
+        [HideReferenceObjectPicker]
+        public HashSet<string> CompletedNpcTasks = new();
+
 
         [HideReferenceObjectPicker]
         public class ResourceEntry

--- a/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
+++ b/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
@@ -10,6 +10,7 @@ namespace Blindsided.SaveData
         public static Dictionary<string, int> UpgradeLevels => oracle.saveData.UpgradeLevels;
         public static Dictionary<string, ResourceEntry> Resources => oracle.saveData.Resources;
         public static Dictionary<string, double> EnemyKills => oracle.saveData.EnemyKills;
+        public static HashSet<string> CompletedNpcTasks => oracle.saveData.CompletedNpcTasks;
 
 
         public static BuyMode PurchaseMode

--- a/Assets/Scripts/MapGeneration/MapGenerationConfig.cs
+++ b/Assets/Scripts/MapGeneration/MapGenerationConfig.cs
@@ -49,8 +49,24 @@ namespace TimelessEchoes.MapGeneration
 
             public List<ProceduralTaskGenerator.WeightedSpawn> enemies = new();
             public List<ProceduralTaskGenerator.WeightedSpawn> tasks = new();
+            public List<NpcSpawnEntry> npcTasks = new();
 
             [MinValue(0f)] public float minTaskDistance = 1.5f;
+
+            [Serializable]
+            [InlineProperty]
+            [HideLabel]
+            public class NpcSpawnEntry
+            {
+                [Required] public GameObject prefab;
+                public string id;
+                public float localX;
+                [MinValue(0)] public int topBuffer = 0;
+                public bool spawnOnWater;
+                public bool spawnOnSand;
+                public bool spawnOnGrass = true;
+                public bool spawnOnlyOnce = true;
+            }
         }
 
         [Serializable]

--- a/Assets/Scripts/Tasks/TalkToNpcTask.cs
+++ b/Assets/Scripts/Tasks/TalkToNpcTask.cs
@@ -1,25 +1,85 @@
+using System.Collections.Generic;
+using Blindsided.SaveData;
+using TMPro;
 using UnityEngine;
+using UnityEngine.UI;
+using TimelessEchoes.Hero;
 
 namespace TimelessEchoes.Tasks
 {
     /// <summary>
-    /// Task for interacting with a specific NPC.
+    /// Simple conversation task for interacting with an NPC.
+    /// Shows text lines sequentially and completes when finished.
     /// </summary>
     public class TalkToNpcTask : BaseTask
     {
-        [SerializeField] private Transform npc;
+        [SerializeField] private string npcId;
+        [SerializeField] private Transform chatPoint;
+        [SerializeField] private GameObject dialogueObject;
+        [SerializeField] private TMP_Text dialogueText;
+        [SerializeField] private Button continueButton;
+        [TextArea]
+        [SerializeField] private List<string> lines = new();
+
+        private int index;
         private bool talked;
 
-        public override Transform Target => npc;
+        public override Transform Target => chatPoint != null ? chatPoint : transform;
+        public override bool BlocksMovement => dialogueObject != null && dialogueObject.activeSelf;
+
+        private void Awake()
+        {
+            if (continueButton != null)
+                continueButton.onClick.AddListener(Advance);
+        }
 
         public override void StartTask()
         {
             talked = false;
+            index = 0;
+            if (dialogueObject != null)
+                dialogueObject.SetActive(false);
         }
 
-        public void Interact()
+        public override void OnArrival(HeroController hero)
         {
+            StartConversation();
+        }
+
+        private void StartConversation()
+        {
+            if (dialogueObject != null)
+                dialogueObject.SetActive(true);
+            ShowLine();
+        }
+
+        private void ShowLine()
+        {
+            if (dialogueText != null && index < lines.Count)
+                dialogueText.text = lines[index];
+        }
+
+        private void Advance()
+        {
+            index++;
+            if (index >= lines.Count)
+            {
+                EndConversation();
+            }
+            else
+            {
+                ShowLine();
+            }
+        }
+
+        private void EndConversation()
+        {
+            if (dialogueObject != null)
+                dialogueObject.SetActive(false);
             talked = true;
+            if (!string.IsNullOrEmpty(npcId))
+                StaticReferences.CompletedNpcTasks.Add(npcId);
+            GrantCompletionXP();
         }
 
         public override bool IsComplete()


### PR DESCRIPTION
## Summary
- add a new CompletedNpcTasks field to the save data with static access
- implement conversation logic and persistence in TalkToNpcTask
- support NPC task spawning through ProceduralTaskGenerator using new MapGenerationConfig entries

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863b872ebec832e9dcc5fc97723f2be