### PR TITLE
Move spawn range to TaskData

### DIFF
--- a/Assets/Scripts/MapGeneration/MapGenerationConfig.cs
+++ b/Assets/Scripts/MapGeneration/MapGenerationConfig.cs
@@ -55,11 +55,11 @@ namespace TimelessEchoes.MapGeneration
 
             public List<ProceduralTaskGenerator.WeightedSpawn> enemies = new();
 
-            [FormerlySerializedAs("tasks")] public List<ProceduralTaskGenerator.WeightedSpawn> woodcuttingTasks = new();
-            public List<ProceduralTaskGenerator.WeightedSpawn> miningTasks = new();
-            public List<ProceduralTaskGenerator.WeightedSpawn> farmingTasks = new();
-            public List<ProceduralTaskGenerator.WeightedSpawn> fishingTasks = new();
-            public List<ProceduralTaskGenerator.WeightedSpawn> lootingTasks = new();
+            [FormerlySerializedAs("tasks")] public List<ProceduralTaskGenerator.WeightedTaskSpawn> woodcuttingTasks = new();
+            public List<ProceduralTaskGenerator.WeightedTaskSpawn> miningTasks = new();
+            public List<ProceduralTaskGenerator.WeightedTaskSpawn> farmingTasks = new();
+            public List<ProceduralTaskGenerator.WeightedTaskSpawn> fishingTasks = new();
+            public List<ProceduralTaskGenerator.WeightedTaskSpawn> lootingTasks = new();
 
             public List<NpcSpawnEntry> npcTasks = new();
 

--- a/Assets/Scripts/Tasks/TaskData.cs
+++ b/Assets/Scripts/Tasks/TaskData.cs
@@ -3,6 +3,7 @@ using Blindsided.Utilities;
 using TimelessEchoes.Skills;
 using TimelessEchoes.Upgrades;
 using TimelessEchoes.Quests;
+using Sirenix.OdinInspector;
 using UnityEngine;
 
 namespace TimelessEchoes.Tasks
@@ -11,17 +12,34 @@ namespace TimelessEchoes.Tasks
     [CreateAssetMenu(fileName = "TaskData", menuName = "SO/Task Data")]
     public class TaskData : ScriptableObject
     {
+        [TitleGroup("General")]
         public string taskName;
+        [TitleGroup("General")]
         public int taskID;
+        [TitleGroup("General")]
+        [PreviewField(60, ObjectFieldAlignment.Left)]
         public Sprite taskIcon;
+        [TitleGroup("General")]
         public Skill associatedSkill;
+        [TitleGroup("General")]
         public float xpForCompletion;
+        [TitleGroup("Spawn Range")]
+        [LabelWidth(70)]
+        [MinValue(0f)]
+        public float minX;
+        [TitleGroup("Spawn Range")]
+        public float maxX = float.PositiveInfinity;
+        [TitleGroup("General")]
         public QuestData requiredQuest;
+        [TitleGroup("General")]
         public float taskDuration;
+        [TitleGroup("General")]
         [Tooltip("Interval between repeated SFX plays while the task is active. Zero disables repeats.")]
         public float sfxInterval;
+        [TitleGroup("General")]
         public List<ResourceDrop> resourceDrops = new();
 
+        [TitleGroup("General")]
         [Tooltip("Restart task progress when returning after an interrupt.")]
         public bool resetProgressOnInterrupt;
 


### PR DESCRIPTION
## Summary
- add spawn range fields to `TaskData` and tidy its inspector
- introduce `WeightedTaskSpawn` to hold `BaseTask` prefab references
- update map generation to use the new spawn data

## Testing
- `echo "No build or test script found"`

------
https://chatgpt.com/codex/tasks/task_e_68796684d8f0832eb6842465db05ffb7