### PR TITLE
Add pinned quest UI

### DIFF
--- a/Assets/Scripts/Blindsided/Oracle.cs
+++ b/Assets/Scripts/Blindsided/Oracle.cs
@@ -242,6 +242,7 @@ namespace Blindsided
             saveData.SkillData ??= new Dictionary<string, GameData.SkillProgress>();
             saveData.EnemyKills ??= new Dictionary<string, double>();
             saveData.CompletedNpcTasks ??= new HashSet<string>();
+            saveData.PinnedQuests ??= new HashSet<string>();
             saveData.BuffSlots ??= new List<string>(new string[5]);
             if (saveData.BuffSlots.Count < 5)
                 while (saveData.BuffSlots.Count < 5)

--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -38,6 +38,8 @@ namespace Blindsided.SaveData
 
         [HideReferenceObjectPicker] public Dictionary<string, QuestRecord> Quests = new();
 
+        [HideReferenceObjectPicker] public HashSet<string> PinnedQuests = new();
+
         [HideReferenceObjectPicker] public Dictionary<int, TaskRecord> TaskRecords = new();
 
         [HideReferenceObjectPicker] public Dictionary<string, ResourceRecord> ResourceStats = new();

--- a/Assets/Scripts/Quests/PinnedQuestUIManager.cs
+++ b/Assets/Scripts/Quests/PinnedQuestUIManager.cs
@@ -1,0 +1,138 @@
+using System.Collections.Generic;
+using System.Text;
+using Blindsided.SaveData;
+using Blindsided.Utilities;
+using TMPro;
+using UnityEngine;
+using static Blindsided.Oracle;
+
+namespace TimelessEchoes.Quests
+{
+    /// <summary>
+    ///     Displays progress for pinned quests.
+    /// </summary>
+    public class PinnedQuestUIManager : MonoBehaviour
+    {
+        public static PinnedQuestUIManager Instance { get; private set; }
+
+        [SerializeField] private TMP_Text entryPrefab;
+        [SerializeField] private Transform entryParent;
+
+        private readonly Dictionary<string, TMP_Text> entries = new();
+
+        private void Awake()
+        {
+            Instance = this;
+        }
+
+        private void OnDestroy()
+        {
+            if (Instance == this)
+                Instance = null;
+        }
+
+        /// <summary>
+        ///     Builds UI entries for all pinned quest IDs.
+        /// </summary>
+        public void RefreshPins()
+        {
+            if (entryPrefab == null || entryParent == null || oracle == null)
+                return;
+
+            foreach (Transform child in entryParent)
+                Destroy(child.gameObject);
+            entries.Clear();
+
+            foreach (var id in oracle.saveData.PinnedQuests)
+            {
+                if (string.IsNullOrEmpty(id))
+                    continue;
+                var txt = Instantiate(entryPrefab, entryParent);
+                entries[id] = txt;
+            }
+
+            UpdateProgress();
+        }
+
+        /// <summary>
+        ///     Updates progress text for all pinned quests.
+        /// </summary>
+        public void UpdateProgress()
+        {
+            if (oracle == null)
+                return;
+
+            var manager = QuestManager.Instance ?? FindFirstObjectByType<QuestManager>();
+            var resourceManager = TimelessEchoes.Upgrades.ResourceManager.Instance;
+            var tracker = TimelessEchoes.Stats.GameplayStatTracker.Instance;
+
+            foreach (var pair in entries)
+            {
+                var id = pair.Key;
+                var text = pair.Value;
+                if (text == null)
+                    continue;
+
+                var data = manager != null ? manager.GetQuestData(id) : null;
+                if (data == null)
+                {
+                    text.text = id;
+                    continue;
+                }
+
+                oracle.saveData.Quests.TryGetValue(id, out var rec);
+
+                var sb = new StringBuilder();
+                sb.AppendLine(data.questName);
+
+                foreach (var req in data.requirements)
+                {
+                    double current = 0;
+                    double target = req.amount;
+
+                    switch (req.type)
+                    {
+                        case QuestData.RequirementType.Resource:
+                            current = resourceManager ? resourceManager.GetAmount(req.resource) : 0;
+                            break;
+                        case QuestData.RequirementType.Kill:
+                            if (rec != null && req.enemies != null)
+                            {
+                                foreach (var enemy in req.enemies)
+                                {
+                                    if (rec.KillProgress.TryGetValue(enemy.name, out var c))
+                                        current += c;
+                                }
+                            }
+                            break;
+                        case QuestData.RequirementType.DistanceRun:
+                            current = tracker ? tracker.LongestRun : 0f;
+                            break;
+                        case QuestData.RequirementType.DistanceTravel:
+                            current = tracker ? tracker.DistanceTravelled : 0f;
+                            if (rec != null)
+                                current -= rec.DistanceBaseline;
+                            break;
+                        case QuestData.RequirementType.Instant:
+                            current = target;
+                            break;
+                        case QuestData.RequirementType.Meet:
+                            current = !string.IsNullOrEmpty(req.meetNpcId) &&
+                                      StaticReferences.CompletedNpcTasks.Contains(req.meetNpcId)
+                                ? target
+                                : 0;
+                            break;
+                    }
+
+                    if (target <= 0)
+                        sb.AppendLine(CalcUtils.FormatNumber(current, true));
+                    else
+                        sb.AppendLine($"{CalcUtils.FormatNumber(current, true)} / {CalcUtils.FormatNumber(target, true)}");
+                }
+
+                text.text = sb.ToString();
+            }
+        }
+    }
+}
+

--- a/Assets/Scripts/Quests/QuestEntryUI.cs
+++ b/Assets/Scripts/Quests/QuestEntryUI.cs
@@ -23,6 +23,7 @@ namespace TimelessEchoes.Quests
         public SlicedFilledImage progressImage;
         public Image questImage;
         public GameObject progressBar;
+        public Button pinButton;
         public CostResourceUIReferences costSlotPrefab;
         public Transform costParent;
 
@@ -48,6 +49,21 @@ namespace TimelessEchoes.Quests
                 turnInButton.onClick.RemoveAllListeners();
                 if (onTurnIn != null && !completed) turnInButton.onClick.AddListener(() => onTurnIn());
                 turnInButton.gameObject.SetActive(onTurnIn != null && !completed);
+            }
+
+            if (pinButton != null && data != null)
+            {
+                pinButton.onClick.RemoveAllListeners();
+                bool pinned = Oracle.oracle != null && Oracle.oracle.saveData.PinnedQuests.Contains(data.questId);
+                UpdatePinVisual(pinned);
+                pinButton.onClick.AddListener(() =>
+                {
+                    var qm = QuestManager.Instance ?? Object.FindFirstObjectByType<QuestManager>();
+                    qm?.TogglePinned(data.questId);
+                    bool nowPinned = Oracle.oracle != null && Oracle.oracle.saveData.PinnedQuests.Contains(data.questId);
+                    UpdatePinVisual(nowPinned);
+                });
+                pinButton.gameObject.SetActive(!completed);
             }
 
             if (questImage != null)
@@ -176,6 +192,14 @@ namespace TimelessEchoes.Quests
                     slot.iconImage.color = Color.white;
                 }
             }
+        }
+
+        private void UpdatePinVisual(bool pinned)
+        {
+            if (pinButton == null) return;
+            var txt = pinButton.GetComponentInChildren<TMP_Text>();
+            if (txt != null)
+                txt.text = pinned ? "Unpin" : "Pin";
         }
 
         private static string GetQuestType(QuestData data)


### PR DESCRIPTION
## Summary
- enable saving pinned quests in `GameData`
- ensure pinned quest data is initialized by `Oracle`
- allow quests to be pinned from `QuestEntryUI`
- manage pinned quest displays through new `PinnedQuestUIManager`
- notify the pinned quest UI when progress changes

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886d240a1ac832e9124c0d482c2eeeb