### PR TITLE
Skip quest cost slots for distance and instant types

### DIFF
--- a/Assets/Scripts/Quests/QuestEntryUI.cs
+++ b/Assets/Scripts/Quests/QuestEntryUI.cs
@@ -71,6 +71,13 @@ namespace TimelessEchoes.Quests
                     var resourceManager = ResourceManager.Instance;
                     foreach (var req in data.requirements)
                     {
+                        if (req.type == QuestData.RequirementType.Instant ||
+                            req.type == QuestData.RequirementType.DistanceRun ||
+                            req.type == QuestData.RequirementType.DistanceTravel)
+                        {
+                            continue;
+                        }
+
                         var slot = Instantiate(costSlotPrefab, costParent);
                         slot.resource = req.type == QuestData.RequirementType.Resource ||
                                         req.type == QuestData.RequirementType.Donation


### PR DESCRIPTION
## Summary
- skip creating cost slot prefabs on `QuestEntryUI` when the quest requirement type is Instant or any distance-based type

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687dec7c570c832e81216f7f87dd14ae