### PR TITLE
Disable average run slider when value < 0.05

### DIFF
--- a/Assets/Scripts/UI/RunStatsPanelUI.cs
+++ b/Assets/Scripts/UI/RunStatsPanelUI.cs
@@ -261,6 +261,10 @@ namespace TimelessEchoes.UI
             {
                 var avgRatio = longest > 0f ? average / longest : 0f;
                 averageRunSlider.value = Mathf.Clamp01((float)avgRatio);
+                if (averageRunSlider.value < 0.05f)
+                    averageRunSlider.gameObject.SetActive(false);
+                else
+                    averageRunSlider.gameObject.SetActive(true);
             }
 
             if (runs.Count > 0)


### PR DESCRIPTION
## Summary
- deactivate the Average Run slider object when the slider value is less than 0.05

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68884298627c832e84e183c4d11e3ee4