### PR TITLE
Add basic Steam achievement support

### DIFF
--- a/Assets/Scripts/Quests/QuestManager.cs
+++ b/Assets/Scripts/Quests/QuestManager.cs
@@ -187,6 +187,8 @@ namespace TimelessEchoes.Quests
                 if (q.npcId == id)
                     TryStartQuest(q);
             }
+            var achievementManager = AchievementManager.Instance;
+            achievementManager?.NotifyNpcMet(id);
             RefreshNoticeboard();
         }
 

--- a/Assets/Scripts/Steamworks.NET/AchievementManager.cs
+++ b/Assets/Scripts/Steamworks.NET/AchievementManager.cs
@@ -1,0 +1,71 @@
+#if !(UNITY_STANDALONE_WIN || UNITY_STANDALONE_LINUX || UNITY_STANDALONE_OSX || STEAMWORKS_WIN || STEAMWORKS_LIN_OSX)
+#define DISABLESTEAMWORKS
+#endif
+
+using UnityEngine;
+#if !DISABLESTEAMWORKS
+using Steamworks;
+#endif
+
+namespace TimelessEchoes
+{
+    /// <summary>
+    /// Handles unlocking Steam achievements.
+    /// </summary>
+    public class AchievementManager : MonoBehaviour
+    {
+#if !DISABLESTEAMWORKS
+        private static AchievementManager instance;
+        public static AchievementManager Instance
+        {
+            get
+            {
+                if (instance == null)
+                {
+                    instance = FindFirstObjectByType<AchievementManager>();
+                    if (instance == null)
+                    {
+                        instance = new GameObject("AchievementManager").AddComponent<AchievementManager>();
+                    }
+                }
+                return instance;
+            }
+        }
+
+        private void Awake()
+        {
+            if (instance != null && instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+            instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+
+        private void UnlockAchievement(string apiName)
+        {
+            if (!SteamManager.Initialized)
+                return;
+
+            if (SteamUserStats.SetAchievement(apiName))
+            {
+                SteamUserStats.StoreStats();
+            }
+        }
+
+        /// <summary>
+        /// Called when an NPC is met.
+        /// </summary>
+        public void NotifyNpcMet(string npcId)
+        {
+            if (npcId == "Ivan1")
+            {
+                UnlockAchievement("MeetIvan");
+            }
+        }
+#else
+        public static AchievementManager Instance => null;
+#endif
+    }
+}

--- a/README.md
+++ b/README.md
@@ -54,5 +54,10 @@ optional rotation.
 ## Building
 Use **File > Build Settings...** to create standalone builds.
 
+## Steam Achievements
+Achievements are managed through the `AchievementManager` component which uses
+Steamworks.NET. Meeting the NPC with id `Ivan1` awards the `MeetIvan` Steam
+achievement.
+
 ## Development Guidelines
 Refer to [Unity's official documentation](https://docs.unity3d.com) and ensure all changes work with **Unity 6000.1.6f1**.


### PR DESCRIPTION
## Summary
- add `AchievementManager` for Steamworks.NET
- unlock `MeetIvan` Steam achievement when NPC `Ivan1` is met
- document Steam achievements in the README

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_686cf8d9866c832e8f82b13a68e1d658