### PR TITLE
Fix copyright year

### DIFF
--- a/Website/index.html
+++ b/Website/index.html
@@ -24,7 +24,7 @@
         </section>
     </main>
     <footer>
-        &copy; 2024 Echoes of Vasteria
+        &copy; 2025 Echoes of Vasteria
     </footer>
 </body>
 </html>

--- a/Website/wiki/green.html
+++ b/Website/wiki/green.html
@@ -59,7 +59,7 @@
     </main>
     </div>
     <footer>
-        &copy; 2024 Echoes of Vasteria
+        &copy; 2025 Echoes of Vasteria
     </footer>
 </body>
 </html>

--- a/Website/wiki/index.html
+++ b/Website/wiki/index.html
@@ -49,7 +49,7 @@
     </main>
     </div>
     <footer>
-        &copy; 2024 Echoes of Vasteria
+        &copy; 2025 Echoes of Vasteria
     </footer>
 </body>
 </html>

--- a/Website/wiki/large.html
+++ b/Website/wiki/large.html
@@ -59,7 +59,7 @@
     </main>
     </div>
     <footer>
-        &copy; 2024 Echoes of Vasteria
+        &copy; 2025 Echoes of Vasteria
     </footer>
 </body>
 </html>

--- a/Website/wiki/small.html
+++ b/Website/wiki/small.html
@@ -59,7 +59,7 @@
     </main>
     </div>
     <footer>
-        &copy; 2024 Echoes of Vasteria
+        &copy; 2025 Echoes of Vasteria
     </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- bump the year on the website footer from 2024 to 2025

## Testing
- `grep -R "2025" -n Website`

------
https://chatgpt.com/codex/tasks/task_e_6885d05638b4832e90b42ed5e7e3c791