### PR TITLE
Implement Meet quest requirement type

### DIFF
--- a/Assets/Scripts/Quests/QuestData.cs
+++ b/Assets/Scripts/Quests/QuestData.cs
@@ -35,6 +35,8 @@ namespace TimelessEchoes.Quests
             public List<EnemyStats> enemies = new();
             [ShowIf("type", RequirementType.Kill)]
             public Sprite killIcon;
+            [ShowIf("type", RequirementType.Meet)]
+            public string meetNpcId;
         }
 
         public enum RequirementType
@@ -44,7 +46,8 @@ namespace TimelessEchoes.Quests
             Donation,
             DistanceRun,
             DistanceTravel,
-            Instant
+            Instant,
+            Meet
         }
     }
 }

--- a/Assets/Scripts/Quests/QuestEntryUI.cs
+++ b/Assets/Scripts/Quests/QuestEntryUI.cs
@@ -73,7 +73,8 @@ namespace TimelessEchoes.Quests
                     {
                         if (req.type == QuestData.RequirementType.Instant ||
                             req.type == QuestData.RequirementType.DistanceRun ||
-                            req.type == QuestData.RequirementType.DistanceTravel)
+                            req.type == QuestData.RequirementType.DistanceTravel ||
+                            req.type == QuestData.RequirementType.Meet)
                         {
                             continue;
                         }
@@ -103,7 +104,8 @@ namespace TimelessEchoes.Quests
                                 slot.iconImage.color = Color.white;
                             }
                             else if (req.type == QuestData.RequirementType.DistanceRun ||
-                                     req.type == QuestData.RequirementType.DistanceTravel)
+                                     req.type == QuestData.RequirementType.DistanceTravel ||
+                                     req.type == QuestData.RequirementType.Meet)
                             {
                                 slot.iconImage.sprite = null;
                                 slot.iconImage.color = Color.white;
@@ -166,7 +168,8 @@ namespace TimelessEchoes.Quests
                     slot.iconImage.color = Color.white;
                 }
                 else if (req.type == QuestData.RequirementType.DistanceRun ||
-                         req.type == QuestData.RequirementType.DistanceTravel)
+                         req.type == QuestData.RequirementType.DistanceTravel ||
+                         req.type == QuestData.RequirementType.Meet)
                 {
                     slot.iconImage.sprite = null;
                     slot.iconImage.color = Color.white;
@@ -198,6 +201,8 @@ namespace TimelessEchoes.Quests
                     return "Travel";
                 case QuestData.RequirementType.Instant:
                     return "Instant";
+                case QuestData.RequirementType.Meet:
+                    return "Meet";
                 default:
                     return type.ToString();
             }

--- a/Assets/Scripts/Quests/QuestManager.cs
+++ b/Assets/Scripts/Quests/QuestManager.cs
@@ -223,6 +223,12 @@ namespace TimelessEchoes.Quests
                 {
                     pct = 1f;
                 }
+                else if (req.type == QuestData.RequirementType.Meet)
+                {
+                    if (!string.IsNullOrEmpty(req.meetNpcId) &&
+                        StaticReferences.CompletedNpcTasks.Contains(req.meetNpcId))
+                        pct = 1f;
+                }
 
                 progress += Mathf.Clamp01(pct);
             }
@@ -282,6 +288,7 @@ namespace TimelessEchoes.Quests
             achievementManager?.NotifyNpcMet(id);
 #endif
             RefreshNoticeboard();
+            UpdateAllProgress();
         }
 
         /// <summary>

--- a/Assets/Scripts/Tests/Editor/QuestManagerTests.cs
+++ b/Assets/Scripts/Tests/Editor/QuestManagerTests.cs
@@ -83,6 +83,35 @@ namespace TimelessEchoes.Tests
 
             Object.DestroyImmediate(next);
         }
+
+        [Test]
+        public void MeetRequirement_CompletesOnNpcMet()
+        {
+            var req = new QuestData.Requirement
+            {
+                type = QuestData.RequirementType.Meet,
+                meetNpcId = "NPC2"
+            };
+            quest.requirements.Add(req);
+
+            typeof(QuestManager).GetField("quests", BindingFlags.NonPublic | BindingFlags.Instance)
+                .SetValue(manager, new List<QuestData> { quest });
+
+            StaticReferences.CompletedNpcTasks.Add("NPC1");
+            manager.OnNpcMet("NPC1");
+
+            var field = typeof(QuestManager).GetField("active", BindingFlags.NonPublic | BindingFlags.Instance);
+            var dict = (System.Collections.IDictionary)field.GetValue(manager);
+            Assert.IsTrue(dict.Contains("Q1"));
+            var inst = dict["Q1"];
+            var readyField = inst.GetType().GetField("ReadyForTurnIn");
+            Assert.IsFalse((bool)readyField.GetValue(inst));
+
+            StaticReferences.CompletedNpcTasks.Add("NPC2");
+            manager.OnNpcMet("NPC2");
+
+            Assert.IsTrue((bool)readyField.GetValue(inst));
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- support a new `Meet` quest requirement
- show `meetNpcId` field in the editor when `Meet` is selected
- treat `Meet` requirements in quest UI
- update quest progress when relevant NPCs are met
- add unit test for the new requirement type

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687df204dc14832ea3c37d69fe2a086d