### PR TITLE
Add chest open audio hooks

### DIFF
--- a/Assets/Scripts/Audio/AudioManager.cs
+++ b/Assets/Scripts/Audio/AudioManager.cs
@@ -33,6 +33,9 @@ namespace TimelessEchoes.Audio
 
         [SerializeField] private AudioClip[] weaponSwingClips;
 
+        [Header("Chest Clips")] [SerializeField]
+        private AudioClip[] chestOpenClips;
+
         public enum TaskType
         {
             Woodcutting,
@@ -136,6 +139,11 @@ namespace TimelessEchoes.Audio
         public void PlayWeaponSwingClip()
         {
             PlayCombatClip(weaponSwingClips);
+        }
+
+        public void PlayChestOpenClip()
+        {
+            PlaySfx(GetRandom(chestOpenClips));
         }
 
         public void PlayFishCatchClip()

--- a/Assets/Scripts/Hero/HeroAudio.cs
+++ b/Assets/Scripts/Hero/HeroAudio.cs
@@ -42,6 +42,11 @@ namespace TimelessEchoes.Hero
             Audio?.PlayWeaponSwingClip();
         }
 
+        public void PlayChestOpen()
+        {
+            Audio?.PlayChestOpenClip();
+        }
+
         public void PlayFishCatch()
         {
             Audio?.PlayFishCatchClip();


### PR DESCRIPTION
## Summary
- extend `AudioManager` with chest open sound list and a `PlayChestOpenClip` method
- expose `PlayChestOpen` in `HeroAudio` so animations can trigger chest sounds

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878a73284f0832e9720f4bf1a319cbc