### PR TITLE
Fix CloudSpawner compile error

### DIFF
--- a/Assets/Scripts/MapGeneration/CloudSpawner.cs
+++ b/Assets/Scripts/MapGeneration/CloudSpawner.cs
@@ -83,11 +83,13 @@ public class CloudSpawner : MonoBehaviour
         var sr = go.GetComponent<SpriteRenderer>();
 
         if (cloudMaterial != null)
+        {
             sr.sharedMaterial = cloudMaterial;
+            sr.sharedMaterial.enableInstancing = true;
+        }
 
         sr.sprite = frames[Random.Range(0, frames.Length)];
         sr.sortingLayerName = "Background";
-        sr.enableInstancing = true;
 
         var cloud = new Cloud { Tr = go.transform };
         Recycle(cloud, spawnInView);


### PR DESCRIPTION
## Summary
- set instancing on cloud material instead of the SpriteRenderer

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687602476510832ea40d539071029f1b