### PR TITLE
Add per-map cloud toggle

### DIFF
--- a/Assets/Scriptables/MapSettings/Mines.asset
+++ b/Assets/Scriptables/MapSettings/Mines.asset
@@ -115,3 +115,4 @@ MonoBehaviour:
     minTaskDistance: 2
   segmentedMapSettings:
     segmentSize: {x: 64, y: 18}
+  allowClouds: 0

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -283,12 +283,14 @@ namespace TimelessEchoes
         private void StartRun(MapGenerationConfig config)
         {
             CurrentGenerationConfig = config;
+            cloudSpawner?.SetAllowClouds(config == null || config.allowClouds);
             StartRun();
         }
 
         private void StartRun()
         {
             HideTooltip();
+            cloudSpawner?.SetAllowClouds(CurrentGenerationConfig == null || CurrentGenerationConfig.allowClouds);
             // Re-enable autobuff for the new run based on the saved preference.
             SetAutoBuffRunDisabled(false);
             returnOnDeathQueued = false;
@@ -562,6 +564,7 @@ namespace TimelessEchoes
             if (tavernCamera != null)
             {
                 tavernCamera.gameObject.SetActive(true);
+                cloudSpawner?.SetAllowClouds(true);
                 cloudSpawner?.ResetClouds(true);
             }
 

--- a/Assets/Scripts/MapGeneration/CloudSpawner.cs
+++ b/Assets/Scripts/MapGeneration/CloudSpawner.cs
@@ -26,6 +26,7 @@ public class CloudSpawner : MonoBehaviour
     private float screenHalfHeight;
     private Cloud[] clouds;
     private Coroutine resetRoutine;
+    private bool allowClouds = true;
 
 #if UNITY_EDITOR
     private void OnValidate()
@@ -126,6 +127,17 @@ public class CloudSpawner : MonoBehaviour
         screenHalfWidth = screenHalfHeight * cam.aspect;
     }
 
+    public void SetAllowClouds(bool allow)
+    {
+        allowClouds = allow;
+        if (!allowClouds && clouds != null)
+        {
+            foreach (var c in clouds)
+                if (c?.Tr != null)
+                    c.Tr.gameObject.SetActive(false);
+        }
+    }
+
     public void ResetClouds(bool inTown)
     {
         if (resetRoutine != null)
@@ -141,6 +153,14 @@ public class CloudSpawner : MonoBehaviour
         UpdateScreenDimensions();
         if (clouds == null)
             yield break;
+
+        if (!allowClouds)
+        {
+            foreach (var c in clouds)
+                c.Tr.gameObject.SetActive(false);
+            resetRoutine = null;
+            yield break;
+        }
 
         var activeCount = inTown ? TownCloudCount : runCloudCount;
 

--- a/Assets/Scripts/MapGeneration/MapGenerationConfig.cs
+++ b/Assets/Scripts/MapGeneration/MapGenerationConfig.cs
@@ -17,6 +17,9 @@ namespace TimelessEchoes.MapGeneration
         public ProceduralTaskSettings taskGeneratorSettings = new();
         public SegmentedMapSettings segmentedMapSettings = new();
 
+        // Whether clouds should be shown while this map is active.
+        public bool allowClouds = true;
+
         [Serializable]
         public class TilemapChunkSettings
         {


### PR DESCRIPTION
## Summary
- allow map configs to disable clouds
- let `CloudSpawner` skip cloud spawning when disabled
- wire up `GameManager` to respect the config
- disable clouds in the Mines map

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68871121009c832e98b64d18bc6b1cc7