### PR TITLE
Adjust middle run number display

### DIFF
--- a/Assets/Scripts/UI/RunStatsPanelUI.cs
+++ b/Assets/Scripts/UI/RunStatsPanelUI.cs
@@ -160,7 +160,10 @@ namespace TimelessEchoes.UI
                 if (middleRunNumberText != null)
                 {
                     var middleNumber = Mathf.FloorToInt((oldestNumber + newestNumber) * 0.5f) + 1;
-                    middleRunNumberText.text = middleNumber.ToString();
+                    if (newestNumber >= 50)
+                        middleRunNumberText.text = middleNumber.ToString();
+                    else
+                        middleRunNumberText.text = string.Empty;
                 }
 
                 if (mostRecentRunNumberText != null)


### PR DESCRIPTION
## Summary
- hide middle run count when fewer than 50 runs completed

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686ba859339c832e8c56d070627105e8