### PR TITLE
Improve settings with FPS toggle

### DIFF
--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -81,6 +81,11 @@ namespace Blindsided.SaveData
             public float MusicVolume = 0.25f;
             public float SfxVolume = 0.7f;
 
+            /// <summary>
+            ///     Desired target frame rate for the game.
+            /// </summary>
+            public int TargetFps = 60;
+
         }
 
         [HideReferenceObjectPicker]

--- a/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
+++ b/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
@@ -108,6 +108,12 @@ namespace Blindsided.SaveData
             set => oracle.saveData.SavedPreferences.SfxVolume = value;
         }
 
+        public static int TargetFps
+        {
+            get => oracle.saveData.SavedPreferences.TargetFps;
+            set => oracle.saveData.SavedPreferences.TargetFps = value;
+        }
+
         public static bool ShowLevelText
         {
             get => oracle.saveData.SavedPreferences.ShowLevelText;

--- a/Assets/Scripts/UI/SettingsPanelUI.cs
+++ b/Assets/Scripts/UI/SettingsPanelUI.cs
@@ -1,0 +1,76 @@
+using Blindsided;
+using Blindsided.SaveData;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TimelessEchoes.UI
+{
+    /// <summary>
+    ///     Controls the Settings panel UI.
+    ///     Currently handles switching between window modes.
+    /// </summary>
+    public class SettingsPanelUI : MonoBehaviour
+    {
+        [SerializeField] private Button fullscreenWindowButton;
+        [SerializeField] private Button windowButton;
+        [SerializeField] private Button fpsButton;
+        [SerializeField] private TMP_Text fpsButtonText;
+
+        private const int Fps60 = 60;
+        private const int Fps120 = 120;
+
+        private void Awake()
+        {
+            if (fullscreenWindowButton != null)
+                fullscreenWindowButton.onClick.AddListener(SetFullscreenWindow);
+            if (windowButton != null)
+                windowButton.onClick.AddListener(SetWindowed);
+            if (fpsButton != null)
+                fpsButton.onClick.AddListener(ToggleFps);
+            EventHandler.OnLoadData += ApplyFps;
+            ApplyFps();
+        }
+
+        private void OnDestroy()
+        {
+            if (fullscreenWindowButton != null)
+                fullscreenWindowButton.onClick.RemoveListener(SetFullscreenWindow);
+            if (windowButton != null)
+                windowButton.onClick.RemoveListener(SetWindowed);
+            if (fpsButton != null)
+                fpsButton.onClick.RemoveListener(ToggleFps);
+            EventHandler.OnLoadData -= ApplyFps;
+        }
+
+        private static void SetFullscreenWindow()
+        {
+            Screen.fullScreenMode = FullScreenMode.FullScreenWindow;
+        }
+
+        private static void SetWindowed()
+        {
+            Screen.fullScreenMode = FullScreenMode.Windowed;
+        }
+
+        private void ToggleFps()
+        {
+            StaticReferences.TargetFps = StaticReferences.TargetFps == Fps60 ? Fps120 : Fps60;
+            ApplyFps();
+        }
+
+        private void ApplyFps()
+        {
+            if (StaticReferences.TargetFps == 0)
+                StaticReferences.TargetFps = Fps60;
+            Application.targetFrameRate = StaticReferences.TargetFps;
+            UpdateFpsButtonText();
+        }
+
+        private void UpdateFpsButtonText()
+        {
+            if (fpsButtonText != null)
+                fpsButtonText.text = $"FPS: {StaticReferences.TargetFps}";
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extend `GameData.Preferences` with an FPS field
- expose `StaticReferences.TargetFps` for persistent FPS value
- update `SettingsPanelUI` to use the saved FPS and reapply it on load

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688745ed843c832e8b5259ab64188c09