### PR TITLE
Add audio system with volume preferences

### DIFF
--- a/Assets/Scripts/Audio/AudioManager.cs
+++ b/Assets/Scripts/Audio/AudioManager.cs
@@ -1,0 +1,136 @@
+using UnityEngine;
+using UnityEngine.Audio;
+using Blindsided.SaveData;
+
+namespace TimelessEchoes.Audio
+{
+    public class AudioManager : MonoBehaviour
+    {
+        public static AudioManager Instance { get; private set; }
+
+        [Header("Mixers")] [SerializeField] private AudioMixer mainMixer;
+        [SerializeField] private AudioMixerGroup musicGroup;
+        [SerializeField] private AudioMixerGroup sfxGroup;
+        [SerializeField] private AudioMixerGroup ambianceGroup;
+
+        [Header("Music")] [SerializeField] private AudioSource musicSource;
+        [SerializeField] private AudioClip musicClip;
+
+        [Header("Task Clips")] [SerializeField] private AudioClip[] woodcuttingClips;
+        [SerializeField] private AudioClip[] farmingClips;
+        [SerializeField] private AudioClip[] fishingClips;
+        [SerializeField] private AudioClip[] miningClips;
+
+        [Header("Combat Clips")] [SerializeField] private AudioClip[] slimeClips;
+
+        public enum TaskType
+        {
+            Woodcutting,
+            Farming,
+            Fishing,
+            Mining
+        }
+
+        private void Awake()
+        {
+            if (Instance == null)
+            {
+                Instance = this;
+                DontDestroyOnLoad(gameObject);
+            }
+            else
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            if (musicClip != null && musicSource != null)
+            {
+                musicSource.clip = musicClip;
+                musicSource.loop = true;
+                musicSource.outputAudioMixerGroup = musicGroup;
+                musicSource.Play();
+            }
+
+            ApplyVolumes();
+        }
+
+        public void ApplyVolumes()
+        {
+            if (mainMixer == null) return;
+            mainMixer.SetFloat("MasterVolume", LinearToDecibel(StaticReferences.MasterVolume));
+            mainMixer.SetFloat("MusicVolume", LinearToDecibel(StaticReferences.MusicVolume));
+            mainMixer.SetFloat("SfxVolume", LinearToDecibel(StaticReferences.SfxVolume));
+        }
+
+        public void SetMasterVolume(float value)
+        {
+            StaticReferences.MasterVolume = value;
+            if (mainMixer != null)
+                mainMixer.SetFloat("MasterVolume", LinearToDecibel(value));
+        }
+
+        public void SetMusicVolume(float value)
+        {
+            StaticReferences.MusicVolume = value;
+            if (mainMixer != null)
+                mainMixer.SetFloat("MusicVolume", LinearToDecibel(value));
+        }
+
+        public void SetSfxVolume(float value)
+        {
+            StaticReferences.SfxVolume = value;
+            if (mainMixer != null)
+                mainMixer.SetFloat("SfxVolume", LinearToDecibel(value));
+        }
+
+        public void PlayTaskClip(TaskType type)
+        {
+            AudioClip clip = null;
+            switch (type)
+            {
+                case TaskType.Woodcutting:
+                    clip = GetRandom(woodcuttingClips);
+                    break;
+                case TaskType.Farming:
+                    clip = GetRandom(farmingClips);
+                    break;
+                case TaskType.Fishing:
+                    clip = GetRandom(fishingClips);
+                    break;
+                case TaskType.Mining:
+                    clip = GetRandom(miningClips);
+                    break;
+            }
+            PlaySfx(clip);
+        }
+
+        public void PlayCombatClip(AudioClip[] clips)
+        {
+            PlaySfx(GetRandom(clips));
+        }
+
+        public void PlaySlimeClip()
+        {
+            PlayCombatClip(slimeClips);
+        }
+
+        private void PlaySfx(AudioClip clip)
+        {
+            if (clip == null) return;
+            AudioSource.PlayClipAtPoint(clip, Vector3.zero, StaticReferences.SfxVolume);
+        }
+
+        private static AudioClip GetRandom(AudioClip[] clips)
+        {
+            if (clips == null || clips.Length == 0) return null;
+            return clips[Random.Range(0, clips.Length)];
+        }
+
+        private static float LinearToDecibel(float value)
+        {
+            float v = Mathf.Clamp(value, 0.0001f, 1f);
+            return Mathf.Log10(v) * 20f;
+        }
+    }
+}

--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -75,6 +75,9 @@ namespace Blindsided.SaveData
             public bool TransparentUi;
             public bool Tutorial;
             public bool UseScaledTimeForValues;
+            public float MasterVolume = 1f;
+            public float MusicVolume = 1f;
+            public float SfxVolume = 1f;
         }
 
         [HideReferenceObjectPicker]

--- a/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
+++ b/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
@@ -86,6 +86,24 @@ namespace Blindsided.SaveData
             set => oracle.saveData.SavedPreferences.UseScaledTimeForValues = value;
         }
 
+        public static float MasterVolume
+        {
+            get => oracle.saveData.SavedPreferences.MasterVolume;
+            set => oracle.saveData.SavedPreferences.MasterVolume = value;
+        }
+
+        public static float MusicVolume
+        {
+            get => oracle.saveData.SavedPreferences.MusicVolume;
+            set => oracle.saveData.SavedPreferences.MusicVolume = value;
+        }
+
+        public static float SfxVolume
+        {
+            get => oracle.saveData.SavedPreferences.SfxVolume;
+            set => oracle.saveData.SavedPreferences.SfxVolume = value;
+        }
+
         public static bool ShowLevelText
         {
             get => oracle.saveData.SavedPreferences.ShowLevelText;
@@ -103,5 +121,4 @@ namespace Blindsided.SaveData
         public static Preferences SavedPreferences => oracle.saveData.SavedPreferences;
         public static Dictionary<string, bool> Foldouts => oracle.saveData.SavedPreferences.Foldouts;
         public static event Action ShowLevelTextChanged;
-    }
-}
+    }}

--- a/Assets/Scripts/UI/AudioSettingsUI.cs
+++ b/Assets/Scripts/UI/AudioSettingsUI.cs
@@ -1,0 +1,70 @@
+using UnityEngine;
+using UnityEngine.UI;
+using Blindsided.SaveData;
+using TimelessEchoes.Audio;
+
+namespace TimelessEchoes.UI
+{
+    public class AudioSettingsUI : MonoBehaviour
+    {
+        [SerializeField] private Slider masterSlider;
+        [SerializeField] private Slider musicSlider;
+        [SerializeField] private Slider sfxSlider;
+
+        private AudioManager audioManager;
+
+        private void Awake()
+        {
+            audioManager = Object.FindFirstObjectByType<AudioManager>();
+        }
+
+        private void OnEnable()
+        {
+            if (masterSlider != null)
+            {
+                masterSlider.value = StaticReferences.MasterVolume;
+                masterSlider.onValueChanged.AddListener(OnMasterChanged);
+            }
+
+            if (musicSlider != null)
+            {
+                musicSlider.value = StaticReferences.MusicVolume;
+                musicSlider.onValueChanged.AddListener(OnMusicChanged);
+            }
+
+            if (sfxSlider != null)
+            {
+                sfxSlider.value = StaticReferences.SfxVolume;
+                sfxSlider.onValueChanged.AddListener(OnSfxChanged);
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (masterSlider != null)
+                masterSlider.onValueChanged.RemoveListener(OnMasterChanged);
+            if (musicSlider != null)
+                musicSlider.onValueChanged.RemoveListener(OnMusicChanged);
+            if (sfxSlider != null)
+                sfxSlider.onValueChanged.RemoveListener(OnSfxChanged);
+        }
+
+        private void OnMasterChanged(float value)
+        {
+            StaticReferences.MasterVolume = value;
+            audioManager?.SetMasterVolume(value);
+        }
+
+        private void OnMusicChanged(float value)
+        {
+            StaticReferences.MusicVolume = value;
+            audioManager?.SetMusicVolume(value);
+        }
+
+        private void OnSfxChanged(float value)
+        {
+            StaticReferences.SfxVolume = value;
+            audioManager?.SetSfxVolume(value);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- persist master, music and sfx volume in preferences
- expose new volume values via `StaticReferences`
- implement `AudioManager` to manage mixer volumes and play clips
- add `AudioSettingsUI` for slider controls

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e24b5dc7c832ea52656aba2111011