### PR TITLE
Implement basic buff system

### DIFF
--- a/Assets/Scripts/Buffs/BuffController.cs
+++ b/Assets/Scripts/Buffs/BuffController.cs
@@ -1,0 +1,133 @@
+using System.Collections.Generic;
+using TimelessEchoes.Upgrades;
+using UnityEngine;
+
+namespace TimelessEchoes.Buffs
+{
+    public class BuffController : MonoBehaviour
+    {
+        [SerializeField] private ResourceManager resourceManager;
+        [SerializeField] private AnimationCurve diminishingCurve = 
+            AnimationCurve.Linear(0f, 1f, 60f, 0f);
+
+        private readonly List<ActiveBuff> activeBuffs = new();
+
+        public IReadOnlyList<ActiveBuff> ActiveBuffs => activeBuffs;
+
+        private void Awake()
+        {
+            if (resourceManager == null)
+                resourceManager = FindFirstObjectByType<ResourceManager>();
+        }
+
+        private void Update()
+        {
+            TickBuffs(Time.deltaTime);
+        }
+
+        private void TickBuffs(float delta)
+        {
+            if (delta <= 0f) return;
+            for (int i = activeBuffs.Count - 1; i >= 0; i--)
+            {
+                var buff = activeBuffs[i];
+                buff.remaining -= delta;
+                if (buff.remaining <= 0f)
+                    activeBuffs.RemoveAt(i);
+            }
+        }
+
+        public bool CanPurchase(BuffRecipe recipe)
+        {
+            if (recipe == null) return false;
+            foreach (var req in recipe.requirements)
+            {
+                if (resourceManager != null &&
+                    resourceManager.GetAmount(req.resource) < req.amount)
+                    return false;
+            }
+            return true;
+        }
+
+        public bool PurchaseBuff(BuffRecipe recipe)
+        {
+            if (!CanPurchase(recipe)) return false;
+
+            foreach (var req in recipe.requirements)
+                resourceManager?.Spend(req.resource, req.amount);
+
+            var buff = activeBuffs.Find(b => b.recipe == recipe);
+            if (buff == null)
+            {
+                buff = new ActiveBuff { recipe = recipe, remaining = recipe.baseDuration };
+                activeBuffs.Add(buff);
+            }
+            else
+            {
+                float extra = recipe.baseDuration;
+                if (diminishingCurve != null)
+                    extra *= diminishingCurve.Evaluate(buff.remaining);
+                buff.remaining += extra;
+            }
+
+            return true;
+        }
+
+        public float GetRemaining(BuffRecipe recipe)
+        {
+            var buff = activeBuffs.Find(b => b.recipe == recipe);
+            return buff != null ? buff.remaining : 0f;
+        }
+
+        public float MoveSpeedMultiplier
+        {
+            get
+            {
+                float percent = 0f;
+                foreach (var b in activeBuffs)
+                    percent += b.recipe.moveSpeedPercent;
+                return 1f + percent / 100f;
+            }
+        }
+
+        public float DamageMultiplier
+        {
+            get
+            {
+                float percent = 0f;
+                foreach (var b in activeBuffs)
+                    percent += b.recipe.damagePercent;
+                return 1f + percent / 100f;
+            }
+        }
+
+        public float DefenseMultiplier
+        {
+            get
+            {
+                float percent = 0f;
+                foreach (var b in activeBuffs)
+                    percent += b.recipe.defensePercent;
+                return 1f + percent / 100f;
+            }
+        }
+
+        public float AttackSpeedMultiplier
+        {
+            get
+            {
+                float percent = 0f;
+                foreach (var b in activeBuffs)
+                    percent += b.recipe.attackSpeedPercent;
+                return 1f + percent / 100f;
+            }
+        }
+
+        [System.Serializable]
+        public class ActiveBuff
+        {
+            public BuffRecipe recipe;
+            public float remaining;
+        }
+    }
+}

--- a/Assets/Scripts/Buffs/BuffRecipe.cs
+++ b/Assets/Scripts/Buffs/BuffRecipe.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using Blindsided.Utilities;
+using TimelessEchoes.Upgrades;
+using UnityEngine;
+
+namespace TimelessEchoes.Buffs
+{
+    [ManageableData]
+    [CreateAssetMenu(fileName = "BuffRecipe", menuName = "SO/Buff Recipe")]
+    public class BuffRecipe : ScriptableObject
+    {
+        public Sprite buffIcon;
+        [Min(0f)] public float baseDuration = 30f;
+        [Range(-100f, 100f)] public float moveSpeedPercent;
+        [Range(-100f, 100f)] public float damagePercent;
+        [Range(-100f, 100f)] public float defensePercent;
+        [Range(-100f, 100f)] public float attackSpeedPercent;
+        public List<ResourceRequirement> requirements = new();
+    }
+
+    [Serializable]
+    public class ResourceRequirement
+    {
+        public Resource resource;
+        public int amount;
+    }
+}

--- a/Assets/Scripts/References/UI/BuffIconUIReferences.cs
+++ b/Assets/Scripts/References/UI/BuffIconUIReferences.cs
@@ -1,0 +1,12 @@
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace References.UI
+{
+    public class BuffIconUIReferences : MonoBehaviour
+    {
+        public Image iconImage;
+        public TMP_Text durationText;
+    }
+}

--- a/Assets/Scripts/References/UI/BuffRecipeUIReferences.cs
+++ b/Assets/Scripts/References/UI/BuffRecipeUIReferences.cs
@@ -1,0 +1,15 @@
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace References.UI
+{
+    public class BuffRecipeUIReferences : MonoBehaviour
+    {
+        public Image iconImage;
+        public TMP_Text durationText;
+        public Button purchaseButton;
+        public CostResourceUIReferences costSlotPrefab;
+        public GameObject costGridLayoutParent;
+    }
+}


### PR DESCRIPTION
## Summary
- add BuffRecipe scriptable object for temporary stat boosts
- manage buffs and stacking logic with new BuffController
- display available buffs and active ones via BuffUIManager
- extend HeroController to apply buffs to combat, defense and speed
- add simple UI reference components for buff icons and recipes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68645a124440832e9c897f9e91020b7e