### PR TITLE
Play audio when hero starts resource tasks

### DIFF
--- a/Assets/Scripts/Tasks/ContinuousTask.cs
+++ b/Assets/Scripts/Tasks/ContinuousTask.cs
@@ -3,6 +3,7 @@ using TimelessEchoes.Hero;
 using UnityEngine;
 using TimelessEchoes.Utilities;
 using TimelessEchoes.Skills;
+using TimelessEchoes.Audio;
 
 namespace TimelessEchoes.Tasks
 {
@@ -23,6 +24,11 @@ namespace TimelessEchoes.Tasks
 
         protected abstract string AnimationName { get; }
         protected abstract string InterruptTriggerName { get; }
+
+        /// <summary>
+        ///     The audio task type associated with this task.
+        /// </summary>
+        protected abstract AudioManager.TaskType TaskType { get; }
 
         public override bool BlocksMovement => true;
 
@@ -54,6 +60,8 @@ namespace TimelessEchoes.Tasks
                 GrantCompletionXP();
                 return;
             }
+            var audio = AudioManager.Instance ?? Object.FindFirstObjectByType<AudioManager>();
+            audio?.PlayTaskClip(TaskType);
 
             hero.Animator.Play(AnimationName);
             ShowProgressBar();

--- a/Assets/Scripts/Tasks/FarmingTask.cs
+++ b/Assets/Scripts/Tasks/FarmingTask.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using TimelessEchoes.Hero;
 using UnityEngine;
+using TimelessEchoes.Audio;
 
 namespace TimelessEchoes.Tasks
 {
@@ -20,6 +21,7 @@ namespace TimelessEchoes.Tasks
 
         protected override string AnimationName => "Water";
         protected override string InterruptTriggerName => "StopWatering";
+        protected override AudioManager.TaskType TaskType => AudioManager.TaskType.Farming;
 
         public override Transform Target => wateringPoint != null ? wateringPoint : transform;
 

--- a/Assets/Scripts/Tasks/FishingTask.cs
+++ b/Assets/Scripts/Tasks/FishingTask.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using TimelessEchoes.Audio;
 
 namespace TimelessEchoes.Tasks
 {
@@ -9,5 +10,5 @@ namespace TimelessEchoes.Tasks
 
         protected override string AnimationName => "Fishing";
         protected override string InterruptTriggerName => "CatchFish";
-    }
-}
+        protected override AudioManager.TaskType TaskType => AudioManager.TaskType.Fishing;
+    }}

--- a/Assets/Scripts/Tasks/MiningTask.cs
+++ b/Assets/Scripts/Tasks/MiningTask.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using TimelessEchoes.Audio;
 
 namespace TimelessEchoes.Tasks
 {
@@ -6,7 +7,7 @@ namespace TimelessEchoes.Tasks
     {
         protected override string AnimationName => "Mining";
         protected override string InterruptTriggerName => "StopMining";
+        protected override AudioManager.TaskType TaskType => AudioManager.TaskType.Mining;
 
         public override Transform Target => transform;
-    }
-}
+    }}

--- a/Assets/Scripts/Tasks/WoodcuttingTask.cs
+++ b/Assets/Scripts/Tasks/WoodcuttingTask.cs
@@ -1,5 +1,6 @@
 using TimelessEchoes.Hero;
 using UnityEngine;
+using TimelessEchoes.Audio;
 
 namespace TimelessEchoes.Tasks
 {
@@ -20,6 +21,7 @@ namespace TimelessEchoes.Tasks
 
         protected override string AnimationName => "Chopping";
         protected override string InterruptTriggerName => "StopChopping";
+        protected override AudioManager.TaskType TaskType => AudioManager.TaskType.Woodcutting;
         public override Transform Target => cuttingPoint != null ? cuttingPoint : transform;
 
         public override void StartTask()


### PR DESCRIPTION
## Summary
- define an AudioManager task type in `ContinuousTask`
- call `PlayTaskClip` when a continuous task starts
- provide the correct audio task type for farming, fishing, mining and woodcutting tasks

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686e2c4f1248832eadbeb754442f9535