### PR TITLE
Fix NullReference in hero task assignment

### DIFF
--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -369,7 +369,7 @@ namespace TimelessEchoes.Hero
             if (setter != null)
             {
                 setter.target = task?.Target;
-                if (ai != null)
+                if (ai != null && ai.isActiveAndEnabled)
                     ai.Teleport(transform.position);
                 else
                     ai?.SearchPath();


### PR DESCRIPTION
## Summary
- ensure HeroController doesn't teleport when its AIPath isn't ready

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_687a182d45c0832ea3ae3b4b986e5f17