### PR TITLE
Fix SFX mixer routing

### DIFF
--- a/Assets/Scripts/Audio/AudioManager.cs
+++ b/Assets/Scripts/Audio/AudioManager.cs
@@ -43,6 +43,7 @@ namespace TimelessEchoes.Audio
             if (Instance == null)
             {
                 Instance = this;
+                SfxPlayer.SetMixerGroup(sfxGroup);
             }
             else
             {

--- a/Assets/Scripts/Audio/SfxPlayer.cs
+++ b/Assets/Scripts/Audio/SfxPlayer.cs
@@ -1,11 +1,13 @@
 using Blindsided.SaveData;
 using UnityEngine;
+using UnityEngine.Audio;
 
 namespace TimelessEchoes.Audio
 {
     public static class SfxPlayer
     {
         private static AudioSource _source;
+        private static AudioMixerGroup _mixerGroup;
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         private static void Init()
@@ -17,6 +19,15 @@ namespace TimelessEchoes.Audio
             _source.spatialBlend = 0f;
             _source.playOnAwake = false;
             _source.loop = false;
+            if (_mixerGroup != null)
+                _source.outputAudioMixerGroup = _mixerGroup;
+        }
+
+        public static void SetMixerGroup(AudioMixerGroup group)
+        {
+            _mixerGroup = group;
+            if (_source != null)
+                _source.outputAudioMixerGroup = _mixerGroup;
         }
 
         public static void PlaySfx(AudioClip clip)


### PR DESCRIPTION
## Summary
- ensure SFX audio source uses the SFX mixer group
- connect `AudioManager` to set the mixer group on startup

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f3f6d86d4832eb7ff72e203015d74