### PR TITLE
Fix echo idle behavior after last on-screen task

### DIFF
--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -593,7 +593,7 @@ namespace TimelessEchoes.Hero
 
             if (CurrentTask == null)
             {
-                bool noVisibleTasks = taskController == null || !taskController.HasVisibleTasks();
+                bool noVisibleTasks = taskController == null || !taskController.HasVisibleTasksForHero(this);
                 if (taskController == null || taskController.tasks.Count == 0 || (IsEcho && noVisibleTasks))
                     AutoAdvance();
                 else

--- a/Assets/Scripts/Tasks/TaskController.cs
+++ b/Assets/Scripts/Tasks/TaskController.cs
@@ -74,6 +74,36 @@ namespace TimelessEchoes.Tasks
             return false;
         }
 
+        public bool HasVisibleTasksForHero(HeroController hero)
+        {
+            if (hero == null)
+                return HasVisibleTasks();
+
+            var echo = hero.GetComponent<EchoController>();
+            IList<Skill> skills = echo != null ? echo.capableSkills : null;
+
+            bool restrictToVisible = hero.IsEcho;
+            foreach (var task in tasks)
+            {
+                if (task == null || task.IsComplete())
+                    continue;
+                if (restrictToVisible && !IsTaskOnScreen(task))
+                    continue;
+
+                if (task is BaseTask baseTask)
+                {
+                    if (baseTask.ClaimedBy != null && baseTask.ClaimedBy != hero)
+                        continue;
+                    if (skills != null && skills.Count > 0 && !skills.Contains(baseTask.associatedSkill))
+                        continue;
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
         private void Awake()
         {
             AcquireHero();


### PR DESCRIPTION
## Summary
- track hero-specific visible tasks to avoid idle echoes when no assignable tasks are nearby
- fall back to following the main hero once no visible tasks exist for the echo

## Testing
- `git diff --cached --stat`

------
https://chatgpt.com/codex/tasks/task_e_6888a2de5220832ea178f0b44fef4d12