### PR TITLE
Add task and resource persistence

### DIFF
--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -29,10 +29,10 @@ namespace Blindsided.SaveData
         public HashSet<string> CompletedNpcTasks = new();
 
         [HideReferenceObjectPicker]
-        public TaskStats Tasks = new();
+        public Dictionary<string, TaskRecord> TaskRecords = new();
 
         [HideReferenceObjectPicker]
-        public ItemStats Items = new();
+        public Dictionary<string, ResourceRecord> ResourceStats = new();
 
         [HideReferenceObjectPicker]
         public GeneralStats General = new();
@@ -79,17 +79,18 @@ namespace Blindsided.SaveData
         }
 
         [HideReferenceObjectPicker]
-        public class TaskStats
+        public class TaskRecord
         {
-            public Dictionary<string, int> Completed = new();
-            public Dictionary<string, float> TimeSpent = new();
+            public int TotalCompleted;
+            public float TimeSpent;
+            public float XpGained;
         }
 
         [HideReferenceObjectPicker]
-        public class ItemStats
+        public class ResourceRecord
         {
-            public Dictionary<string, int> ItemsReceived = new();
-            public Dictionary<string, int> ItemsSpent = new();
+            public int TotalReceived;
+            public int TotalSpent;
         }
 
         [HideReferenceObjectPicker]

--- a/Assets/Scripts/Tasks/BaseTask.cs
+++ b/Assets/Scripts/Tasks/BaseTask.cs
@@ -12,6 +12,11 @@ namespace TimelessEchoes.Tasks
     {
         [SerializeField] public Skill associatedSkill;
         [SerializeField] private float xpGrantedOnCompletion;
+        [SerializeField] public TaskData taskData;
+
+        private float lastGrantedXp;
+
+        public float LastGrantedXp => lastGrantedXp;
 
         /// <summary>
         ///     A property to indicate if this task should prevent the hero from moving.
@@ -62,9 +67,10 @@ namespace TimelessEchoes.Tasks
             return controller && controller.RollForEffect(associatedSkill, MilestoneType.InstantTask);
         }
 
-        protected void GrantCompletionXP()
+        protected float GrantCompletionXP()
         {
-            if (associatedSkill == null || xpGrantedOnCompletion <= 0f) return;
+            lastGrantedXp = 0f;
+            if (associatedSkill == null || xpGrantedOnCompletion <= 0f) return 0f;
             var controller = FindFirstObjectByType<SkillController>();
             var amount = xpGrantedOnCompletion;
             if (controller)
@@ -73,6 +79,8 @@ namespace TimelessEchoes.Tasks
                 amount *= mult;
             }
             controller?.AddExperience(associatedSkill, amount);
+            lastGrantedXp = amount;
+            return amount;
         }
     }
 }

--- a/Assets/Scripts/Tasks/TaskController.cs
+++ b/Assets/Scripts/Tasks/TaskController.cs
@@ -349,7 +349,9 @@ namespace TimelessEchoes.Tasks
             if (task != null && task.IsComplete())
             {
                 var tracker = FindFirstObjectByType<TimelessEchoes.Stats.GameplayStatTracker>();
-                tracker?.RegisterTaskComplete(task.GetType().Name, duration);
+                TaskData data = (task as BaseTask)?.taskData;
+                float xp = (task as BaseTask)?.LastGrantedXp ?? 0f;
+                tracker?.RegisterTaskComplete(data, duration, xp);
             }
 
             if (index <= currentIndex)

--- a/Assets/Scripts/Tasks/TaskData.cs
+++ b/Assets/Scripts/Tasks/TaskData.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using Blindsided.Utilities;
+using TimelessEchoes.Skills;
+using TimelessEchoes.Upgrades;
+using UnityEngine;
+
+namespace TimelessEchoes.Tasks
+{
+    [ManageableData]
+    [CreateAssetMenu(fileName = "TaskData", menuName = "SO/Task Data")]
+    public class TaskData : ScriptableObject
+    {
+        public string taskName;
+        public string taskID;
+        public Sprite taskIcon;
+        public Skill associatedSkill;
+        public float xpForCompletion;
+        public float taskDuration;
+        public List<ResourceDrop> resourceDrops = new();
+
+        [System.Serializable]
+        public class Persistent
+        {
+            public int totalTimesCompleted;
+            public float timeSpent;
+            public float experienceGained;
+        }
+
+        [HideInInspector]
+        public Persistent persistent = new();
+    }
+}

--- a/Assets/Scripts/Upgrades/Resource.cs
+++ b/Assets/Scripts/Upgrades/Resource.cs
@@ -10,5 +10,8 @@ namespace TimelessEchoes.Upgrades
     public class Resource : ScriptableObject
     {
         public Sprite icon;
+
+        [HideInInspector] public int totalReceived;
+        [HideInInspector] public int totalSpent;
     }
 }


### PR DESCRIPTION
## Summary
- create new **TaskData** scriptable object for task definitions and persistent stats
- track XP granted in `BaseTask` and report stats via `TaskController`
- rewrite `GameplayStatTracker` to use `TaskData` and new GameData fields
- extend `Resource` with lifetime received/spent counts and persist them in `ResourceManager`
- replace removed `TaskStats` and `ItemStats` with `TaskRecord` and `ResourceRecord` in `GameData`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6864e9c3973c832e8a365d71436eb413