### PR TITLE
Update GameManager and TownWindowManager

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -16,6 +16,7 @@ using TimelessEchoes.NPC;
 using TimelessEchoes.Stats;
 using TimelessEchoes.Tasks;
 using TimelessEchoes.Upgrades;
+using TimelessEchoes.UI;
 using TMPro;
 using Unity.Cinemachine;
 using UnityEngine;
@@ -291,6 +292,7 @@ namespace TimelessEchoes
         {
             CurrentGenerationConfig = config;
             cloudSpawner?.SetAllowClouds(config == null || config.allowClouds);
+            TownWindowManager.Instance?.CloseAllWindows();
             StartRun();
         }
 

--- a/Assets/Scripts/UI/TownWindowManager.cs
+++ b/Assets/Scripts/UI/TownWindowManager.cs
@@ -7,11 +7,12 @@ namespace TimelessEchoes.UI
 {
     /// <summary>
     /// Manages the town UI windows. Clicking a button closes all windows except
-    /// the inventory and opens the associated one. The Start Run button only
-    /// closes the windows. Right-click closes all windows.
+    /// the inventory and opens the associated one. Right-click closes all
+    /// windows.
     /// </summary>
     public class TownWindowManager : MonoBehaviour
     {
+        public static TownWindowManager Instance { get; private set; }
         [Serializable]
         [InlineProperty]
         public class WindowReference
@@ -31,11 +32,11 @@ namespace TimelessEchoes.UI
         [SerializeField] private WindowReference inventory = new();
         [SerializeField] private WindowReference options = new();
 
-        [SerializeField]
-        private Button startRunButton;
+
 
         private void Awake()
         {
+            Instance = this;
             if (upgrades.button != null)
                 upgrades.button.onClick.AddListener(OpenUpgrades);
             if (buffs.button != null)
@@ -54,8 +55,6 @@ namespace TimelessEchoes.UI
                 options.button.onClick.AddListener(OpenOptions);
             if (inventory.button != null)
                 inventory.button.onClick.AddListener(ToggleInventory);
-            if (startRunButton != null)
-                startRunButton.onClick.AddListener(CloseAllWindows);
         }
 
         private void Start()
@@ -83,8 +82,8 @@ namespace TimelessEchoes.UI
                 options.button.onClick.RemoveListener(OpenOptions);
             if (inventory.button != null)
                 inventory.button.onClick.RemoveListener(ToggleInventory);
-            if (startRunButton != null)
-                startRunButton.onClick.RemoveListener(CloseAllWindows);
+            if (Instance == this)
+                Instance = null;
         }
 
         private void Update()
@@ -134,7 +133,7 @@ namespace TimelessEchoes.UI
                 options.window.SetActive(false);
         }
 
-        private void CloseAllWindows()
+        public void CloseAllWindows()
         {
             if (upgrades.window != null)
                 upgrades.window.SetActive(false);


### PR DESCRIPTION
## Summary
- expose `TownWindowManager.Instance` and `CloseAllWindows`
- remove old start run button hook
- close town windows when a run is started from generation buttons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887173ef1e0832eae2650213aa1f869