### PR TITLE
Show resource names in pinned quest list

### DIFF
--- a/Assets/Scripts/Quests/PinnedQuestUIManager.cs
+++ b/Assets/Scripts/Quests/PinnedQuestUIManager.cs
@@ -136,10 +136,21 @@ namespace TimelessEchoes.Quests
                             break;
                     }
 
-                    if (target <= 0)
-                        sb.AppendLine(CalcUtils.FormatNumber(current, true));
+                    if (req.type == QuestData.RequirementType.Resource)
+                    {
+                        var name = req.resource ? req.resource.name : "";
+                        if (target <= 0)
+                            sb.AppendLine($"{name}: {CalcUtils.FormatNumber(current, true)}");
+                        else
+                            sb.AppendLine($"{name}: {CalcUtils.FormatNumber(current, true)} / {CalcUtils.FormatNumber(target, true)}");
+                    }
                     else
-                        sb.AppendLine($"{CalcUtils.FormatNumber(current, true)} / {CalcUtils.FormatNumber(target, true)}");
+                    {
+                        if (target <= 0)
+                            sb.AppendLine(CalcUtils.FormatNumber(current, true));
+                        else
+                            sb.AppendLine($"{CalcUtils.FormatNumber(current, true)} / {CalcUtils.FormatNumber(target, true)}");
+                    }
                 }
 
                 text.text = sb.ToString();


### PR DESCRIPTION
## Summary
- show the resource name when displaying progress for pinned quests

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688868d3f8ac832e9cd1b229270707c8