### PR TITLE
Support unlisted terrain tasks

### DIFF
--- a/Assets/Scripts/MapGeneration/TerrainSettings.cs
+++ b/Assets/Scripts/MapGeneration/TerrainSettings.cs
@@ -23,6 +23,9 @@ namespace TimelessEchoes.MapGeneration
             [MinValue(0)] public int bottomBorderOffset;
             [MinValue(0)] public int leftBorderOffset;
             [MinValue(0)] public int rightBorderOffset;
+            // When false, spawned tasks are not registered with the TaskController.
+            [ToggleLeft]
+            public bool addToTaskList = true;
         }
 
         [Serializable]

--- a/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
+++ b/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
@@ -458,10 +458,16 @@ namespace TimelessEchoes.Tasks
             MonoBehaviour mono = obj;
             if (mono == null) return true;
 
-            if (clearExisting)
-                spawnedTasks.Add((pos, mono));
-            else
-                Controller.AddRuntimeTaskObject(mono);
+            var addToList = chosenTerrain == null || chosenTerrain.taskSettings.addToTaskList;
+
+            if (addToList)
+            {
+                if (clearExisting)
+                    spawnedTasks.Add((pos, mono));
+                else
+                    Controller.AddRuntimeTaskObject(mono);
+            }
+
             taskPositions.Add(pos);
             taskMap[pos] = mono;
             return true;

--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ from the edges tasks must spawn. Task spawn counts now rely solely on each
 terrain's `taskSettings.taskDensity` value; the generator's overall density
 setting has been removed.
 
+When `addToTaskList` is disabled on a terrain, the generator still spawns its
+tasks but they are not registered with the hero's `TaskController`.
+
 ## Building
 Use **File > Build Settings...** to create standalone builds.
 


### PR DESCRIPTION
## Summary
- allow TerrainSettings to spawn tasks without registering them
- respect the new flag when generating tasks
- document the `addToTaskList` terrain option

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888896582fc832ebea6c488e8215b44