### PR TITLE
Fix regen UI not refreshing on load

### DIFF
--- a/Assets/Scripts/Regen/RegenManager.cs
+++ b/Assets/Scripts/Regen/RegenManager.cs
@@ -203,6 +203,7 @@ namespace TimelessEchoes.Regen
                 oracle.saveData.FishDonations.TryGetValue(res.name, out var val);
                 donations[res] = val;
             }
+            UpdateAllEntries();
         }
     }
 }


### PR DESCRIPTION
## Summary
- refresh regen UI after loading saved fish donations

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686c5b2240b8832eab573413368fa5ca