### PR TITLE
Bugfix: Only track main hero distance

### DIFF
--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -210,7 +210,7 @@ namespace TimelessEchoes.Hero
                               (buffController != null ? buffController.MoveSpeedMultiplier : 1f);
             UpdateAnimation();
             UpdateBehavior();
-            if (mapUI != null)
+            if (!IsEcho && mapUI != null)
                 mapUI.UpdateDistance(transform.position.x);
 
             var tracker = GameplayStatTracker.Instance;


### PR DESCRIPTION
## Summary
- fix distance UI calculation to ignore echo clones

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687f2a6d8578832e8da168e76ebcd5ae