### PR TITLE
Track times the reaper has reaped

### DIFF
--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -142,6 +142,7 @@ namespace Blindsided.SaveData
             public int Deaths;
             public float DamageDealt;
             public float DamageTaken;
+            public int TimesReaped;
             public double TotalResourcesGathered;
 
             // Records for the most recent runs. Limited to the last 50.

--- a/Assets/Scripts/Enemies/ReaperManager.cs
+++ b/Assets/Scripts/Enemies/ReaperManager.cs
@@ -78,6 +78,9 @@ namespace TimelessEchoes.Enemies
             if (target == null) return;
             var hp = target.GetComponent<IHasHealth>();
             var dmg = target.GetComponent<IDamageable>();
+            var tracker = GameplayStatTracker.Instance ??
+                          FindFirstObjectByType<GameplayStatTracker>();
+
             if (hp != null && dmg != null && hp.CurrentHealth > 0f)
             {
                 var amount = hp.CurrentHealth;
@@ -87,8 +90,6 @@ namespace TimelessEchoes.Enemies
                 dmg.TakeDamage(amount);
                 if (fromHero)
                 {
-                    var tracker = GameplayStatTracker.Instance ??
-                                  FindFirstObjectByType<GameplayStatTracker>();
                     tracker?.AddDamageDealt(amount);
                     var buff = BuffManager.Instance ??
                                FindFirstObjectByType<BuffManager>();
@@ -103,6 +104,8 @@ namespace TimelessEchoes.Enemies
                     }
                 }
             }
+
+            tracker?.AddTimesReaped();
 
             onKill?.Invoke();
             target = null;

--- a/Assets/Scripts/Stats/GameplayStatTracker.cs
+++ b/Assets/Scripts/Stats/GameplayStatTracker.cs
@@ -38,6 +38,8 @@ namespace TimelessEchoes.Stats
 
         public float DamageTaken { get; private set; }
 
+        public int TimesReaped { get; private set; }
+
         public double TotalResourcesGathered { get; private set; }
 
         public IReadOnlyList<GameData.RunRecord> RecentRuns => recentRuns;
@@ -109,6 +111,7 @@ namespace TimelessEchoes.Stats
             g.Deaths = Deaths;
             g.DamageDealt = DamageDealt;
             g.DamageTaken = DamageTaken;
+            g.TimesReaped = TimesReaped;
             g.TotalResourcesGathered = TotalResourcesGathered;
             g.RecentRuns = new List<GameData.RunRecord>(recentRuns);
             g.LongestRun = LongestRun;
@@ -140,6 +143,7 @@ namespace TimelessEchoes.Stats
             Deaths = g.Deaths;
             DamageDealt = g.DamageDealt;
             DamageTaken = g.DamageTaken;
+            TimesReaped = g.TimesReaped;
             TotalResourcesGathered = g.TotalResourcesGathered;
             recentRuns.Clear();
             if (g.RecentRuns != null)
@@ -231,6 +235,11 @@ namespace TimelessEchoes.Stats
                 DamageTaken += amount;
                 currentRunDamageTaken += amount;
             }
+        }
+
+        public void AddTimesReaped()
+        {
+            TimesReaped++;
         }
 
         public void AddResources(double amount, bool bonus = false)

--- a/Assets/Scripts/Steamworks.NET/SteamStatsUpdater.cs
+++ b/Assets/Scripts/Steamworks.NET/SteamStatsUpdater.cs
@@ -105,6 +105,16 @@ namespace TimelessEchoes
                 }
             }
 
+            if (SteamUserStats.GetStat("TimesReaped", out int storedReaps))
+            {
+                int newReaps = tracker.TimesReaped;
+                if (newReaps > storedReaps)
+                {
+                    SteamUserStats.SetStat("TimesReaped", newReaps);
+                    changed = true;
+                }
+            }
+
             if (changed)
                 SteamUserStats.StoreStats();
         }


### PR DESCRIPTION
## Summary
- add `TimesReaped` stat to save data
- count reaper kills in `ReaperManager`
- expose new stat in `GameplayStatTracker`
- push new value to Steam via `SteamStatsUpdater`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ab881a03c832ea9a9a10ad7b0a242