### PR TITLE
Fix cost slot prefab reference

### DIFF
--- a/Assets/Scripts/Upgrades/StatUpgradeUIManager.cs
+++ b/Assets/Scripts/Upgrades/StatUpgradeUIManager.cs
@@ -98,7 +98,7 @@ namespace TimelessEchoes.Upgrades
                 var refs = statReferences[i];
                 var list = new List<CostResourceUIReferences>();
                 var parent = refs.costGridLayoutParent;
-                var prefab = refs.costSlotPrefab != null ? refs.costSlotPrefab : costSlotPrefab;
+                var prefab = costSlotPrefab;
 
                 if (parent != null && prefab != null)
                 {


### PR DESCRIPTION
## Summary
- fix prefab selection logic in `StatUpgradeUIManager`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686af64a4f68832eb61ab12e6126c71f