### PR TITLE
Fix BetterRuleTiles editor assembly configuration

### DIFF
--- a/Assets/BetterRuleTiles/Editor/Utilities/VinarkGames.Utilities.Editor.asmdef
+++ b/Assets/BetterRuleTiles/Editor/Utilities/VinarkGames.Utilities.Editor.asmdef
@@ -3,7 +3,9 @@
     "references": [
         "GUID:c6617bc2cd6da0a4986abd5476deb30d"
     ],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,

--- a/Assets/BetterRuleTiles/Editor/VinarkGames.BetterRuleTiles.Editor.asmdef
+++ b/Assets/BetterRuleTiles/Editor/VinarkGames.BetterRuleTiles.Editor.asmdef
@@ -8,7 +8,9 @@
         "GUID:6e9b38dea3ea97a479022ee7a855f1d9",
         "GUID:c6617bc2cd6da0a4986abd5476deb30d"
     ],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,


### PR DESCRIPTION
## Summary
- restrict BetterRuleTiles editor assemblies to the Editor platform to avoid build errors

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874b499a374832eae619aac45ded73c