### PR TITLE
Modify mining tasks to leave depleted ore sprite

### DIFF
--- a/Assets/Scripts/Tasks/MiningTask.cs
+++ b/Assets/Scripts/Tasks/MiningTask.cs
@@ -1,10 +1,51 @@
+using TimelessEchoes.Hero;
 using UnityEngine;
 
 namespace TimelessEchoes.Tasks
 {
+    /// <summary>
+    ///     Task for mining ore. On completion the ore sprite is replaced with
+    ///     a depleted rock sprite and the object remains in the scene.
+    /// </summary>
     public class MiningTask : ContinuousTask
     {
+        [SerializeField] private SpriteRenderer spriteRenderer;
+        [SerializeField] private Sprite depletedSprite;
+        [SerializeField] private Transform miningPoint;
+
+        private Sprite originalSprite;
+        private bool isDepleted;
+
         protected override string AnimationName => "Mining";
         protected override string InterruptTriggerName => "StopMining";
 
-        public override Transform Target => transform;    }}
+        public override Transform Target => miningPoint != null ? miningPoint : transform;
+
+        public override void StartTask()
+        {
+            base.StartTask();
+            isDepleted = false;
+            if (spriteRenderer == null)
+                spriteRenderer = GetComponent<SpriteRenderer>();
+            if (spriteRenderer != null)
+            {
+                if (originalSprite == null)
+                    originalSprite = spriteRenderer.sprite;
+                spriteRenderer.sprite = originalSprite;
+            }
+        }
+
+        public override void Tick(HeroController hero)
+        {
+            base.Tick(hero);
+            if (!isDepleted && IsComplete())
+            {
+                isDepleted = true;
+                if (spriteRenderer == null)
+                    spriteRenderer = GetComponent<SpriteRenderer>();
+                if (spriteRenderer != null && depletedSprite != null)
+                    spriteRenderer.sprite = depletedSprite;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Tasks/TaskController.cs
+++ b/Assets/Scripts/Tasks/TaskController.cs
@@ -457,6 +457,8 @@ namespace TimelessEchoes.Tasks
                         Destroy(obj.GetComponent<OpenChestTask>());
                     else if (task is WoodcuttingTask)
                         Destroy(obj.GetComponent<WoodcuttingTask>());
+                    else if (task is MiningTask)
+                        Destroy(obj.GetComponent<MiningTask>());
                     else if (task is FarmingTask)
                         Destroy(obj.GetComponent<FarmingTask>());
                     else
@@ -468,6 +470,8 @@ namespace TimelessEchoes.Tasks
                 if (task is OpenChestTask)
                     Destroy(mb);
                 else if (task is WoodcuttingTask)
+                    Destroy(mb);
+                else if (task is MiningTask)
                     Destroy(mb);
                 else if (task is FarmingTask)
                     Destroy(mb);


### PR DESCRIPTION
## Summary
- update `MiningTask` to swap to a depleted sprite after completion
- ensure the ore object persists by only removing the task component
- adjust `TaskController` to preserve mining objects

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688801e01dd8832e8ae6280560f1bd59