### PR TITLE
Add skill selection toggle via button

### DIFF
--- a/Assets/Scripts/Skills/SkillUIManager.cs
+++ b/Assets/Scripts/Skills/SkillUIManager.cs
@@ -16,6 +16,7 @@ namespace TimelessEchoes.Skills
         [SerializeField] private SkillController controller;
         [SerializeField] private List<SkillUIReferences> skillSelectors = new();
         [SerializeField] private List<Skill> skills = new();
+        [SerializeField] private Button firstSkillButton;
         [SerializeField] private TMP_Text skillTitle;
         [SerializeField] private TMP_Text levelText;
         [SerializeField] private TMP_Text experienceText;
@@ -23,6 +24,7 @@ namespace TimelessEchoes.Skills
         [SerializeField] private MilestoneBonusUI bonusUI;
 
         private int selectedIndex = -1;
+        private int previousSelectedIndex = -1;
 
         private Skill CurrentSkill => selectedIndex >= 0 && selectedIndex < skills.Count ? skills[selectedIndex] : null;
 
@@ -54,10 +56,10 @@ namespace TimelessEchoes.Skills
 
             if (bonusUI != null && !bonusUI.gameObject.activeSelf)
                 bonusUI.gameObject.SetActive(true);
+            if (firstSkillButton != null)
+                firstSkillButton.onClick.AddListener(ToggleFirstSkill);
             DeselectSkill();
             UpdateSkillSelectorLevels();
-            if (skills.Count > 0)
-                SelectSkill(0);
         }
 
         private void OnEnable()
@@ -70,17 +72,10 @@ namespace TimelessEchoes.Skills
             ShowLevelTextChanged += OnShowLevelTextChanged;
             OnLoadData += OnLoadDataHandler;
             OnShowLevelTextChanged();
-            if (selectedIndex < 0)
-            {
-                if (skills.Count > 0)
-                    SelectSkill(0);
-                else
-                    DeselectSkill();
-            }
-            else
-            {
+            if (selectedIndex >= 0)
                 UpdateSelectedSkillUI();
-            }
+            else
+                DeselectSkill();
             UpdateSkillSelectorLevels();
         }
 
@@ -117,6 +112,8 @@ namespace TimelessEchoes.Skills
 
         private void SelectSkill(int index)
         {
+            if (selectedIndex != index)
+                previousSelectedIndex = selectedIndex;
             selectedIndex = Mathf.Clamp(index, 0, skillSelectors.Count - 1);
             for (int i = 0; i < skillSelectors.Count; i++)
                 if (skillSelectors[i] != null)
@@ -181,13 +178,6 @@ namespace TimelessEchoes.Skills
             }
         }
 
-        private void Update()
-        {
-            if (Input.GetMouseButtonDown(1))
-            {
-                DeselectSkill();
-            }
-        }
 
         private void OnShowLevelTextChanged()
         {
@@ -205,6 +195,22 @@ namespace TimelessEchoes.Skills
         {
             yield return null;
             OnShowLevelTextChanged();
+        }
+
+        private void ToggleFirstSkill()
+        {
+            if (skills.Count == 0)
+                return;
+
+            if (selectedIndex != 0)
+            {
+                previousSelectedIndex = selectedIndex;
+                SelectSkill(0);
+            }
+            else if (previousSelectedIndex >= 0 && previousSelectedIndex < skills.Count)
+            {
+                SelectSkill(previousSelectedIndex);
+            }
         }
 
         private void DeselectSkill()


### PR DESCRIPTION
## Summary
- add optional button to toggle selecting the first skill
- stop auto-selecting the first skill on enable
- remember and restore previously selected skill
- remove right-click deselect behaviour

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686cdc9e86b4832e9cb43a47488bb566