### PR TITLE
Add lifesteal buff

### DIFF
--- a/Assets/Scripts/Buffs/BuffManager.cs
+++ b/Assets/Scripts/Buffs/BuffManager.cs
@@ -193,6 +193,17 @@ namespace TimelessEchoes.Buffs
             }
         }
 
+        public float LifestealPercent
+        {
+            get
+            {
+                float percent = 0f;
+                foreach (var b in activeBuffs)
+                    percent += b.recipe.lifestealPercent;
+                return percent;
+            }
+        }
+
         private void LoadSlots()
         {
             if (oracle == null) return;

--- a/Assets/Scripts/Buffs/BuffRecipe.cs
+++ b/Assets/Scripts/Buffs/BuffRecipe.cs
@@ -22,6 +22,8 @@ namespace TimelessEchoes.Buffs
         [Range(-100f, 100f)] public float damagePercent;
         [Range(-100f, 100f)] public float defensePercent;
         [Range(-100f, 100f)] public float attackSpeedPercent;
+        [Tooltip("Percent of damage returned as health while active.")]
+        [Range(0f, 100f)] public float lifestealPercent;
         [Tooltip("Tasks complete instantly while active.")]
         public bool instantTasks;
         [Tooltip("Percent of longest run distance this buff remains active. 0 = no distance limit")]

--- a/Assets/Scripts/Projectile.cs
+++ b/Assets/Scripts/Projectile.cs
@@ -2,6 +2,9 @@ using System.Collections.Generic;
 using UnityEngine;
 using Blindsided.Utilities.Pooling;
 using TimelessEchoes.Audio;
+using TimelessEchoes.Buffs;
+using TimelessEchoes.Enemies;
+using TimelessEchoes.Hero;
 
 namespace TimelessEchoes
 {
@@ -101,6 +104,16 @@ namespace TimelessEchoes
                     var tracker = TimelessEchoes.Stats.GameplayStatTracker.Instance ??
                                      FindFirstObjectByType<TimelessEchoes.Stats.GameplayStatTracker>();
                     tracker?.AddDamageDealt(dmgAmount);
+                    var buffManager = TimelessEchoes.Buffs.BuffManager.Instance ??
+                                      FindFirstObjectByType<TimelessEchoes.Buffs.BuffManager>();
+                    var hero = FindFirstObjectByType<TimelessEchoes.Hero.HeroController>();
+                    var heroHealth = hero != null ? hero.GetComponent<TimelessEchoes.Enemies.Health>() : null;
+                    if (buffManager != null && heroHealth != null)
+                    {
+                        float ls = buffManager.LifestealPercent;
+                        if (ls > 0f)
+                            heroHealth.Heal(dmgAmount * ls / 100f);
+                    }
                 }
                 var sfx = GetComponent<ProjectileHitSfx>();
                 sfx?.PlayHit();


### PR DESCRIPTION
## Summary
- enable a lifesteal field on `BuffRecipe`
- expose lifesteal percent from `BuffManager`
- heal the hero when projectiles hit if lifesteal is active

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870b1be8160832e923fe7be5d2c86a6