### PR TITLE
Add Mildred unlock logic and donation quest tracking

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -44,6 +44,7 @@ namespace TimelessEchoes
         [SerializeField] private Button deathReturnButton;
         [SerializeField] private SlicedFilledImage deathTimerImage;
         [SerializeField] private float deathWindowDuration = 20f;
+        [SerializeField] private string mildredQuestId;
 
         [Header("Cameras")] [SerializeField] private CinemachineCamera tavernCamera;
 
@@ -177,6 +178,8 @@ namespace TimelessEchoes
                         hp.HealthBar = runCalebUI.healthBar;
                 }
             }
+
+            EnableMildred();
 
             Physics2D.SyncTransforms();
             yield return null;
@@ -366,6 +369,32 @@ namespace TimelessEchoes
             {
                 Destroy(currentMap); // safe to destroy AstarPath now
                 currentMap = null;
+            }
+
+        }
+
+        private static bool QuestCompleted(string questId)
+        {
+            if (string.IsNullOrEmpty(questId))
+                return true;
+            if (oracle == null)
+                return false;
+            oracle.saveData.Quests ??= new Dictionary<string, GameData.QuestRecord>();
+            return oracle.saveData.Quests.TryGetValue(questId, out var rec) && rec.Completed;
+        }
+
+        private void EnableMildred()
+        {
+            if (currentMap == null)
+                return;
+            bool unlocked = QuestCompleted(mildredQuestId);
+            foreach (var t in currentMap.GetComponentsInChildren<Transform>(true))
+            {
+                if (t.gameObject.name == "Mildred")
+                {
+                    t.gameObject.SetActive(unlocked);
+                    break;
+                }
             }
         }
     }

--- a/Assets/Scripts/NPC/MildredMovementController.cs
+++ b/Assets/Scripts/NPC/MildredMovementController.cs
@@ -1,0 +1,33 @@
+using Pathfinding;
+using TimelessEchoes.Hero;
+using UnityEngine;
+
+namespace TimelessEchoes.NPC
+{
+    /// <summary>
+    /// Simple movement and animation controller for Mildred the cat.
+    /// </summary>
+    [RequireComponent(typeof(AIPath))]
+    public class MildredMovementController : MonoBehaviour
+    {
+        [SerializeField] private Animator animator;
+        [SerializeField] private HeroController hero;
+        private AIPath ai;
+
+        private void Awake()
+        {
+            ai = GetComponent<AIPath>();
+            if (hero == null)
+                hero = FindFirstObjectByType<HeroController>();
+        }
+
+        private void Update()
+        {
+            if (hero != null && ai != null)
+                ai.maxSpeed = hero.MoveSpeed + 1f;
+
+            if (animator != null && ai != null)
+                animator.SetFloat("MoveMagnitude", ai.desiredVelocity.magnitude);
+        }
+    }
+}

--- a/Assets/Scripts/Quests/QuestData.cs
+++ b/Assets/Scripts/Quests/QuestData.cs
@@ -26,7 +26,7 @@ namespace TimelessEchoes.Quests
         public class Requirement
         {
             public RequirementType type;
-            [ShowIf("type", RequirementType.Resource)]
+            [ShowIf("@type == RequirementType.Resource || type == RequirementType.Donation")]
             public Resource resource;
             public int amount = 1;
             [ShowIf("type", RequirementType.Kill)]
@@ -38,7 +38,8 @@ namespace TimelessEchoes.Quests
         public enum RequirementType
         {
             Resource,
-            Kill
+            Kill,
+            Donation
         }
     }
 }

--- a/Assets/Scripts/Quests/QuestEntryUI.cs
+++ b/Assets/Scripts/Quests/QuestEntryUI.cs
@@ -47,10 +47,13 @@ namespace TimelessEchoes.Quests
                     foreach (var req in data.requirements)
                     {
                         var slot = Instantiate(costSlotPrefab, costParent);
-                        slot.resource = req.type == QuestData.RequirementType.Resource ? req.resource : null;
+                        slot.resource = (req.type == QuestData.RequirementType.Resource ||
+                                         req.type == QuestData.RequirementType.Donation)
+                                         ? req.resource : null;
                         if (slot.iconImage != null)
                         {
-                            if (req.type == QuestData.RequirementType.Resource)
+                            if (req.type == QuestData.RequirementType.Resource ||
+                                req.type == QuestData.RequirementType.Donation)
                                 slot.iconImage.sprite = req.resource ? req.resource.icon : null;
                             else if (req.type == QuestData.RequirementType.Kill)
                                 slot.iconImage.sprite = req.killIcon;
@@ -69,5 +72,4 @@ namespace TimelessEchoes.Quests
             if (turnInButton != null)
                 turnInButton.interactable = pct >= 1f;
         }
-    }
-}
+    }}

--- a/Assets/Scripts/Quests/QuestManager.cs
+++ b/Assets/Scripts/Quests/QuestManager.cs
@@ -4,6 +4,7 @@ using TimelessEchoes.Enemies;
 using TimelessEchoes.NpcGeneration;
 using TimelessEchoes.Stats;
 using TimelessEchoes.Upgrades;
+using TimelessEchoes.Regen;
 using UnityEngine;
 using static Blindsided.Oracle;
 using static Blindsided.EventHandler;
@@ -139,6 +140,13 @@ namespace TimelessEchoes.Quests
 
                     if (req.amount > 0)
                         pct = (float)(total / req.amount);
+                }
+                else if (req.type == QuestData.RequirementType.Donation)
+                {
+                    double donated = RegenManager.Instance ?
+                        RegenManager.Instance.GetDonationTotal(req.resource) : 0;
+                    if (req.amount > 0)
+                        pct = (float)(donated / req.amount);
                 }
 
                 progress += Mathf.Clamp01(pct);

--- a/Assets/Scripts/Regen/RegenManager.cs
+++ b/Assets/Scripts/Regen/RegenManager.cs
@@ -15,6 +15,7 @@ namespace TimelessEchoes.Regen
     /// </summary>
     public class RegenManager : MonoBehaviour
     {
+        public static RegenManager Instance { get; private set; }
         [SerializeField] private ResourceManager resourceManager;
         [SerializeField] private ResourceInventoryUI inventoryUI;
         [SerializeField] private List<Resource> fishResources = new();
@@ -27,6 +28,7 @@ namespace TimelessEchoes.Regen
 
         private void Awake()
         {
+            Instance = this;
             if (resourceManager == null)
             {
                 resourceManager = ResourceManager.Instance;
@@ -57,6 +59,8 @@ namespace TimelessEchoes.Regen
             OnLoadData -= LoadState;
             if (resourceManager != null)
                 resourceManager.OnInventoryChanged -= UpdateAllEntries;
+            if (Instance == this)
+                Instance = null;
         }
 
         private void Update()
@@ -189,6 +193,19 @@ namespace TimelessEchoes.Regen
             foreach (var pair in donations)
                 sum += GetRegenFor(pair.Key);
             return sum;
+        }
+
+        public double GetDonationTotal(Resource res = null)
+        {
+            if (res == null)
+            {
+                double sum = 0;
+                foreach (var val in donations.Values)
+                    sum += val;
+                return sum;
+            }
+
+            return donations.TryGetValue(res, out var val) ? val : 0;
         }
 
         private void SaveState()


### PR DESCRIPTION
## Summary
- add movement controller for Mildred that follows the hero's AIPath speed
- expose donation totals via `RegenManager` and make it a singleton
- implement new `Donation` quest requirement type
- update quest UI and manager logic for donations
- allow GameManager to enable Mildred when her quest is complete

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_686ee12f2268832e966c1a10f226fbe3