### PR TITLE
Add echo tinting based on single skill

### DIFF
--- a/Assets/Scripts/Hero/EchoManager.cs
+++ b/Assets/Scripts/Hero/EchoManager.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using TimelessEchoes.Skills;
 using TimelessEchoes.Tasks;
 using UnityEngine;
@@ -28,13 +29,41 @@ namespace TimelessEchoes.Hero
                 {
                     var c = r.color;
                     c.a = 0.7f;
+                    var newColor = c;
 
                     // Combat only echoes should appear slightly red to
                     // differentiate them from regular echoes.
                     if (combat && disableSkills)
-                        r.color = new Color(1f, 0.5f, 0.5f, c.a);
-                    else
-                        r.color = c;
+                    {
+                        newColor = new Color(1f, 0.5f, 0.5f, c.a);
+                    }
+                    else if (!disableSkills && skills != null)
+                    {
+                        var list = skills.Where(s => s != null).ToList();
+                        if (list.Count == 1)
+                        {
+                            switch (list[0].skillName)
+                            {
+                                case "Farming":
+                                    newColor = new Color(1f, 1f, 0f, c.a); // Yellow
+                                    break;
+                                case "Woodcutting":
+                                    newColor = new Color(0f, 1f, 0f, c.a); // Green
+                                    break;
+                                case "Fishing":
+                                    newColor = new Color(0f, 0.6f, 1f, c.a); // Blue
+                                    break;
+                                case "Mining":
+                                    newColor = new Color(1f, 0.65f, 0f, c.a); // Orange
+                                    break;
+                                case "Looting":
+                                    newColor = new Color(0.6f, 0f, 0.8f, c.a); // Purple
+                                    break;
+                            }
+                        }
+                    }
+
+                    r.color = newColor;
                 }
 
                 // Echoes share the primary hero's health. Keep the existing


### PR DESCRIPTION
## Summary
- tint echoes based on single-skill capability

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-6.0` *(fails: Package has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_687cc9d99e2c832e9374612a52beb3f7