### PR TITLE
Add hero cloning buff system

### DIFF
--- a/Assets/Scripts/Buffs/BuffManager.cs
+++ b/Assets/Scripts/Buffs/BuffManager.cs
@@ -109,6 +109,7 @@ namespace TimelessEchoes.Buffs
                     activeBuffs.RemoveAt(i);
                     if (buff.recipe != null)
                         TELogger.Log($"Buff {buff.recipe.name} expired", TELogCategory.Buff, this);
+                    HandleBuffEnded(buff);
                 }
             }
         }
@@ -148,6 +149,7 @@ namespace TimelessEchoes.Buffs
                 buff = new ActiveBuff { recipe = recipe, remaining = recipe.baseDuration, expireAtDistance = expireDist };
                 activeBuffs.Add(buff);
                 TELogger.Log($"Buff {recipe.name} added", TELogCategory.Buff, this);
+                HandleBuffStarted(buff);
             }
             else
             {
@@ -288,6 +290,8 @@ namespace TimelessEchoes.Buffs
 
         public void ClearActiveBuffs()
         {
+            foreach (var buff in activeBuffs)
+                HandleBuffEnded(buff);
             activeBuffs.Clear();
         }
 
@@ -301,8 +305,59 @@ namespace TimelessEchoes.Buffs
                     activeBuffs.RemoveAt(i);
                     if (buff.recipe != null)
                         TELogger.Log($"Buff {buff.recipe.name} expired", TELogCategory.Buff, this);
+                    HandleBuffEnded(buff);
                 }
             }
+        }
+
+        private void HandleBuffStarted(ActiveBuff buff)
+        {
+            if (buff?.recipe == null || buff.recipe.heroClones <= 0)
+                return;
+
+            var hero = TimelessEchoes.Hero.HeroController.Instance ??
+                       FindFirstObjectByType<TimelessEchoes.Hero.HeroController>();
+            if (hero == null)
+                return;
+
+            for (int i = 0; i < buff.recipe.heroClones; i++)
+            {
+                var cloneObj = Object.Instantiate(hero.gameObject, hero.transform.parent);
+                cloneObj.name = hero.gameObject.name + "_Clone";
+                var controller = cloneObj.GetComponent<TimelessEchoes.Hero.HeroController>();
+                if (controller != null)
+                {
+                    controller.isClone = true;
+                }
+
+                var health = cloneObj.GetComponent<TimelessEchoes.Hero.HeroHealth>();
+                if (health != null)
+                    Object.Destroy(health);
+                cloneObj.AddComponent<TimelessEchoes.Hero.CloneHeroHealth>();
+
+                foreach (var sr in cloneObj.GetComponentsInChildren<SpriteRenderer>())
+                {
+                    var c = sr.color;
+                    c.a *= 0.7f;
+                    sr.color = c;
+                }
+
+                var marker = cloneObj.AddComponent<TimelessEchoes.Hero.HeroCloneMarker>();
+                marker.ownerBuff = buff;
+
+                buff.clones.Add(controller);
+            }
+        }
+
+        private void HandleBuffEnded(ActiveBuff buff)
+        {
+            if (buff == null) return;
+            foreach (var clone in buff.clones)
+            {
+                if (clone != null)
+                    Object.Destroy(clone.gameObject);
+            }
+            buff.clones.Clear();
         }
 
 
@@ -312,6 +367,7 @@ namespace TimelessEchoes.Buffs
             public BuffRecipe recipe;
             public float remaining;
             public float expireAtDistance = float.PositiveInfinity;
+            public List<TimelessEchoes.Hero.HeroController> clones = new();
         }
     }
 }

--- a/Assets/Scripts/Buffs/BuffRecipe.cs
+++ b/Assets/Scripts/Buffs/BuffRecipe.cs
@@ -24,6 +24,8 @@ namespace TimelessEchoes.Buffs
         [Range(-100f, 100f)] public float attackSpeedPercent;
         [Tooltip("Percent of damage returned as health while active.")]
         [Range(0f, 100f)] public float lifestealPercent;
+        [Tooltip("Number of hero clones spawned while active.")]
+        [Min(0)] public int heroClones;
         [Tooltip("Tasks complete instantly while active.")]
         public bool instantTasks;
         [Tooltip("Percent of longest run distance this buff remains active. 0 = no distance limit")]

--- a/Assets/Scripts/Hero/CloneHeroHealth.cs
+++ b/Assets/Scripts/Hero/CloneHeroHealth.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+
+namespace TimelessEchoes.Hero
+{
+    /// <summary>
+    /// Hero health variant used by clones. Prevents death while active.
+    /// </summary>
+    public class CloneHeroHealth : HeroHealth
+    {
+        protected override void OnZeroHealth()
+        {
+            // Clones are immortal; reset to max health instead of dying.
+            CurrentHealth = MaxHealth;
+            RaiseHealthChanged();
+        }
+    }
+}

--- a/Assets/Scripts/Hero/HeroCloneMarker.cs
+++ b/Assets/Scripts/Hero/HeroCloneMarker.cs
@@ -1,0 +1,13 @@
+using TimelessEchoes.Buffs;
+using UnityEngine;
+
+namespace TimelessEchoes.Hero
+{
+    /// <summary>
+    /// Marker component used to track clone heroes spawned by a buff.
+    /// </summary>
+    public class HeroCloneMarker : MonoBehaviour
+    {
+        public BuffManager.ActiveBuff ownerBuff;
+    }
+}

--- a/Assets/Scripts/Tasks/BaseTask.cs
+++ b/Assets/Scripts/Tasks/BaseTask.cs
@@ -15,6 +15,40 @@ namespace TimelessEchoes.Tasks
         [SerializeField] public TaskData taskData;
 
         private float lastGrantedXp;
+        private HeroController claimedBy;
+
+        /// <summary>
+        /// Hero that has claimed this task or null if unclaimed.
+        /// </summary>
+        public HeroController ClaimedBy => claimedBy;
+
+        /// <summary>
+        /// True if the task has been claimed by any hero.
+        /// </summary>
+        public bool IsClaimed => claimedBy != null;
+
+        /// <summary>
+        /// Attempt to claim the task for a hero.
+        /// </summary>
+        public bool Claim(HeroController hero)
+        {
+            if (hero == null) return false;
+            if (claimedBy == null || claimedBy == hero)
+            {
+                claimedBy = hero;
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Release the claim if held by the given hero.
+        /// </summary>
+        public void ReleaseClaim(HeroController hero)
+        {
+            if (hero != null && claimedBy == hero)
+                claimedBy = null;
+        }
 
         public float LastGrantedXp => lastGrantedXp;
 


### PR DESCRIPTION
## Summary
- allow BuffRecipe to configure hero clones
- track spawned clones in BuffManager and clean up when buff ends
- make tasks claimable and assign tasks per hero
- adjust HeroController for clone support
- add immortal CloneHeroHealth and marker components

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a1e15e678832e8961dd632be0f519