### PR TITLE
Add central SfxPlayer for 2D task audio

### DIFF
--- a/Assets/Scripts/Audio/AudioManager.cs
+++ b/Assets/Scripts/Audio/AudioManager.cs
@@ -120,8 +120,7 @@ namespace TimelessEchoes.Audio
 
         private void PlaySfx(AudioClip clip)
         {
-            if (clip == null) return;
-            AudioSource.PlayClipAtPoint(clip, Vector3.zero, StaticReferences.SfxVolume);
+            SfxPlayer.PlaySfx(clip);
         }
 
         private static AudioClip GetRandom(AudioClip[] clips)
@@ -135,5 +134,4 @@ namespace TimelessEchoes.Audio
             var v = Mathf.Clamp(value, 0.0001f, 1f);
             return Mathf.Log10(v) * 20f;
         }
-    }
-}
+    }}

--- a/Assets/Scripts/Audio/SfxPlayer.cs
+++ b/Assets/Scripts/Audio/SfxPlayer.cs
@@ -1,0 +1,28 @@
+using Blindsided.SaveData;
+using UnityEngine;
+
+namespace TimelessEchoes.Audio
+{
+    public static class SfxPlayer
+    {
+        private static AudioSource _source;
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+        private static void Init()
+        {
+            var go = new GameObject("SFX Source");
+            Object.DontDestroyOnLoad(go);
+
+            _source = go.AddComponent<AudioSource>();
+            _source.spatialBlend = 0f;
+            _source.playOnAwake = false;
+            _source.loop = false;
+        }
+
+        public static void PlaySfx(AudioClip clip)
+        {
+            if (clip == null || _source == null) return;
+            _source.PlayOneShot(clip, StaticReferences.SfxVolume);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add new `SfxPlayer` static helper that holds a 2D `AudioSource`
- play sound effects through `SfxPlayer` from `AudioManager`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e36199754832eb674053bc5ebd46b