### PR TITLE
Fix hero controller singleton initialization

### DIFF
--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -109,8 +109,7 @@ namespace TimelessEchoes.Hero
         {
             if (Instance != null && Instance != this)
             {
-                Destroy(Instance);
-                return;
+                Destroy(Instance.gameObject);
             }
 
             Instance = this;


### PR DESCRIPTION
## Summary
- properly destroy old hero object on new hero creation
- ensure Awake always assigns new singleton

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6870befa24f4832e8272a7a41f099ab8