### PR TITLE
Add reaped run tracking and bar color

### DIFF
--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -145,6 +145,7 @@ namespace Blindsided.SaveData
             public float DamageDealt;
             public float DamageTaken;
             public bool Died;
+            public bool Reaped;
             public bool Abandoned;
         }
 

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -103,6 +103,7 @@ namespace TimelessEchoes
 
         private GameObject currentMap;
         private bool runEndedByDeath;
+        private bool runEndedByReaper;
         private bool heroDead;
         private Coroutine deathWindowCoroutine;
         private HeroController hero;
@@ -351,9 +352,11 @@ namespace TimelessEchoes
 #if !DISABLESTEAMWORKS
             RichPresenceManager.Instance?.SetInRun();
 #endif
-            if (runEndedByDeath && statTracker != null) statTracker.EndRun(true);
+            if (runEndedByDeath && statTracker != null)
+                statTracker.EndRun(true, runEndedByReaper);
             Log("Run starting", TELogCategory.Run, this);
             runEndedByDeath = false;
+            runEndedByReaper = false;
             if (deathWindowCoroutine != null)
             {
                 StopCoroutine(deathWindowCoroutine);
@@ -490,6 +493,7 @@ namespace TimelessEchoes
             UpdateAutoBuffUI();
 
             runEndedByDeath = true;
+            runEndedByReaper = distanceReaper;
             if (runDropUI != null)
                 runDropUI.ResetDrops();
 
@@ -596,7 +600,7 @@ namespace TimelessEchoes
             if (statTracker != null)
             {
                 if (runEndedByDeath)
-                    statTracker.EndRun(true);
+                    statTracker.EndRun(true, runEndedByReaper);
                 else
                     statTracker.EndRun(false);
             }

--- a/Assets/Scripts/Stats/GameplayStatTracker.cs
+++ b/Assets/Scripts/Stats/GameplayStatTracker.cs
@@ -388,7 +388,7 @@ namespace TimelessEchoes.Stats
             AverageRun = recentRuns.Count > 0 ? sum / recentRuns.Count : 0f;
         }
 
-        public void EndRun(bool died)
+        public void EndRun(bool died, bool reaped = false)
         {
             if (!RunInProgress)
                 return;
@@ -404,6 +404,7 @@ namespace TimelessEchoes.Stats
                 DamageDealt = currentRunDamageDealt,
                 DamageTaken = currentRunDamageTaken,
                 Died = died,
+                Reaped = reaped,
                 Abandoned = false
             };
             AddRunRecord(record);
@@ -435,6 +436,7 @@ namespace TimelessEchoes.Stats
                 DamageDealt = currentRunDamageDealt,
                 DamageTaken = currentRunDamageTaken,
                 Died = false,
+                Reaped = false,
                 Abandoned = true
             };
             AddRunRecord(record);

--- a/Assets/Scripts/UI/RunStatsPanelUI.cs
+++ b/Assets/Scripts/UI/RunStatsPanelUI.cs
@@ -27,13 +27,16 @@ namespace TimelessEchoes.UI
         [SerializeField] private Color deathBarColor = Color.red;
         [SerializeField] private Color retreatBarColor = Color.green;
         [SerializeField] private Color abandonedBarColor = Color.gray;
+        [SerializeField] private Color reapedBarColor = Color.magenta;
         [SerializeField] private Color resourcesDeathBarColor = Color.red;
         [SerializeField] private Color resourcesRetreatBarColor = Color.green;
         [SerializeField] private Color resourcesAbandonedBarColor = Color.gray;
+        [SerializeField] private Color resourcesReapedBarColor = Color.magenta;
         [SerializeField] private Color resourcesBonusBarColor = Color.yellow;
         [SerializeField] private Color killsDeathBarColor = Color.red;
         [SerializeField] private Color killsRetreatBarColor = Color.green;
         [SerializeField] private Color killsAbandonedBarColor = Color.gray;
+        [SerializeField] private Color killsReapedBarColor = Color.magenta;
 
         public enum GraphMode
         {
@@ -177,6 +180,8 @@ namespace TimelessEchoes.UI
             {
                 if (record.Abandoned)
                     runStatUI.statusText.text = "Status: Abandoned";
+                else if (record.Reaped)
+                    runStatUI.statusText.text = "Status: Reaped";
                 else
                     runStatUI.statusText.text = record.Died ? "Status: Died" : "Status: Retreated";
             }
@@ -319,6 +324,8 @@ namespace TimelessEchoes.UI
                     {
                         if (runs[index].Abandoned)
                             color = abandonedBarColor;
+                        else if (runs[index].Reaped)
+                            color = reapedBarColor;
                         else
                             color = runs[index].Died ? deathBarColor : retreatBarColor;
                     }
@@ -326,6 +333,8 @@ namespace TimelessEchoes.UI
                     {
                         if (runs[index].Abandoned)
                             color = resourcesAbandonedBarColor;
+                        else if (runs[index].Reaped)
+                            color = resourcesReapedBarColor;
                         else
                             color = runs[index].Died ? resourcesDeathBarColor : resourcesRetreatBarColor;
                         runBars[i].OverlayColor = resourcesBonusBarColor;
@@ -334,6 +343,8 @@ namespace TimelessEchoes.UI
                     {
                         if (runs[index].Abandoned)
                             color = killsAbandonedBarColor;
+                        else if (runs[index].Reaped)
+                            color = killsReapedBarColor;
                         else
                             color = runs[index].Died ? killsDeathBarColor : killsRetreatBarColor;
                     }


### PR DESCRIPTION
## Summary
- track when a run ends because the player was reaped
- add new colours to bar graphs for reaped runs
- show "Status: Reaped" in run tooltip

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68889d008984832eb7639b6c978b6a8a