### PR TITLE
Enhance website with responsive design and wiki pages

### DIFF
--- a/Website/index.html
+++ b/Website/index.html
@@ -4,42 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Echoes of Vasteria</title>
-    <style>
-        /* Colors from the Endesga-64 palette */
-        body {
-            font-family: Arial, sans-serif;
-            margin: 0;
-            padding: 0;
-            background-color: #262b44;
-            color: #c0cbdc;
-        }
-        header {
-            background-color: #181425;
-            color: #fee761;
-            padding: 20px;
-            text-align: center;
-        }
-        nav {
-            background-color: #3a4466;
-            padding: 10px;
-            text-align: center;
-        }
-        nav a {
-            color: #fee761;
-            margin: 0 10px;
-            text-decoration: none;
-        }
-        nav a:hover {
-            color: #ff0044;
-        }
-        main { padding: 20px; }
-        footer {
-            background-color: #181425;
-            color: #c0cbdc;
-            text-align: center;
-            padding: 10px;
-        }
-    </style>
+    <link rel="stylesheet" href="style.css">
 </head>
 <body>
     <header>

--- a/Website/style.css
+++ b/Website/style.css
@@ -1,0 +1,59 @@
+:root {
+  --bg-color: #c0cbdc;
+  --text-color: #181425;
+  --header-bg: #63c74d;
+  --nav-bg: #3e8948;
+  --accent-color: #0099db;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg-color: #181425;
+    --text-color: #c0cbdc;
+    --header-bg: #124e89;
+    --nav-bg: #262b44;
+    --accent-color: #2ce8f5;
+  }
+}
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  background-color: var(--bg-color);
+  color: var(--text-color);
+}
+header {
+  background-color: var(--header-bg);
+  color: var(--text-color);
+  padding: 20px;
+  text-align: center;
+}
+nav {
+  background-color: var(--nav-bg);
+  padding: 10px;
+  text-align: center;
+}
+nav a {
+  color: var(--accent-color);
+  margin: 0 10px;
+  text-decoration: none;
+}
+nav a:hover {
+  color: #fee761;
+}
+main {
+  padding: 20px;
+  max-width: 800px;
+  margin: auto;
+}
+footer {
+  background-color: var(--header-bg);
+  color: var(--text-color);
+  text-align: center;
+  padding: 10px;
+}
+@media (max-width: 600px) {
+  nav a {
+    display: block;
+    margin: 5px 0;
+  }
+}

--- a/Website/wiki/index.html
+++ b/Website/wiki/index.html
@@ -4,41 +4,26 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Echoes of Vasteria Wiki</title>
+    <link rel="stylesheet" href="../style.css">
     <style>
-        /* Colors from the Endesga-64 palette */
-        body {
-            font-family: Arial, sans-serif;
-            margin: 0;
-            padding: 0;
-            background-color: #262b44;
-            color: #c0cbdc;
-        }
-        header {
-            background-color: #181425;
-            color: #fee761;
+        main {
             padding: 20px;
-            text-align: center;
+            max-width: 800px;
+            margin: auto;
         }
-        nav {
-            background-color: #3a4466;
-            padding: 10px;
-            text-align: center;
-        }
-        nav a {
-            color: #fee761;
-            margin: 0 10px;
-            text-decoration: none;
-        }
-        nav a:hover {
-            color: #ff0044;
-        }
-        main { padding: 20px; }
         section { margin-bottom: 40px; }
-        footer {
-            background-color: #181425;
-            color: #c0cbdc;
-            text-align: center;
-            padding: 10px;
+        #sidebar {
+            border-right: 1px solid var(--nav-bg);
+            padding-right: 10px;
+            margin-right: 20px;
+        }
+        @media (min-width: 768px) {
+            .wiki-container {
+                display: flex;
+            }
+            #sidebar {
+                width: 200px;
+            }
         }
     </style>
 </head>
@@ -50,6 +35,15 @@
         <a href="../index.html">Home</a>
         <a href="index.html">Wiki Home</a>
     </nav>
+    <div class="wiki-container">
+    <aside id="sidebar">
+        <h2>Slimes</h2>
+        <ul>
+            <li><a href="small.html">Small Green Slime</a></li>
+            <li><a href="medium.html">Medium Green Slime</a></li>
+            <li><a href="large.html">Large Green Slime</a></li>
+        </ul>
+    </aside>
     <main>
         <section id="tasks">
             <h2>Tasks</h2>
@@ -64,6 +58,7 @@
             <p>Check back for more details on mechanics, gear upgrades, and strategies as the wiki expands.</p>
         </section>
     </main>
+    </div>
     <footer>
         &copy; 2024 Echoes of Vasteria
     </footer>

--- a/Website/wiki/large.html
+++ b/Website/wiki/large.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Large Green Slime</title>
+    <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+    <header>
+        <h1>Large Green Slime</h1>
+    </header>
+    <nav>
+        <a href="../index.html">Home</a>
+        <a href="index.html">Wiki Home</a>
+    </nav>
+    <main>
+        <p>The largest of the green slimes. It is slow but can deal significant damage.</p>
+        <img src="../images/Slime_Big_Green.png" alt="Large Green Slime sprite" />
+    </main>
+    <footer>
+        &copy; 2024 Echoes of Vasteria
+    </footer>
+</body>
+</html>

--- a/Website/wiki/medium.html
+++ b/Website/wiki/medium.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Medium Green Slime</title>
+    <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+    <header>
+        <h1>Medium Green Slime</h1>
+    </header>
+    <nav>
+        <a href="../index.html">Home</a>
+        <a href="index.html">Wiki Home</a>
+    </nav>
+    <main>
+        <p>A sturdier version of the green slime. It has moderate health and can take a few hits.</p>
+        <img src="../images/Slime_Medium_Green.png" alt="Medium Green Slime sprite" />
+    </main>
+    <footer>
+        &copy; 2024 Echoes of Vasteria
+    </footer>
+</body>
+</html>

--- a/Website/wiki/small.html
+++ b/Website/wiki/small.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Small Green Slime</title>
+    <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+    <header>
+        <h1>Small Green Slime</h1>
+    </header>
+    <nav>
+        <a href="../index.html">Home</a>
+        <a href="index.html">Wiki Home</a>
+    </nav>
+    <main>
+        <p>The smallest variant of green slime. These weak creatures often appear in groups.</p>
+        <img src="../images/Slime_Small_Green.png" alt="Small Green Slime sprite" />
+    </main>
+    <footer>
+        &copy; 2024 Echoes of Vasteria
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- use shared `style.css` and switch color palette to blue/green tones
- support light/dark mode using `prefers-color-scheme`
- update site nav and layout for responsiveness
- rework wiki layout with sidebar
- add pages for small, medium and large green slimes

## Testing
- `tidy -q Website/index.html`
- `tidy -q Website/wiki/index.html`
- `tidy -q Website/wiki/small.html`
- `tidy -q Website/wiki/medium.html`
- `tidy -q Website/wiki/large.html`


------
https://chatgpt.com/codex/tasks/task_e_6885a725f7cc832ea0fa691d87558695