### PR TITLE
Fix task progress reset on combat

### DIFF
--- a/Assets/Scripts/Tasks/TaskController.cs
+++ b/Assets/Scripts/Tasks/TaskController.cs
@@ -282,10 +282,22 @@ namespace TimelessEchoes.Tasks
                     currentTaskObject = obj;
                 else if (task is MonoBehaviour mb)
                     currentTaskObject = mb;
-                Log($"Starting task: {currentTaskName}", TELogCategory.Task, this);
                 hero?.SetTask(task);
-                task.StartTask();
-                taskStartTimes[task] = Time.time;
+                bool restart = false;
+                if (task is BaseTask baseTask && baseTask.taskData != null)
+                    restart = baseTask.taskData.resetProgressOnInterrupt;
+
+                if (!taskStartTimes.ContainsKey(task) || restart)
+                {
+                    var msg = taskStartTimes.ContainsKey(task) ? "Restarting" : "Starting";
+                    Log($"{msg} task: {currentTaskName}", TELogCategory.Task, this);
+                    task.StartTask();
+                    taskStartTimes[task] = Time.time;
+                }
+                else
+                {
+                    Log($"Resuming task: {currentTaskName}", TELogCategory.Task, this);
+                }
                 return;
             }
 

--- a/Assets/Scripts/Tasks/TaskData.cs
+++ b/Assets/Scripts/Tasks/TaskData.cs
@@ -18,6 +18,9 @@ namespace TimelessEchoes.Tasks
         public float taskDuration;
         public List<ResourceDrop> resourceDrops = new();
 
+        [Tooltip("Restart task progress when returning after an interrupt.")]
+        public bool resetProgressOnInterrupt;
+
         [System.Serializable]
         public class Persistent
         {


### PR DESCRIPTION
## Summary
- keep tasks from restarting when the hero exits combat
- add optional `resetProgressOnInterrupt` field to `TaskData`
- respect that setting in `TaskController`

## Testing
- `grep -R "TODO" -n | head`
- `ls Assets/Scripts/Tests/Editor`


------
https://chatgpt.com/codex/tasks/task_e_686e0a0633b4832eb016e017a7629401