### PR TITLE
Ensure echoes wait for initialization before claiming tasks

### DIFF
--- a/Assets/Scripts/Hero/EchoController.cs
+++ b/Assets/Scripts/Hero/EchoController.cs
@@ -24,6 +24,11 @@ namespace TimelessEchoes.Hero
         private float remaining;
         private bool initialized;
 
+        /// <summary>
+        /// Returns true once <see cref="Init"/> has completed.
+        /// </summary>
+        public bool Initialized => initialized;
+
         private void Awake()
         {
             hero = GetComponent<HeroController>();

--- a/Assets/Scripts/Tasks/TaskController.cs
+++ b/Assets/Scripts/Tasks/TaskController.cs
@@ -204,6 +204,11 @@ namespace TimelessEchoes.Tasks
             SortTaskListsByProximity();
 
             hero?.SetTask(null);
+
+            var echo = hero != null ? hero.GetComponent<EchoController>() : null;
+            if (hero != null && hero.IsEcho && (echo == null || !echo.Initialized))
+                return;
+
             SelectEarliestTask(hero);
         }
 


### PR DESCRIPTION
## Summary
- expose `Initialized` status on `EchoController`
- prevent `TaskController` from assigning tasks to echoes until initialization is complete

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687ebe648904832ea02c7cabdc6d9978