### PR TITLE
Fix link color and restore sidebar color

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -114,17 +114,21 @@ nav.center-nav {
   justify-content: flex-start;
   align-items: center;
 }
-nav a {
+a {
   color: var(--accent-color);
-  margin: 0 10px;
   text-decoration: none;
+}
+a:hover {
+  text-decoration: underline;
+}
+a:visited {
+  color: var(--accent-color);
+}
+nav a {
+  margin: 0 10px;
 }
 nav a:hover {
   color: #fee761;
-}
-
-a:visited {
-  color: var(--accent-color);
 }
 main {
   flex: 1;
@@ -145,6 +149,7 @@ main > section:last-child {
   flex-shrink: 0;
   padding: 15px;
   box-sizing: border-box;
+  background-color: #265c42;
 }
 
 .dark-mode .sidebar {


### PR DESCRIPTION
## Summary
- ensure anchor tags use the accent color so they never appear blue
- restore a green background on the wiki sidebar

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885f9f47348832e827e08d7ba0daa99