### PR TITLE
Increase max distance after distance reap

### DIFF
--- a/Assets/Scripts/Enemies/ReaperManager.cs
+++ b/Assets/Scripts/Enemies/ReaperManager.cs
@@ -113,6 +113,14 @@ namespace TimelessEchoes.Enemies
 
             tracker?.AddTimesReaped();
 
+            // If the hero was reaped for reaching the maximum distance,
+            // increase that maximum by 1% for future runs.
+            if (heroCtrl != null && heroCtrl.ReaperSpawnedByDistance && tracker != null)
+            {
+                var increase = tracker.MaxRunDistance * 0.01f;
+                tracker.IncreaseMaxRunDistance(increase);
+            }
+
             onKill?.Invoke();
             target = null;
         }


### PR DESCRIPTION
## Summary
- grow MaxRunDistance by 1% when the hero is reaped for exceeding it

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688829e67e7c832e9e61110f6d73fee8