### PR TITLE
Fix nested variable conflict in ReaperManager

### DIFF
--- a/Assets/Scripts/Enemies/ReaperManager.cs
+++ b/Assets/Scripts/Enemies/ReaperManager.cs
@@ -101,12 +101,12 @@ namespace TimelessEchoes.Enemies
                                FindFirstObjectByType<BuffManager>();
                     var hero = HeroController.Instance ??
                                FindFirstObjectByType<HeroController>();
-                    var heroHp = hero != null ? hero.GetComponent<HeroHealth>() : null;
-                    if (buff != null && heroHp != null)
+                    var heroHealth = hero != null ? hero.GetComponent<HeroHealth>() : null;
+                    if (buff != null && heroHealth != null)
                     {
                         var ls = buff.LifestealPercent;
                         if (ls > 0f)
-                            heroHp.Heal(amount * ls / 100f);
+                            heroHealth.Heal(amount * ls / 100f);
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- fix scoped variable naming in `KillTarget` to resolve CS0136 error

## Testing
- `grep -n heroHealth Assets/Scripts/Enemies/ReaperManager.cs`

------
https://chatgpt.com/codex/tasks/task_e_68875d1e50b4832ea46a33b350424742