### PR TITLE
Fix dice roller not triggering in combat

### DIFF
--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -547,9 +547,6 @@ namespace TimelessEchoes.Hero
             if (state == State.PerformingTask && CurrentTask != null)
                 CurrentTask.OnInterrupt(this);
 
-            state = State.Combat;
-            setter.target = enemy.transform;
-            ai?.SearchPath();
             HandleCombat(enemy.transform);
         }
 


### PR DESCRIPTION
## Summary
- ensure `OnEnemyEngage` doesn't set combat state before rolling dice

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a15acbaac832e9e77453a8b38f1ed