### PR TITLE
Update quest pinning logic

### DIFF
--- a/Assets/Scripts/Quests/PinnedQuestUIManager.cs
+++ b/Assets/Scripts/Quests/PinnedQuestUIManager.cs
@@ -47,6 +47,18 @@ namespace TimelessEchoes.Quests
             {
                 if (string.IsNullOrEmpty(id))
                     continue;
+                var qm = QuestManager.Instance ?? FindFirstObjectByType<QuestManager>();
+                var data = qm != null ? qm.GetQuestData(id) : null;
+                var instant = false;
+                if (data != null && data.requirements != null)
+                    foreach (var req in data.requirements)
+                        if (req != null && req.type == QuestData.RequirementType.Instant)
+                        {
+                            instant = true;
+                            break;
+                        }
+                if (instant)
+                    continue;
                 var txt = Instantiate(entryPrefab, entryParent);
                 entries[id] = txt;
             }

--- a/Assets/Scripts/Quests/QuestEntryUI.cs
+++ b/Assets/Scripts/Quests/QuestEntryUI.cs
@@ -86,7 +86,15 @@ namespace TimelessEchoes.Quests
                                     Oracle.oracle.saveData.PinnedQuests.Contains(data.questId);
                     UpdatePinVisual(nowPinned);
                 });
-                pinButton.gameObject.SetActive(!completed);
+                var instant = false;
+                if (data.requirements != null)
+                    foreach (var req in data.requirements)
+                        if (req != null && req.type == QuestData.RequirementType.Instant)
+                        {
+                            instant = true;
+                            break;
+                        }
+                pinButton.gameObject.SetActive(!completed && !instant);
             }
 
             if (questImage != null)

--- a/Assets/Scripts/Quests/QuestManager.cs
+++ b/Assets/Scripts/Quests/QuestManager.cs
@@ -166,6 +166,16 @@ namespace TimelessEchoes.Quests
             return true;
         }
 
+        private static bool IsInstantQuest(QuestData quest)
+        {
+            if (quest == null || quest.requirements == null)
+                return false;
+            foreach (var req in quest.requirements)
+                if (req != null && req.type == QuestData.RequirementType.Instant)
+                    return true;
+            return false;
+        }
+
         private void StartAvailableQuests()
         {
             foreach (var q in quests)
@@ -276,8 +286,10 @@ namespace TimelessEchoes.Quests
             RefreshNoticeboard();
             Log($"Quest {id} completed", TELogCategory.Quest, this);
             QuestHandin(id);
-
-            PinnedQuestUIManager.Instance?.UpdateProgress();
+            if (oracle.saveData.PinnedQuests.Remove(id))
+                PinnedQuestUIManager.Instance?.RefreshPins();
+            else
+                PinnedQuestUIManager.Instance?.UpdateProgress();
         }
 
         /// <summary>
@@ -335,6 +347,9 @@ namespace TimelessEchoes.Quests
         public void TogglePinned(string questId)
         {
             if (oracle == null || string.IsNullOrEmpty(questId))
+                return;
+            var data = GetQuestData(questId);
+            if (IsInstantQuest(data))
                 return;
             var set = oracle.saveData.PinnedQuests;
             if (set.Contains(questId))


### PR DESCRIPTION
## Summary
- unpin quests when they complete
- disallow pinning instant quests in the UI and manager
- skip invalid pinned quests when showing pinned UI

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888668cef94832ebaec6672f5b14be9