### PR TITLE
Add task stats panel

### DIFF
--- a/Assets/Scripts/References/StatPanel/StatPanelReferences.cs
+++ b/Assets/Scripts/References/StatPanel/StatPanelReferences.cs
@@ -6,5 +6,7 @@ namespace TimelessEchoes.References.StatPanel
     {
         public Transform enemyEntryParent;
         public Transform enemyEntryPrefab;
+        public Transform taskEntryParent;
+        public Transform taskEntryPrefab;
     }
 }

--- a/Assets/Scripts/References/StatPanel/TaskStatEntryUIReferences.cs
+++ b/Assets/Scripts/References/StatPanel/TaskStatEntryUIReferences.cs
@@ -1,0 +1,14 @@
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TimelessEchoes.References.StatPanel
+{
+    public class TaskStatEntryUIReferences : MonoBehaviour
+    {
+        public Image entryIconImage;
+        public TMP_Text entryIDText;
+        public TMP_Text entryNameText;
+        public TMP_Text entryCompletionsTimeOnTaskExperienceText;
+    }
+}

--- a/Assets/Scripts/References/StatPanel/TaskStatEntryUIReferences.cs.meta
+++ b/Assets/Scripts/References/StatPanel/TaskStatEntryUIReferences.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fa4b6ac5c39994e2fe14e7793aaa6f79

--- a/Assets/Scripts/Stats/GameplayStatTracker.cs
+++ b/Assets/Scripts/Stats/GameplayStatTracker.cs
@@ -120,6 +120,11 @@ namespace TimelessEchoes.Stats
             tasksCompleted++;
         }
 
+        public GameData.TaskRecord GetTaskRecord(TaskData data)
+        {
+            return data != null && taskRecords.TryGetValue(data, out var record) ? record : null;
+        }
+
         public void AddDistance(float dist)
         {
             if (dist > 0f)

--- a/Assets/Scripts/UI/TaskStatsPanelUI.cs
+++ b/Assets/Scripts/UI/TaskStatsPanelUI.cs
@@ -1,0 +1,146 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using TimelessEchoes.References.StatPanel;
+using TimelessEchoes.Tasks;
+using TimelessEchoes.Stats;
+using Blindsided.Utilities;
+
+namespace TimelessEchoes.UI
+{
+    public class TaskStatsPanelUI : MonoBehaviour
+    {
+        [SerializeField] private StatPanelReferences references;
+        [SerializeField] private GameplayStatTracker statTracker;
+
+        private readonly Dictionary<TaskData, TaskStatEntryUIReferences> entries = new();
+        private List<TaskData> defaultOrder = new();
+
+        public enum SortMode
+        {
+            Default,
+            Completions,
+            TaskTime
+        }
+
+        [SerializeField] private SortMode sortMode = SortMode.Default;
+
+        private void Awake()
+        {
+            if (references == null)
+                references = GetComponent<StatPanelReferences>();
+            if (statTracker == null)
+                statTracker = FindFirstObjectByType<GameplayStatTracker>();
+            BuildEntries();
+        }
+
+        private void OnEnable()
+        {
+            UpdateEntries();
+        }
+
+        private void Update()
+        {
+            UpdateEntries();
+            SortEntries();
+        }
+
+        public void SetSortMode(SortMode mode)
+        {
+            sortMode = mode;
+            SortEntries();
+        }
+
+        private void BuildEntries()
+        {
+            if (references == null || references.taskEntryParent == null || references.taskEntryPrefab == null)
+                return;
+
+            foreach (Transform child in references.taskEntryParent)
+                Destroy(child.gameObject);
+
+            var allTasks = Resources.LoadAll<TaskData>("Tasks");
+            var sorted = allTasks.OrderBy(t => t.taskName).ToList();
+            defaultOrder = sorted;
+            entries.Clear();
+
+            foreach (var data in sorted)
+            {
+                var obj = Instantiate(references.taskEntryPrefab.gameObject, references.taskEntryParent);
+                var ui = obj.GetComponent<TaskStatEntryUIReferences>();
+                if (ui == null) continue;
+                entries[data] = ui;
+            }
+
+            SortEntries();
+        }
+
+        private void UpdateEntries()
+        {
+            foreach (var pair in entries)
+                UpdateEntry(pair.Key, pair.Value);
+        }
+
+        private void UpdateEntry(TaskData data, TaskStatEntryUIReferences ui)
+        {
+            if (data == null || ui == null) return;
+
+            var record = statTracker ? statTracker.GetTaskRecord(data) : null;
+            int completed = record?.TotalCompleted ?? 0;
+            float time = record?.TimeSpent ?? 0f;
+            float xp = record?.XpGained ?? 0f;
+
+            if (ui.entryIconImage != null)
+            {
+                ui.entryIconImage.sprite = data.taskIcon;
+                if (data.taskIcon != null)
+                    ui.entryIconImage.SetNativeSize();
+                ui.entryIconImage.enabled = data.taskIcon != null;
+            }
+
+            if (ui.entryIDText != null)
+                ui.entryIDText.text = $"#{data.taskID}";
+
+            if (ui.entryNameText != null)
+                ui.entryNameText.text = data.taskName;
+
+            if (ui.entryCompletionsTimeOnTaskExperienceText != null)
+            {
+                string comp = CalcUtils.FormatNumber(completed, true, 400f, false);
+                string timeStr = CalcUtils.FormatNumber(time, true, 400f, false);
+                string xpStr = CalcUtils.FormatNumber(xp, true, 400f, false);
+                ui.entryCompletionsTimeOnTaskExperienceText.text = $"Completions: {comp}\nTime on Task: {timeStr}\nXP: {xpStr}";
+            }
+        }
+
+        private void SortEntries()
+        {
+            if (entries.Count == 0)
+                return;
+
+            if (sortMode == SortMode.Default)
+            {
+                ApplyOrder(defaultOrder);
+                return;
+            }
+
+            IOrderedEnumerable<TaskData> ordered;
+            if (sortMode == SortMode.Completions)
+                ordered = entries.Keys.OrderByDescending(t => statTracker?.GetTaskRecord(t)?.TotalCompleted ?? 0);
+            else
+                ordered = entries.Keys.OrderByDescending(t => statTracker?.GetTaskRecord(t)?.TimeSpent ?? 0f);
+
+            ApplyOrder(ordered.ToList());
+        }
+
+        private void ApplyOrder(IList<TaskData> order)
+        {
+            int index = 0;
+            foreach (var data in order)
+            {
+                if (entries.TryGetValue(data, out var ui))
+                    ui.transform.SetSiblingIndex(index++);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/UI/TaskStatsPanelUI.cs.meta
+++ b/Assets/Scripts/UI/TaskStatsPanelUI.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: acc6bf2cc5049aece9561339c883b4ef


### PR DESCRIPTION
## Summary
- add `TaskStatEntryUIReferences` script for task stats UI
- extend `StatPanelReferences` to support task entries
- implement `TaskStatsPanelUI` to build/sort task stats
- expose `GetTaskRecord` in `GameplayStatTracker`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864f5810df0832e8a76f9d69d754f80