### PR TITLE
Add enable-while-in-progress section

### DIFF
--- a/Assets/Scripts/Quests/QuestManager.cs
+++ b/Assets/Scripts/Quests/QuestManager.cs
@@ -297,6 +297,16 @@ namespace TimelessEchoes.Quests
             return false;
         }
 
+        /// <summary>
+        ///     Returns true if the quest with the given id is currently active.
+        /// </summary>
+        public bool IsQuestInProgress(string questId)
+        {
+            if (string.IsNullOrEmpty(questId))
+                return false;
+            return active.ContainsKey(questId);
+        }
+
         private void TryStartQuest(QuestData quest)
         {
             if (quest == null) return;

--- a/Assets/Scripts/Quests/QuestObjectStateController.cs
+++ b/Assets/Scripts/Quests/QuestObjectStateController.cs
@@ -18,6 +18,7 @@ namespace TimelessEchoes.Quests
             public QuestData quest;
             public List<GameObject> disableUntilComplete = new();
             public List<GameObject> enableUntilComplete = new();
+            public List<GameObject> enableWhileInProgress = new();
         }
 
         [SerializeField]
@@ -65,12 +66,16 @@ namespace TimelessEchoes.Quests
             {
                 if (entry == null) continue;
                 bool completed = entry.quest != null && QuestCompleted(entry.quest.questId);
+                bool inProgress = entry.quest != null && QuestInProgress(entry.quest.questId);
                 foreach (var obj in entry.disableUntilComplete)
                     if (obj != null)
                         obj.SetActive(completed);
                 foreach (var obj in entry.enableUntilComplete)
                     if (obj != null)
                         obj.SetActive(!completed);
+                foreach (var obj in entry.enableWhileInProgress)
+                    if (obj != null)
+                        obj.SetActive(inProgress);
             }
         }
 
@@ -82,6 +87,12 @@ namespace TimelessEchoes.Quests
                 return false;
             Oracle.oracle.saveData.Quests ??= new Dictionary<string, GameData.QuestRecord>();
             return Oracle.oracle.saveData.Quests.TryGetValue(questId, out var rec) && rec.Completed;
+        }
+
+        private static bool QuestInProgress(string questId)
+        {
+            var manager = Object.FindFirstObjectByType<QuestManager>();
+            return manager != null && manager.IsQuestInProgress(questId);
         }
     }
 }


### PR DESCRIPTION
## Summary
- update `QuestObjectStateController` to support objects enabled only while quests are in progress
- expose `IsQuestInProgress` from `QuestManager`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6886ce1cd6f0832ebcce57fb9ebbede9