### PR TITLE
Remove serialized ResourceManager references

### DIFF
--- a/Assets/Scripts/Regen/RegenManager.cs
+++ b/Assets/Scripts/Regen/RegenManager.cs
@@ -17,7 +17,6 @@ namespace TimelessEchoes.Regen
     public class RegenManager : MonoBehaviour
     {
         public static RegenManager Instance { get; private set; }
-        [SerializeField] private ResourceManager resourceManager;
         [SerializeField] private ResourceInventoryUI inventoryUI;
         [SerializeField] private List<Resource> fishResources = new();
         [SerializeField] private RegenEntryUIReferences entryPrefab;
@@ -30,12 +29,9 @@ namespace TimelessEchoes.Regen
         private void Awake()
         {
             Instance = this;
-            if (resourceManager == null)
-            {
-                resourceManager = ResourceManager.Instance;
-                if (resourceManager == null)
-                    Log("ResourceManager missing", TELogCategory.Resource, this);
-            }
+            var manager = ResourceManager.Instance;
+            if (manager == null)
+                Log("ResourceManager missing", TELogCategory.Resource, this);
 
             if (inventoryUI == null)
             {
@@ -54,8 +50,8 @@ namespace TimelessEchoes.Regen
             OnSaveData += SaveState;
             OnLoadData += LoadState;
             OnResetData += ResetDonations;
-            if (resourceManager != null)
-                resourceManager.OnInventoryChanged += UpdateAllEntries;
+            if (manager != null)
+                manager.OnInventoryChanged += UpdateAllEntries;
         }
 
         private void OnDestroy()
@@ -63,8 +59,9 @@ namespace TimelessEchoes.Regen
             OnSaveData -= SaveState;
             OnLoadData -= LoadState;
             OnResetData -= ResetDonations;
-            if (resourceManager != null)
-                resourceManager.OnInventoryChanged -= UpdateAllEntries;
+            var manager = ResourceManager.Instance;
+            if (manager != null)
+                manager.OnInventoryChanged -= UpdateAllEntries;
             if (Instance == this)
                 Instance = null;
         }
@@ -131,8 +128,9 @@ namespace TimelessEchoes.Regen
             var res = fishResources[index];
             if (entry == null || res == null) return;
 
-            var unlocked = resourceManager && resourceManager.IsUnlocked(res);
-            var playerAmt = resourceManager ? resourceManager.GetAmount(res) : 0;
+            var manager = ResourceManager.Instance;
+            var unlocked = manager != null && manager.IsUnlocked(res);
+            var playerAmt = manager != null ? manager.GetAmount(res) : 0;
             var donated = donations.TryGetValue(res, out var val) ? val : 0;
 
             var costRefs = entry.costResourceUIReferences;
@@ -165,21 +163,23 @@ namespace TimelessEchoes.Regen
 
         private void DonatePercentage(Resource res, float pct)
         {
-            if (resourceManager == null || res == null) return;
-            double amount = Mathf.Floor((float)(resourceManager.GetAmount(res) * pct));
+            var manager = ResourceManager.Instance;
+            if (manager == null || res == null) return;
+            double amount = Mathf.Floor((float)(manager.GetAmount(res) * pct));
             if (amount <= 0) return;
             AddDonation(res, amount);
-            resourceManager.Spend(res, amount);
+            manager.Spend(res, amount);
             UpdateAllEntries();
         }
 
         private void DonateAll(Resource res)
         {
-            if (resourceManager == null || res == null) return;
-            var amount = resourceManager.GetAmount(res);
+            var manager = ResourceManager.Instance;
+            if (manager == null || res == null) return;
+            var amount = manager.GetAmount(res);
             if (amount <= 0) return;
             AddDonation(res, amount);
-            resourceManager.Spend(res, amount);
+            manager.Spend(res, amount);
             UpdateAllEntries();
         }
 

--- a/Assets/Scripts/Upgrades/StatUpgradeController.cs
+++ b/Assets/Scripts/Upgrades/StatUpgradeController.cs
@@ -13,7 +13,6 @@ namespace TimelessEchoes.Upgrades
     public class StatUpgradeController : MonoBehaviour
     {
         public static StatUpgradeController Instance { get; private set; }
-        [SerializeField] private ResourceManager resourceManager;
         [SerializeField] private List<StatUpgrade> upgrades = new();
 
         private readonly Dictionary<StatUpgrade, int> levels = new();
@@ -78,7 +77,8 @@ namespace TimelessEchoes.Upgrades
             {
                 var lvl = GetLevel(upgrade);
                 var cost = req.amount + Mathf.Max(0, lvl - threshold.minLevel) * req.amountIncreasePerLevel;
-                if (resourceManager != null && resourceManager.GetAmount(req.resource) < cost)
+                var manager = ResourceManager.Instance;
+                if (manager != null && manager.GetAmount(req.resource) < cost)
                     return false;
             }
 
@@ -95,7 +95,7 @@ namespace TimelessEchoes.Upgrades
             {
                 var lvl = GetLevel(upgrade);
                 var cost = req.amount + Mathf.Max(0, lvl - threshold.minLevel) * req.amountIncreasePerLevel;
-                resourceManager?.Spend(req.resource, cost);
+                ResourceManager.Instance?.Spend(req.resource, cost);
             }
 
             levels[upgrade] = GetLevel(upgrade) + 1;


### PR DESCRIPTION
## Summary
- clean up ResourceManager usage
- use `ResourceManager.Instance` in RegenManager
- use `ResourceManager.Instance` in StatUpgradeController

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687232798c38832eaf59cedb139d8a10