### PR TITLE
Fix echo targeting logic

### DIFF
--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -455,7 +455,7 @@ namespace TimelessEchoes.Hero
             }
 
             var nearest = allowAttacks && currentEnemy != null ? currentEnemy : null;
-            if (allowAttacks && nearest == null)
+            if (IsEcho && allowAttacks && nearest == null)
             {
                 var range = UnlimitedAggroRange ? float.PositiveInfinity : stats.visionRange;
                 nearest = FindNearestEnemy(range);


### PR DESCRIPTION
## Summary
- avoid enemy searches for main hero by limiting target acquisition logic to echoes

## Testing
- `npx unity-test-runner -h` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ea8d03e50832eaccdb2a3c9646628