### PR TITLE
Fix reaper movement direction from right side

### DIFF
--- a/Assets/Scripts/Enemies/ReaperManager.cs
+++ b/Assets/Scripts/Enemies/ReaperManager.cs
@@ -41,7 +41,8 @@ namespace TimelessEchoes.Enemies
                 var remaining = moveDistance - moved;
                 var horizStep = step;
                 if (horizStep > remaining) horizStep = remaining;
-                transform.position += transform.right * horizStep;
+                var direction = Mathf.Sign(transform.localScale.x);
+                transform.position += transform.right * horizStep * direction;
                 moved += horizStep;
             }
 


### PR DESCRIPTION
## Summary
- ensure reaper moves toward the target when spawned from the right

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876f5a493fc832e91abfde0f30525a9