### PR TITLE
Update quest turn-in UI text

### DIFF
--- a/Assets/Prefabs/UI/Quests/QuestPrefab.prefab
+++ b/Assets/Prefabs/UI/Quests/QuestPrefab.prefab
@@ -447,6 +447,7 @@ MonoBehaviour:
   rewardText: {fileID: 6522647304009456842}
   typeText: {fileID: 4873516550394383077}
   turnInButton: {fileID: 8950382192853892662}
+  turnInText: {fileID: 1960547979965173984}
   progressImage: {fileID: 6972726677016055629}
   questImage: {fileID: 2894457934127420967}
   progressBar: {fileID: 4932138921774110340}

--- a/Assets/Scripts/Quests/QuestEntryUI.cs
+++ b/Assets/Scripts/Quests/QuestEntryUI.cs
@@ -21,6 +21,7 @@ namespace TimelessEchoes.Quests
         public TMP_Text rewardText;
         public TMP_Text typeText;
         public Button turnInButton;
+        public TMP_Text turnInText;
         public SlicedFilledImage progressImage;
         public Image questImage;
         public GameObject progressBar;
@@ -50,6 +51,17 @@ namespace TimelessEchoes.Quests
                 turnInButton.onClick.RemoveAllListeners();
                 if (onTurnIn != null && !completed) turnInButton.onClick.AddListener(() => onTurnIn());
                 turnInButton.gameObject.SetActive(onTurnIn != null && !completed);
+            }
+            if (turnInText != null)
+            {
+                var label = "Turn In";
+                if (data != null && data.requirements != null && data.requirements.Count > 0)
+                {
+                    var type = data.requirements[0].type;
+                    if (type == QuestData.RequirementType.Instant || type == QuestData.RequirementType.Meet)
+                        label = "Okay";
+                }
+                turnInText.text = label;
             }
 
             if (pinButton != null && data != null)


### PR DESCRIPTION
## Summary
- add `turnInText` to QuestEntryUI
- set turn in button text based on quest type
- hook up new text component in QuestPrefab prefab

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688860808f6c832e86aa754696a52327