### PR TITLE
Split map tasks into separate lists

### DIFF
--- a/Assets/Scripts/MapGeneration/MapGenerationConfig.cs
+++ b/Assets/Scripts/MapGeneration/MapGenerationConfig.cs
@@ -54,7 +54,13 @@ namespace TimelessEchoes.MapGeneration
             [MinValue(0f)] public float otherTaskEdgeOffset = 1f;
 
             public List<ProceduralTaskGenerator.WeightedSpawn> enemies = new();
-            public List<ProceduralTaskGenerator.WeightedSpawn> tasks = new();
+
+            [FormerlySerializedAs("tasks")] public List<ProceduralTaskGenerator.WeightedSpawn> woodcuttingTasks = new();
+            public List<ProceduralTaskGenerator.WeightedSpawn> miningTasks = new();
+            public List<ProceduralTaskGenerator.WeightedSpawn> farmingTasks = new();
+            public List<ProceduralTaskGenerator.WeightedSpawn> fishingTasks = new();
+            public List<ProceduralTaskGenerator.WeightedSpawn> lootingTasks = new();
+
             public List<NpcSpawnEntry> npcTasks = new();
 
             [MinValue(0f)] public float minTaskDistance = 1.5f;

--- a/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
+++ b/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
@@ -144,7 +144,14 @@ namespace TimelessEchoes.Tasks
             blockingMask = config.taskGeneratorSettings.blockingMask;
             otherTaskEdgeOffset = config.taskGeneratorSettings.otherTaskEdgeOffset;
             enemies = config.taskGeneratorSettings.enemies;
-            tasks = config.taskGeneratorSettings.tasks;
+
+            tasks = new List<WeightedSpawn>();
+            tasks.AddRange(config.taskGeneratorSettings.woodcuttingTasks);
+            tasks.AddRange(config.taskGeneratorSettings.miningTasks);
+            tasks.AddRange(config.taskGeneratorSettings.farmingTasks);
+            tasks.AddRange(config.taskGeneratorSettings.fishingTasks);
+            tasks.AddRange(config.taskGeneratorSettings.lootingTasks);
+
             npcTasks = config.taskGeneratorSettings.npcTasks;
             minTaskDistance = config.taskGeneratorSettings.minTaskDistance;
         }


### PR DESCRIPTION
## Summary
- separate task configuration lists by category
- merge all task categories in ProceduralTaskGenerator

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874a1a0c570832e8646c748e39e9df7