### PR TITLE
Track per-map stats

### DIFF
--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -44,6 +44,8 @@ namespace Blindsided.SaveData
 
         [HideReferenceObjectPicker] public Dictionary<string, ResourceRecord> ResourceStats = new();
 
+        [HideReferenceObjectPicker] public Dictionary<string, MapStats> MapStats = new();
+
         [HideReferenceObjectPicker] public GeneralStats General = new();
 
 
@@ -168,6 +170,19 @@ namespace Blindsided.SaveData
             public float AverageRun;
             public float MaxRunDistance = 50f;
             public int NextRunNumber = 1;
+        }
+
+        [HideReferenceObjectPicker]
+        public class MapStats
+        {
+            public float Steps;
+            public float LongestTrek;
+            public int TasksCompleted;
+            public double ResourcesGathered;
+            public int Kills;
+            public float DamageDealt;
+            public int Deaths;
+            public float DamageTaken;
         }
 
 

--- a/Assets/Scripts/MapGeneration/MapGenerationButton.cs
+++ b/Assets/Scripts/MapGeneration/MapGenerationButton.cs
@@ -1,5 +1,6 @@
 using System;
 using Sirenix.OdinInspector;
+using TMPro;
 using UnityEngine.UI;
 
 namespace TimelessEchoes.MapGeneration
@@ -11,5 +12,9 @@ namespace TimelessEchoes.MapGeneration
         public Button button;
         [HorizontalGroup("Row")]
         public MapGenerationConfig config;
+        [HorizontalGroup("Row")]
+        public TMP_Text topStatsText;
+        [HorizontalGroup("Row")]
+        public TMP_Text bottomStatsText;
     }
 }

--- a/Assets/Scripts/UI/GeneralStatsPanelUI.cs
+++ b/Assets/Scripts/UI/GeneralStatsPanelUI.cs
@@ -42,8 +42,9 @@ namespace TimelessEchoes.UI
                 var average = CalcUtils.FormatNumber(statTracker.AverageRun, true);
                 var tasks = CalcUtils.FormatNumber(statTracker.TasksCompleted, true);
                 var resources = CalcUtils.FormatNumber(statTracker.TotalResourcesGathered, true);
+                var reapDist = CalcUtils.FormatNumber(statTracker.MaxRunDistance, true);
                 references.distanceLongestTasksText.text =
-                    $"Steps Taken: {dist}\nLongest Run: {longest}\nTasks Completed: {tasks}\nResources Gathered: {resources}";
+                    $"Steps Taken: {dist}\nLongest Trek: {longest}\nTasks Completed: {tasks}\nResources Gathered: {resources}\nReaping Distance: {reapDist}";
             }
 
             if (references.killsDamageDeathsText != null)
@@ -52,8 +53,9 @@ namespace TimelessEchoes.UI
                 var dealt = CalcUtils.FormatNumber(statTracker.DamageDealt, true);
                 var deaths = CalcUtils.FormatNumber(statTracker.Deaths, true);
                 var taken = CalcUtils.FormatNumber(statTracker.DamageTaken, true);
+                var reaps = statTracker.TimesReaped.ToString();
                 references.killsDamageDeathsText.text =
-                    $"Kills: {kills}\nDamage Dealt: {dealt}\nDeaths: {deaths}\nDamage Taken: {taken}";
+                    $"Kills: {kills}\nDamage Dealt: {dealt}\nDeaths: {deaths}\nDamage Taken: {taken}\nTimes Reaped: {reaps}";
             }
         }
     }


### PR DESCRIPTION
## Summary
- add `MapStats` records and dictionary to saved game state
- extend `GameplayStatTracker` to track stats per map
- display map stats in `GameManager` generation buttons
- update general stats UI wording and extra rows
- add TMP text fields in `MapGenerationButton`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68884c2db970832eba2dd2003da889d6