### PR TITLE
Ensure off-screen tasks only restricted for echoes

### DIFF
--- a/Assets/Scripts/Tasks/TaskController.cs
+++ b/Assets/Scripts/Tasks/TaskController.cs
@@ -343,10 +343,11 @@ namespace TimelessEchoes.Tasks
             }
 
             RemoveCompletedTasks();
+            bool restrictToVisible = targetHero != null && targetHero.IsEcho;
             for (var i = 0; i < tasks.Count; i++)
             {
                 var task = tasks[i];
-                if (task == null || task.IsComplete() || !IsTaskOnScreen(task))
+                if (task == null || task.IsComplete() || (restrictToVisible && !IsTaskOnScreen(task)))
                     continue;
 
                 if (task is BaseTask baseTask)
@@ -401,10 +402,11 @@ namespace TimelessEchoes.Tasks
             }
 
             RemoveCompletedTasks();
+            bool restrictToVisible = targetHero != null && targetHero.IsEcho;
             for (var i = 0; i < tasks.Count; i++)
             {
                 var task = tasks[i];
-                if (task == null || task.IsComplete() || !IsTaskOnScreen(task))
+                if (task == null || task.IsComplete() || (restrictToVisible && !IsTaskOnScreen(task)))
                     continue;
 
                 if (task is BaseTask baseTask)


### PR DESCRIPTION
## Summary
- limit task screen visibility checks to echoes only

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68889a776940832e883198b33dead6eb