### PR TITLE
Prioritize NPC tasks and gate farming

### DIFF
--- a/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
+++ b/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
@@ -548,8 +548,14 @@ namespace TimelessEchoes.Tasks
 
             var taskTotalWeight = 0f;
             foreach (var t in tasks)
-                if (TaskAllowed(t, allowWaterTasks, allowGrassTasks, allowSandTasks))
-                    taskTotalWeight += t.GetWeight(worldX);
+            {
+                if (!TaskAllowed(t, allowWaterTasks, allowGrassTasks, allowSandTasks))
+                    continue;
+                if (t.prefab != null && t.prefab.GetComponent<FarmingTask>() != null &&
+                    !StaticReferences.CompletedNpcTasks.Contains("Witch1"))
+                    continue;
+                taskTotalWeight += t.GetWeight(worldX);
+            }
 
             var totalWeight = enemyTotalWeight + taskTotalWeight;
             if (totalWeight <= 0f)
@@ -571,6 +577,9 @@ namespace TimelessEchoes.Tasks
                 foreach (var t in tasks)
                 {
                     if (!TaskAllowed(t, allowWaterTasks, allowGrassTasks, allowSandTasks))
+                        continue;
+                    if (t.prefab != null && t.prefab.GetComponent<FarmingTask>() != null &&
+                        !StaticReferences.CompletedNpcTasks.Contains("Witch1"))
                         continue;
                     r -= t.GetWeight(worldX);
                     if (r > 0f) continue;

--- a/Assets/Scripts/Tasks/TaskController.cs
+++ b/Assets/Scripts/Tasks/TaskController.cs
@@ -343,7 +343,9 @@ namespace TimelessEchoes.Tasks
 
         private void SortTaskListsByX()
         {
-            var pairs = new List<(float x, MonoBehaviour obj, ITask task)>();
+            var npcPairs = new List<(float x, MonoBehaviour obj, ITask task)>();
+            var regularPairs = new List<(float x, MonoBehaviour obj, ITask task)>();
+
             foreach (var task in tasks)
             {
                 MonoBehaviour obj = null;
@@ -353,15 +355,32 @@ namespace TimelessEchoes.Tasks
                     x = obj.transform.position.x;
                 else if (task != null && task.Target != null)
                     x = task.Target.position.x;
-                pairs.Add((x, obj, task));
+
+                var pair = (x, obj, task);
+                if (task is TalkToNpcTask)
+                    npcPairs.Add(pair);
+                else
+                    regularPairs.Add(pair);
             }
 
-            pairs.Sort((a, b) => a.x.CompareTo(b.x));
+            npcPairs.Sort((a, b) => a.x.CompareTo(b.x));
+            regularPairs.Sort((a, b) => a.x.CompareTo(b.x));
 
             tasks.Clear();
             taskObjects.Clear();
             taskMap.Clear();
-            foreach (var p in pairs)
+
+            foreach (var p in npcPairs)
+            {
+                tasks.Add(p.task);
+                if (p.obj != null)
+                {
+                    taskObjects.Add(p.obj);
+                    taskMap[p.task] = p.obj;
+                }
+            }
+
+            foreach (var p in regularPairs)
             {
                 tasks.Add(p.task);
                 if (p.obj != null)


### PR DESCRIPTION
## Summary
- sort tasks so NPC interactions are done first
- block FarmingTask spawns until the witch meeting is complete

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6863c166d474832ea9bd07b9fd3058d0