### PR TITLE
Fix edge-only task spawning

### DIFF
--- a/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
+++ b/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
@@ -520,7 +520,7 @@ namespace TimelessEchoes.Tasks
 
         private bool IsEdge(Vector3Int cell, TileBase tile, int offset = 0)
         {
-            var range = offset + 1;
+            var range = offset;
             for (var dx = -range; dx <= range; dx++)
             for (var dy = -range; dy <= range; dy++)
             {
@@ -577,14 +577,6 @@ namespace TimelessEchoes.Tasks
                 var areaBottom = terrainMap.WorldToCell(transform.position).y;
                 var bottomLimit = Mathf.Max(areaBottom + bottomBuffer, terrainMap.cellBounds.yMin);
                 if (cell.y < bottomLimit)
-                    return false;
-
-                var areaLeft = terrainMap.WorldToCell(new Vector3(transform.position.x + minX, transform.position.y, 0f)).x;
-                var areaRight = terrainMap.WorldToCell(new Vector3(transform.position.x + maxX, transform.position.y, 0f)).x;
-                var leftLimit = Mathf.Max(areaLeft, terrainMap.cellBounds.xMin);
-                var rightLimit = Mathf.Min(areaRight, terrainMap.cellBounds.xMax);
-                var offset = settings.taskSettings.edgeOffset;
-                if (cell.x > leftLimit + offset && cell.x < rightLimit - offset)
                     return false;
 
                 return isEdge;


### PR DESCRIPTION
## Summary
- allow edge-only tasks anywhere on a terrain instead of just along the area's left/right edges
- tweak edge detection offset math

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6881834e9e98832e99346fb5d70ee618