### PR TITLE
Refactor StatSortingManager to use preconfigured buttons

### DIFF
--- a/Assets/Scripts/UI/StatSortingManager.cs
+++ b/Assets/Scripts/UI/StatSortingManager.cs
@@ -6,24 +6,62 @@ using UnityEngine.Events;
 namespace TimelessEchoes.UI
 {
     /// <summary>
-    /// Instantiates and manages sorting buttons based on the active stats tab.
+    /// Manages sorting buttons based on the active stats tab.
     /// </summary>
     public class StatSortingManager : MonoBehaviour
     {
-        [SerializeField] private Transform buttonParent;
-        [SerializeField] private StatSortButton buttonPrefab;
-
+        [SerializeField] private GeneralStatsPanelUI generalPanel;
         [SerializeField] private EnemyStatsPanelUI enemyPanel;
         [SerializeField] private TaskStatsPanelUI taskPanel;
         [SerializeField] private ItemStatsPanelUI itemPanel;
 
-        private readonly List<StatSortButton> buttons = new();
+        [Serializable]
+        private struct EnemyButton
+        {
+            public EnemyStatsPanelUI.SortMode mode;
+            public StatSortButton button;
+        }
+
+        [Serializable]
+        private struct TaskButton
+        {
+            public TaskStatsPanelUI.SortMode mode;
+            public StatSortButton button;
+        }
+
+        [Serializable]
+        private struct ItemButton
+        {
+            public ItemStatsPanelUI.SortMode mode;
+            public StatSortButton button;
+        }
+
+        [SerializeField] private List<EnemyButton> enemyButtons = new();
+        [SerializeField] private List<TaskButton> taskButtons = new();
+        [SerializeField] private List<ItemButton> itemButtons = new();
+
         private readonly Dictionary<StatSortButton, Enum> buttonModes = new();
+        private readonly Dictionary<StatSortButton, UnityAction> buttonActions = new();
 
         private int currentTab = -1;
         private EnemyStatsPanelUI.SortMode enemyMode = EnemyStatsPanelUI.SortMode.Default;
         private TaskStatsPanelUI.SortMode taskMode = TaskStatsPanelUI.SortMode.Default;
         private ItemStatsPanelUI.SortMode itemMode = ItemStatsPanelUI.SortMode.Default;
+
+        private void Awake()
+        {
+            SetupEnemyButtons();
+            SetupTaskButtons();
+            SetupItemButtons();
+            HideAllButtons();
+        }
+
+        private void OnDestroy()
+        {
+            foreach (var pair in buttonActions)
+                if (pair.Key != null)
+                    pair.Key.Button.onClick.RemoveListener(pair.Value);
+        }
 
         private void Update()
         {
@@ -37,88 +75,107 @@ namespace TimelessEchoes.UI
 
         private int GetActiveTab()
         {
+            if (generalPanel != null && generalPanel.gameObject.activeInHierarchy) return 0;
             if (enemyPanel != null && enemyPanel.gameObject.activeInHierarchy) return 1;
             if (taskPanel != null && taskPanel.gameObject.activeInHierarchy) return 2;
             if (itemPanel != null && itemPanel.gameObject.activeInHierarchy) return 3;
-            return 0;
+            return -1;
         }
 
         private void BuildButtons()
         {
-            ClearButtons();
+            HideAllButtons();
             switch (currentTab)
             {
                 case 1:
-                    BuildEnemyButtons();
+                    ShowButtons(enemyButtons);
                     break;
                 case 2:
-                    BuildTaskButtons();
+                    ShowButtons(taskButtons);
                     break;
                 case 3:
-                    BuildItemButtons();
+                    ShowButtons(itemButtons);
                     break;
+            }
+            UpdateButtonStates();
+        }
+
+        private void HideAllButtons()
+        {
+            foreach (var pair in buttonModes)
+                if (pair.Key != null)
+                    pair.Key.gameObject.SetActive(false);
+        }
+
+        private void SetupEnemyButtons()
+        {
+            foreach (var entry in enemyButtons)
+            {
+                if (entry.button == null) continue;
+                entry.button.SetLabel(entry.mode.ToString());
+                UnityAction action = () =>
+                {
+                    enemyMode = entry.mode;
+                    if (enemyPanel != null) enemyPanel.SetSortMode(entry.mode);
+                    UpdateButtonStates();
+                };
+                entry.button.Button.onClick.AddListener(action);
+                buttonModes[entry.button] = entry.mode;
+                buttonActions[entry.button] = action;
             }
         }
 
-        private void ClearButtons()
+        private void SetupTaskButtons()
         {
-            foreach (var b in buttons)
-                if (b != null)
-                    Destroy(b.gameObject);
-            buttons.Clear();
-            buttonModes.Clear();
-        }
-
-        private void BuildEnemyButtons()
-        {
-            foreach (EnemyStatsPanelUI.SortMode mode in Enum.GetValues(typeof(EnemyStatsPanelUI.SortMode)))
-                CreateButton(mode, () =>
+            foreach (var entry in taskButtons)
+            {
+                if (entry.button == null) continue;
+                entry.button.SetLabel(entry.mode.ToString());
+                UnityAction action = () =>
                 {
-                    enemyMode = mode;
-                    if (enemyPanel != null) enemyPanel.SetSortMode(mode);
+                    taskMode = entry.mode;
+                    if (taskPanel != null) taskPanel.SetSortMode(entry.mode);
                     UpdateButtonStates();
-                });
-            UpdateButtonStates();
+                };
+                entry.button.Button.onClick.AddListener(action);
+                buttonModes[entry.button] = entry.mode;
+                buttonActions[entry.button] = action;
+            }
         }
 
-        private void BuildTaskButtons()
+        private void SetupItemButtons()
         {
-            foreach (TaskStatsPanelUI.SortMode mode in Enum.GetValues(typeof(TaskStatsPanelUI.SortMode)))
-                CreateButton(mode, () =>
+            foreach (var entry in itemButtons)
+            {
+                if (entry.button == null) continue;
+                entry.button.SetLabel(entry.mode.ToString());
+                UnityAction action = () =>
                 {
-                    taskMode = mode;
-                    if (taskPanel != null) taskPanel.SetSortMode(mode);
+                    itemMode = entry.mode;
+                    if (itemPanel != null) itemPanel.SetSortMode(entry.mode);
                     UpdateButtonStates();
-                });
-            UpdateButtonStates();
+                };
+                entry.button.Button.onClick.AddListener(action);
+                buttonModes[entry.button] = entry.mode;
+                buttonActions[entry.button] = action;
+            }
         }
 
-        private void BuildItemButtons()
+        private void ShowButtons<T>(IEnumerable<T> list) where T : struct
         {
-            foreach (ItemStatsPanelUI.SortMode mode in Enum.GetValues(typeof(ItemStatsPanelUI.SortMode)))
-                CreateButton(mode, () =>
-                {
-                    itemMode = mode;
-                    if (itemPanel != null) itemPanel.SetSortMode(mode);
-                    UpdateButtonStates();
-                });
-            UpdateButtonStates();
-        }
-
-        private void CreateButton(Enum mode, UnityAction action)
-        {
-            if (buttonParent == null || buttonPrefab == null) return;
-
-            var btn = Instantiate(buttonPrefab, buttonParent);
-            btn.SetLabel(mode.ToString());
-            btn.Button.onClick.AddListener(action);
-            buttons.Add(btn);
-            buttonModes[btn] = mode;
+            foreach (var entry in list)
+            {
+                StatSortButton btn = default;
+                if (entry is EnemyButton e) btn = e.button;
+                else if (entry is TaskButton t) btn = t.button;
+                else if (entry is ItemButton i) btn = i.button;
+                if (btn != null) btn.gameObject.SetActive(true);
+            }
         }
 
         private void UpdateButtonStates()
         {
-            if (buttons.Count == 0) return;
+            if (buttonModes.Count == 0) return;
 
             Enum selected = null;
             switch (currentTab)
@@ -136,7 +193,8 @@ namespace TimelessEchoes.UI
             if (selected == null) return;
 
             foreach (var pair in buttonModes)
-                pair.Key.SetInteractable(!Equals(pair.Value, selected));
+                if (pair.Key != null && pair.Key.gameObject.activeSelf)
+                    pair.Key.SetInteractable(!Equals(pair.Value, selected));
         }
     }
 }


### PR DESCRIPTION
## Summary
- refactor `StatSortingManager` to rely on button references instead of instantiating them
- support General tab by hiding all sort buttons when active
- add cleanup of button listeners

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865204bc5cc832e936c1afe838caef5