### PR TITLE
Add max run distance with reaper trigger

### DIFF
--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -159,6 +159,7 @@ namespace Blindsided.SaveData
             public float LongestRun;
             public float ShortestRun;
             public float AverageRun;
+            public float MaxRunDistance = 50f;
             public int NextRunNumber = 1;
         }
 

--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -107,6 +107,8 @@ namespace TimelessEchoes.Hero
 
         private bool logicActive = true;
 
+        private bool reaperSpawnedByDistance;
+
         private float damageBonus;
         private float defenseBonus;
 
@@ -254,6 +256,16 @@ namespace TimelessEchoes.Hero
 #if !DISABLESTEAMWORKS
                 RichPresenceManager.Instance?.UpdateDistance(tracker.CurrentRunDistance);
 #endif
+                if (!IsEcho && !reaperSpawnedByDistance && transform.position.x >= tracker.MaxRunDistance)
+                {
+                    var gm = GameManager.Instance;
+                    var hp = health != null ? health : GetComponent<HeroHealth>();
+                    if (gm != null && hp != null && hp.CurrentHealth > 0f && gm.ReaperPrefab != null && gm.CurrentMap != null)
+                    {
+                        ReaperManager.Spawn(gm.ReaperPrefab, gameObject, gm.CurrentMap.transform, false, null, gm.ReaperSpawnOffset);
+                        reaperSpawnedByDistance = true;
+                    }
+                }
             }
         }
 
@@ -277,6 +289,8 @@ namespace TimelessEchoes.Hero
 
             if (!IsEcho)
                 buffController?.Resume();
+
+            reaperSpawnedByDistance = false;
 
             if (mapUI == null)
                 mapUI = FindFirstObjectByType<MapUI>();

--- a/Assets/Scripts/Quests/QuestData.cs
+++ b/Assets/Scripts/Quests/QuestData.cs
@@ -22,6 +22,7 @@ namespace TimelessEchoes.Quests
         public GameObject unlockPrefab;
         public List<GameObject> unlockObjects = new();
         public int unlockBuffSlots;
+        public float maxDistanceIncrease;
 
         [Serializable]
         public class Requirement

--- a/Assets/Scripts/Quests/QuestManager.cs
+++ b/Assets/Scripts/Quests/QuestManager.cs
@@ -257,6 +257,8 @@ namespace TimelessEchoes.Quests
                     obj.SetActive(true);
             if (inst.data.unlockBuffSlots > 0)
                 BuffManager.Instance?.UnlockSlots(inst.data.unlockBuffSlots);
+            if (inst.data.maxDistanceIncrease > 0f)
+                GameplayStatTracker.Instance?.IncreaseMaxRunDistance(inst.data.maxDistanceIncrease);
             if (!string.IsNullOrEmpty(inst.data.npcId))
                 StaticReferences.CompletedNpcTasks.Add(inst.data.npcId);
             if (inst.ui != null)

--- a/Assets/Scripts/Stats/GameplayStatTracker.cs
+++ b/Assets/Scripts/Stats/GameplayStatTracker.cs
@@ -64,6 +64,8 @@ namespace TimelessEchoes.Stats
 
         public float AverageRun { get; private set; }
 
+        public float MaxRunDistance { get; private set; } = 50f;
+
         public int CurrentRunKills { get; private set; }
 
         public double CurrentRunBonusResources { get; private set; }
@@ -136,6 +138,7 @@ namespace TimelessEchoes.Stats
             g.LongestRun = LongestRun;
             g.ShortestRun = ShortestRun;
             g.AverageRun = AverageRun;
+            g.MaxRunDistance = MaxRunDistance;
             g.NextRunNumber = nextRunNumber;
             oracle.saveData.General = g;
         }
@@ -172,6 +175,7 @@ namespace TimelessEchoes.Stats
             LongestRun = g.LongestRun;
             ShortestRun = g.ShortestRun;
             AverageRun = g.AverageRun;
+            MaxRunDistance = g.MaxRunDistance > 0f ? g.MaxRunDistance : 50f;
             if (g.NextRunNumber > 0)
                 nextRunNumber = g.NextRunNumber;
             else if (recentRuns.Count > 0)
@@ -289,6 +293,13 @@ namespace TimelessEchoes.Stats
                         CurrentRunBonusResources += amount;
                 }
             }
+        }
+
+        public void IncreaseMaxRunDistance(float amount)
+        {
+            if (amount <= 0f) return;
+            MaxRunDistance += amount;
+            SaveState();
         }
 
         public void BeginRun()

--- a/Assets/Scripts/UI/MapUI.cs
+++ b/Assets/Scripts/UI/MapUI.cs
@@ -1,5 +1,6 @@
 using TMPro;
 using UnityEngine;
+using Blindsided.Utilities;
 
 namespace TimelessEchoes.UI
 {
@@ -9,6 +10,17 @@ namespace TimelessEchoes.UI
     public class MapUI : MonoBehaviour
     {
         [SerializeField] private TMP_Text distanceText;
+        [SerializeField] private Blindsided.Utilities.SlicedFilledImage distanceSlider;
+        [SerializeField] private GameObject distanceSliderPrefab;
+
+        private void Awake()
+        {
+            if (distanceSlider == null && distanceSliderPrefab != null)
+            {
+                var obj = Instantiate(distanceSliderPrefab, transform);
+                distanceSlider = obj.GetComponent<Blindsided.Utilities.SlicedFilledImage>();
+            }
+        }
 
         /// <summary>
         ///     Updates the UI with the distance the hero has reached.
@@ -16,9 +28,18 @@ namespace TimelessEchoes.UI
         /// <param name="distance">The hero's X position.</param>
         public void UpdateDistance(float distance)
         {
-            if (distanceText == null) return;
-            int x = Mathf.FloorToInt(distance);
-            distanceText.text = $"Distance Reached: {x}";
+            if (distanceText != null)
+            {
+                int x = Mathf.FloorToInt(distance);
+                distanceText.text = $"Distance Reached: {x}";
+            }
+
+            if (distanceSlider != null)
+            {
+                var tracker = TimelessEchoes.Stats.GameplayStatTracker.Instance;
+                var max = tracker != null ? tracker.MaxRunDistance : 1f;
+                distanceSlider.fillAmount = Mathf.Clamp01(distance / max);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- track a MaxRunDistance value in saved GeneralStats and GameplayStatTracker
- add IncreaseMaxRunDistance helper and save/load logic
- auto-spawn the reaper when hero exceeds max distance
- expose a max distance reward on quests and apply it on completion
- show distance progress with a slider on MapUI
- initialize the MaxRunDistance default to 50

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885883fbe24832ea375c89f5177c6a9