### PR TITLE
Integrate Steam Cloud save

### DIFF
--- a/Assets/Scripts/Blindsided/Oracle.cs
+++ b/Assets/Scripts/Blindsided/Oracle.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
 using Blindsided.SaveData;
+using TimelessEchoes;
 using Sirenix.OdinInspector;
 using Sirenix.Serialization;
 using UnityEngine;
@@ -36,6 +37,7 @@ namespace Blindsided
             {
                 bufferSize = 8192
             };
+            SteamCloudManager.DownloadFile(_fileName); // ensure local cache is up-to-date
             ES3.CacheFile(_fileName); // pull existing save into RAM
         }
 
@@ -161,6 +163,7 @@ namespace Blindsided
         private void FlushToDisk()
         {
             ES3.StoreCachedFile(_fileName); // RAM ➜ file
+            SteamCloudManager.UploadFile(_fileName); // push to Steam Cloud
             _lastFlush = Time.unscaledTime;
         }
 

--- a/Assets/Scripts/Steamworks.NET/SteamCloudManager.cs
+++ b/Assets/Scripts/Steamworks.NET/SteamCloudManager.cs
@@ -1,0 +1,58 @@
+#if !(UNITY_STANDALONE_WIN || UNITY_STANDALONE_LINUX || UNITY_STANDALONE_OSX || STEAMWORKS_WIN || STEAMWORKS_LIN_OSX)
+#define DISABLESTEAMWORKS
+#endif
+
+using System.IO;
+using UnityEngine;
+#if !DISABLESTEAMWORKS
+using Steamworks;
+#endif
+
+namespace TimelessEchoes
+{
+    /// <summary>
+    /// Utility methods for syncing save files with Steam Cloud.
+    /// </summary>
+    public static class SteamCloudManager
+    {
+#if !DISABLESTEAMWORKS
+        /// <summary>
+        /// Uploads a local file to Steam Cloud if Steam is initialized.
+        /// </summary>
+        public static void UploadFile(string fileName)
+        {
+            if (!SteamManager.Initialized)
+                return;
+
+            var path = Path.Combine(Application.persistentDataPath, fileName);
+            if (!File.Exists(path))
+                return;
+
+            var data = File.ReadAllBytes(path);
+            SteamRemoteStorage.FileWrite(fileName, data, data.Length);
+        }
+
+        /// <summary>
+        /// Downloads a file from Steam Cloud if available. Returns true when a file was retrieved.
+        /// </summary>
+        public static bool DownloadFile(string fileName)
+        {
+            if (!SteamManager.Initialized)
+                return false;
+
+            if (!SteamRemoteStorage.FileExists(fileName))
+                return false;
+
+            var size = SteamRemoteStorage.GetFileSize(fileName);
+            var buffer = new byte[size];
+            var read = SteamRemoteStorage.FileRead(fileName, buffer, size);
+            if (read != size)
+                return false;
+
+            var path = Path.Combine(Application.persistentDataPath, fileName);
+            File.WriteAllBytes(path, buffer);
+            return true;
+        }
+#endif
+    }
+}


### PR DESCRIPTION
## Summary
- add `SteamCloudManager` for reading/writing save data through `SteamRemoteStorage`
- sync with Steam Cloud when creating the cache and when flushing to disk

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686dc2bec0d4832eb19cac7e3b0a27f4