### PR TITLE
Add fish regen donation system

### DIFF
--- a/Assets/Scripts/Blindsided/Oracle.cs
+++ b/Assets/Scripts/Blindsided/Oracle.cs
@@ -209,6 +209,7 @@ namespace Blindsided
             saveData.CompletedNpcTasks ??= new HashSet<string>();
             saveData.ActiveBuffs ??= new Dictionary<string, float>();
             saveData.Quests ??= new Dictionary<string, GameData.QuestRecord>();
+            saveData.FishDonations ??= new Dictionary<string, double>();
         }
 
         public static void AwayForSeconds()

--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -24,6 +24,7 @@ namespace Blindsided.SaveData
         [HideReferenceObjectPicker] public Dictionary<string, ResourceEntry> Resources = new();
         [HideReferenceObjectPicker] public Dictionary<string, double> EnemyKills = new();
         [HideReferenceObjectPicker] public Dictionary<string, float> ActiveBuffs = new();
+        [HideReferenceObjectPicker] public Dictionary<string, double> FishDonations = new();
 
         [HideReferenceObjectPicker]
         public HashSet<string> CompletedNpcTasks = new();

--- a/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
+++ b/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
@@ -11,6 +11,7 @@ namespace Blindsided.SaveData
         public static Dictionary<string, ResourceEntry> Resources => oracle.saveData.Resources;
         public static Dictionary<string, double> EnemyKills => oracle.saveData.EnemyKills;
         public static HashSet<string> CompletedNpcTasks => oracle.saveData.CompletedNpcTasks;
+        public static Dictionary<string, double> FishDonations => oracle.saveData.FishDonations;
 
 
         public static BuyMode PurchaseMode

--- a/Assets/Scripts/Enemies/Health.cs
+++ b/Assets/Scripts/Enemies/Health.cs
@@ -55,6 +55,13 @@ namespace TimelessEchoes.Enemies
             }
         }
 
+        public void Heal(float amount)
+        {
+            if (amount <= 0f || CurrentHealth >= MaxHealth) return;
+            CurrentHealth = Mathf.Min(CurrentHealth + amount, MaxHealth);
+            UpdateBar();
+        }
+
         public float CurrentHealth { get; private set; }
         public float MaxHealth => maxHealth;
 

--- a/Assets/Scripts/Regen/RegenManager.cs
+++ b/Assets/Scripts/Regen/RegenManager.cs
@@ -1,0 +1,208 @@
+using System.Collections.Generic;
+using References.UI;
+using TimelessEchoes.Upgrades;
+using TimelessEchoes.Hero;
+using TimelessEchoes.Enemies;
+using UnityEngine;
+using static Blindsided.EventHandler;
+using static Blindsided.Oracle;
+
+namespace TimelessEchoes.Regen
+{
+    /// <summary>
+    ///     Handles fish donations and applies health regeneration to the hero.
+    /// </summary>
+    public class RegenManager : MonoBehaviour
+    {
+        [SerializeField] private ResourceManager resourceManager;
+        [SerializeField] private ResourceInventoryUI inventoryUI;
+        [SerializeField] private List<Resource> fishResources = new();
+        [SerializeField] private RegenEntryUIReferences entryPrefab;
+        [SerializeField] private Transform entryParent;
+
+        private readonly Dictionary<Resource, double> donations = new();
+        private readonly List<RegenEntryUIReferences> entries = new();
+        private Health heroHealth;
+
+        private void Awake()
+        {
+            if (resourceManager == null)
+                resourceManager = FindFirstObjectByType<ResourceManager>();
+            if (inventoryUI == null)
+                inventoryUI = FindFirstObjectByType<ResourceInventoryUI>();
+            heroHealth = FindFirstObjectByType<HeroController>()?.GetComponent<Health>();
+
+            LoadState();
+            BuildEntries();
+            UpdateAllEntries();
+
+            OnSaveData += SaveState;
+            OnLoadData += LoadState;
+            if (resourceManager != null)
+                resourceManager.OnInventoryChanged += UpdateAllEntries;
+        }
+
+        private void OnDestroy()
+        {
+            OnSaveData -= SaveState;
+            OnLoadData -= LoadState;
+            if (resourceManager != null)
+                resourceManager.OnInventoryChanged -= UpdateAllEntries;
+        }
+
+        private void Update()
+        {
+            if (heroHealth == null)
+                return;
+            float regen = (float)GetTotalRegen();
+            if (regen > 0f && heroHealth.CurrentHealth < heroHealth.MaxHealth)
+                heroHealth.Heal(regen * Time.deltaTime);
+        }
+
+        private void BuildEntries()
+        {
+            if (entryPrefab == null || entryParent == null)
+                return;
+
+            foreach (Transform child in entryParent)
+                Destroy(child.gameObject);
+            entries.Clear();
+
+            foreach (var res in fishResources)
+            {
+                if (res == null) continue;
+                var entry = Instantiate(entryPrefab, entryParent);
+                entry.costResourceUIReferences.resource = res;
+                if (entry.costResourceUIReferences.selectButton != null)
+                {
+                    var r = res;
+                    entry.costResourceUIReferences.selectButton.onClick.RemoveAllListeners();
+                    entry.costResourceUIReferences.selectButton.onClick.AddListener(() => inventoryUI?.HighlightResource(r));
+                }
+                if (entry.donate10PercentButton != null)
+                {
+                    var r = res;
+                    entry.donate10PercentButton.onClick.AddListener(() => DonatePercentage(r, 0.1f));
+                }
+                if (entry.donateAllButton != null)
+                {
+                    var r = res;
+                    entry.donateAllButton.onClick.AddListener(() => DonateAll(r));
+                }
+                entries.Add(entry);
+            }
+        }
+
+        private void UpdateAllEntries()
+        {
+            for (int i = 0; i < entries.Count && i < fishResources.Count; i++)
+                UpdateEntry(i);
+        }
+
+        private void UpdateEntry(int index)
+        {
+            if (index < 0 || index >= entries.Count || index >= fishResources.Count)
+                return;
+
+            var entry = entries[index];
+            var res = fishResources[index];
+            if (entry == null || res == null) return;
+
+            bool unlocked = resourceManager && resourceManager.IsUnlocked(res);
+            double playerAmt = resourceManager ? resourceManager.GetAmount(res) : 0;
+            double donated = donations.TryGetValue(res, out var val) ? val : 0;
+
+            var costRefs = entry.costResourceUIReferences;
+            if (costRefs.iconImage != null)
+            {
+                costRefs.iconImage.sprite = res.icon;
+                costRefs.iconImage.enabled = unlocked;
+            }
+            if (costRefs.questionMarkImage != null)
+                costRefs.questionMarkImage.enabled = !unlocked;
+            if (costRefs.countText != null)
+                costRefs.countText.text = unlocked ? Mathf.FloorToInt((float)playerAmt).ToString() : string.Empty;
+
+            if (entry.fishNameText != null)
+                entry.fishNameText.text = unlocked ? res.name : "???";
+
+            if (entry.amountDonatedText != null)
+                entry.amountDonatedText.text = Mathf.FloorToInt((float)donated).ToString();
+
+            if (entry.regenText != null)
+                entry.regenText.text = $"Granting {GetRegenFor(res):0.###} Regen";
+
+            bool canDonate = playerAmt > 0;
+            if (entry.donateAllButton != null)
+                entry.donateAllButton.interactable = canDonate;
+            if (entry.donate10PercentButton != null)
+                entry.donate10PercentButton.interactable = playerAmt > 10;
+        }
+
+        private void DonatePercentage(Resource res, float pct)
+        {
+            if (resourceManager == null || res == null) return;
+            double amount = Mathf.Floor((float)(resourceManager.GetAmount(res) * pct));
+            if (amount <= 0) return;
+            resourceManager.Spend(res, amount);
+            AddDonation(res, amount);
+            UpdateAllEntries();
+        }
+
+        private void DonateAll(Resource res)
+        {
+            if (resourceManager == null || res == null) return;
+            double amount = resourceManager.GetAmount(res);
+            if (amount <= 0) return;
+            resourceManager.Spend(res, amount);
+            AddDonation(res, amount);
+            UpdateAllEntries();
+        }
+
+        private void AddDonation(Resource res, double amount)
+        {
+            if (donations.ContainsKey(res))
+                donations[res] += amount;
+            else
+                donations[res] = amount;
+        }
+
+        private double GetRegenFor(Resource res)
+        {
+            if (!donations.TryGetValue(res, out var val) || val <= 0)
+                return 0;
+            return Mathf.Log10((float)val) / 10f;
+        }
+
+        public double GetTotalRegen()
+        {
+            double sum = 0;
+            foreach (var pair in donations)
+                sum += GetRegenFor(pair.Key);
+            return sum;
+        }
+
+        private void SaveState()
+        {
+            if (oracle == null) return;
+            oracle.saveData.FishDonations ??= new Dictionary<string, double>();
+            oracle.saveData.FishDonations.Clear();
+            foreach (var pair in donations)
+                if (pair.Key != null)
+                    oracle.saveData.FishDonations[pair.Key.name] = pair.Value;
+        }
+
+        private void LoadState()
+        {
+            if (oracle == null) return;
+            oracle.saveData.FishDonations ??= new Dictionary<string, double>();
+            donations.Clear();
+            foreach (var res in fishResources)
+            {
+                if (res == null) continue;
+                oracle.saveData.FishDonations.TryGetValue(res.name, out var val);
+                donations[res] = val;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add persistent fish donation data
- expose donation data through StaticReferences
- ensure save data initializes new dictionary
- allow Health component to heal
- implement `RegenManager` to manage fish donations and regen

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_686b9b1786d0832eb76a65c56a0dc462