### PR TITLE
Implement enemy level scaling

### DIFF
--- a/Assets/Scripts/Enemies/EnemyData.cs
+++ b/Assets/Scripts/Enemies/EnemyData.cs
@@ -78,6 +78,22 @@ namespace TimelessEchoes.Enemies
         [TitleGroup("Balance Data/Movement Stats")]
         public float wanderDistance = 2f;
 
+        [TitleGroup("Level Scaling")]
+        [MinValue(0)]
+        public int damagePerLevel = 0;
+
+        [TitleGroup("Level Scaling")]
+        [MinValue(0)]
+        public int healthPerLevel = 0;
+
+        [TitleGroup("Level Scaling")]
+        [MinValue(0f)]
+        public float defensePerLevel = 0f;
+
+        [TitleGroup("Level Scaling")]
+        [MinValue(1f)]
+        public float distancePerLevel = float.PositiveInfinity;
+
         [TitleGroup("References")]
         public GameObject projectilePrefab;
 
@@ -87,6 +103,28 @@ namespace TimelessEchoes.Enemies
             if (worldX < minX || worldX > maxX)
                 return 0f;
             return Mathf.Max(0f, weight);
+        }
+
+        public int GetLevel(float worldX)
+        {
+            if (distancePerLevel <= 0f || float.IsInfinity(distancePerLevel))
+                return 1;
+            return Mathf.FloorToInt(Mathf.Max(0f, worldX) / distancePerLevel) + 1;
+        }
+
+        public int GetMaxHealthForLevel(int level)
+        {
+            return maxHealth + healthPerLevel * level;
+        }
+
+        public int GetDamageForLevel(int level)
+        {
+            return damage + damagePerLevel * level;
+        }
+
+        public float GetDefenseForLevel(int level)
+        {
+            return defense + defensePerLevel * level;
         }
     }
 }

--- a/Assets/Scripts/Enemies/Health.cs
+++ b/Assets/Scripts/Enemies/Health.cs
@@ -32,7 +32,7 @@ namespace TimelessEchoes.Enemies
             if (CurrentHealth <= 0f) return;
 
             var enemy = GetComponent<Enemy>();
-            var defense = enemy != null && enemy.Stats != null ? enemy.Stats.defense : 0f;
+            var defense = enemy != null ? enemy.GetDefense() : 0f;
 
             float full = amount + bonusDamage;
             float total = Mathf.Max(full - defense, full * 0.1f);


### PR DESCRIPTION
## Summary
- add level scaling properties to `EnemyData`
- calculate enemy level at spawn and apply scaled stats
- adjust projectiles and damage reduction to use scaled values
- display enemy level using a `TMP_Text` label

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68881e134724832ea76a12039dabfd95