### PR TITLE
Implement Steam stat updater

### DIFF
--- a/Assets/Scripts/Stats/GameplayStatTracker.cs
+++ b/Assets/Scripts/Stats/GameplayStatTracker.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 using Blindsided.SaveData;
 using TimelessEchoes.Upgrades;
 using TimelessEchoes.Tasks;
+using TimelessEchoes;
 using static Blindsided.EventHandler;
 using static Blindsided.Oracle;
 
@@ -172,6 +173,7 @@ namespace TimelessEchoes.Stats
             record.XpGained += xp;
             tasksCompleted++;
             currentRunTasks++;
+            SteamStatsUpdater.Instance?.UpdateStats();
         }
 
         public GameData.TaskRecord GetTaskRecord(TaskData data)
@@ -288,6 +290,7 @@ namespace TimelessEchoes.Stats
             currentRunDamageTaken = 0f;
             lastHeroPos = Vector3.zero;
             runStartTime = Time.time;
+            SteamStatsUpdater.Instance?.UpdateStats();
         }
     }
 }

--- a/Assets/Scripts/Steamworks.NET/SteamStatsUpdater.cs
+++ b/Assets/Scripts/Steamworks.NET/SteamStatsUpdater.cs
@@ -1,0 +1,112 @@
+#if !(UNITY_STANDALONE_WIN || UNITY_STANDALONE_LINUX || UNITY_STANDALONE_OSX || STEAMWORKS_WIN || STEAMWORKS_LIN_OSX)
+#define DISABLESTEAMWORKS
+#endif
+
+using UnityEngine;
+#if !DISABLESTEAMWORKS
+using Steamworks;
+#endif
+
+namespace TimelessEchoes
+{
+    /// <summary>
+    /// Updates Steam user stats based on values from GameplayStatTracker.
+    /// </summary>
+    public class SteamStatsUpdater : MonoBehaviour
+    {
+#if !DISABLESTEAMWORKS
+        private static SteamStatsUpdater instance;
+
+        /// <summary>
+        /// Singleton instance accessor.
+        /// </summary>
+        public static SteamStatsUpdater Instance
+        {
+            get
+            {
+                if (instance == null)
+                {
+                    instance = FindFirstObjectByType<SteamStatsUpdater>();
+                    if (instance == null)
+                        instance = new GameObject("SteamStatsUpdater").AddComponent<SteamStatsUpdater>();
+                }
+
+                return instance;
+            }
+        }
+
+        [SerializeField]
+        private float updateInterval = 5f;
+        private float lastUpdate;
+
+        private void Awake()
+        {
+            if (instance != null && instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+
+        private void Update()
+        {
+            if (Time.unscaledTime - lastUpdate >= updateInterval)
+            {
+                lastUpdate = Time.unscaledTime;
+                UpdateStats();
+            }
+        }
+
+        /// <summary>
+        /// Updates the DistanceReached, TotalKilometers and TasksCompleted stats.
+        /// </summary>
+        public void UpdateStats()
+        {
+            if (!SteamManager.Initialized)
+                return;
+
+            var tracker = Stats.GameplayStatTracker.Instance;
+            if (tracker == null)
+                return;
+
+            bool changed = false;
+
+            if (SteamUserStats.GetStat("DistanceReached", out int storedDistance))
+            {
+                int newDistance = Mathf.FloorToInt(tracker.LongestRun);
+                if (newDistance > storedDistance)
+                {
+                    SteamUserStats.SetStat("DistanceReached", newDistance);
+                    changed = true;
+                }
+            }
+
+            if (SteamUserStats.GetStat("TotalKilometers", out float storedKm))
+            {
+                float newKm = tracker.DistanceTravelled / 1000f;
+                if (newKm > storedKm)
+                {
+                    SteamUserStats.SetStat("TotalKilometers", newKm);
+                    changed = true;
+                }
+            }
+
+            if (SteamUserStats.GetStat("TasksCompleted", out int storedTasks))
+            {
+                int newTasks = tracker.TasksCompleted;
+                if (newTasks > storedTasks)
+                {
+                    SteamUserStats.SetStat("TasksCompleted", newTasks);
+                    changed = true;
+                }
+            }
+
+            if (changed)
+                SteamUserStats.StoreStats();
+        }
+#endif
+    }
+}


### PR DESCRIPTION
## Summary
- add `SteamStatsUpdater` component to push gameplay stats to Steam
- hook stat updater into `GameplayStatTracker` for task completion and run end

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6874cad33ab4832e875e27daa147ef90