### PR TITLE
Fix fishing task asset YAML

### DIFF
--- a/Assets/Resources/Tasks/Fishing/Bloopicus Maximus.asset
+++ b/Assets/Resources/Tasks/Fishing/Bloopicus Maximus.asset
@@ -20,7 +20,7 @@ MonoBehaviour:
   taskDuration: 2
   resourceDrops:
   - resource: {fileID: 11400000, guid: 289297afb43756445933dca5ff8d7138, type: 2}
-    dropRange: {x: 1, 2}
+    dropRange: {x: 1, y: 2}
     dropChance: 1
     minX: 10000
     maxX: Infinity

--- a/Assets/Resources/Tasks/Fishing/Flippy Floppy.asset
+++ b/Assets/Resources/Tasks/Fishing/Flippy Floppy.asset
@@ -20,7 +20,7 @@ MonoBehaviour:
   taskDuration: 2
   resourceDrops:
   - resource: {fileID: 11400000, guid: 691350e69adc08a4082225a8015d2955, type: 2}
-    dropRange: {x: 1, 2}
+    dropRange: {x: 1, y: 2}
     dropChance: 1
     minX: 0
     maxX: 250

--- a/Assets/Resources/Tasks/Fishing/Flipzoid.asset
+++ b/Assets/Resources/Tasks/Fishing/Flipzoid.asset
@@ -20,7 +20,7 @@ MonoBehaviour:
   taskDuration: 2
   resourceDrops:
   - resource: {fileID: 11400000, guid: c906b6628db99c14d94b3b43d531523f, type: 2}
-    dropRange: {x: 1, 3}
+    dropRange: {x: 1, y: 3}
     dropChance: 1
     minX: 2500
     maxX: Infinity

--- a/Assets/Resources/Tasks/Fishing/Muddy Muck Muncher.asset
+++ b/Assets/Resources/Tasks/Fishing/Muddy Muck Muncher.asset
@@ -20,7 +20,7 @@ MonoBehaviour:
   taskDuration: 2
   resourceDrops:
   - resource: {fileID: 11400000, guid: 457dbb132eac48d429163353adb4b532, type: 2}
-    dropRange: {x: 1, 3}
+    dropRange: {x: 1, y: 3}
     dropChance: 1
     minX: 100
     maxX: 500

--- a/Assets/Resources/Tasks/Fishing/Niblet the Bold.asset
+++ b/Assets/Resources/Tasks/Fishing/Niblet the Bold.asset
@@ -20,7 +20,7 @@ MonoBehaviour:
   taskDuration: 2
   resourceDrops:
   - resource: {fileID: 11400000, guid: 25caf48dcc8c9d64d9b2927980cfa324, type: 2}
-    dropRange: {x: 1, 2}
+    dropRange: {x: 1, y: 2}
     dropChance: 1
     minX: 5000
     maxX: Infinity

--- a/Assets/Resources/Tasks/Fishing/Sir Splashford III.asset
+++ b/Assets/Resources/Tasks/Fishing/Sir Splashford III.asset
@@ -20,7 +20,7 @@ MonoBehaviour:
   taskDuration: 2
   resourceDrops:
   - resource: {fileID: 11400000, guid: 59c67a9fee0efc84997a60754c5f02ba, type: 2}
-    dropRange: {x: 1, 2}
+    dropRange: {x: 1, y: 2}
     dropChance: 1
     minX: 250
     maxX: 1000

--- a/Assets/Resources/Tasks/Fishing/Snapjaw Jr..asset
+++ b/Assets/Resources/Tasks/Fishing/Snapjaw Jr..asset
@@ -20,7 +20,7 @@ MonoBehaviour:
   taskDuration: 2
   resourceDrops:
   - resource: {fileID: 11400000, guid: bf23b8a0a0d501543b9e7310db929300, type: 2}
-    dropRange: {x: 1, 2}
+    dropRange: {x: 1, y: 2}
     dropChance: 1
     minX: 1000
     maxX: 10000

--- a/Assets/Resources/Tasks/Fishing/Wigglelittle.asset
+++ b/Assets/Resources/Tasks/Fishing/Wigglelittle.asset
@@ -20,7 +20,7 @@ MonoBehaviour:
   taskDuration: 2
   resourceDrops:
   - resource: {fileID: 11400000, guid: c6baa65f60afab548b279c321897df99, type: 2}
-    dropRange: {x: 1, 4}
+    dropRange: {x: 1, y: 4}
     dropChance: 1
     minX: 500
     maxX: 2500


### PR DESCRIPTION
## Summary
- fix invalid YAML mapping for fishing task `dropRange`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687496f89400832e9bb2c422c9aa5a49