### PR TITLE
Add min padding to ScreenSafeArea

### DIFF
--- a/Assets/Scripts/Blindsided/Utilities/ScreenSafeArea.cs
+++ b/Assets/Scripts/Blindsided/Utilities/ScreenSafeArea.cs
@@ -9,6 +9,11 @@ namespace Blindsided.Utilities
         private Vector2 minAnchor;
         private Rect safeArea;
 
+        [Tooltip("Minimum space from the top edge in pixels")] public float minPaddingTop;
+        [Tooltip("Minimum space from the bottom edge in pixels")] public float minPaddingBottom;
+        [Tooltip("Minimum space from the left edge in pixels")] public float minPaddingLeft;
+        [Tooltip("Minimum space from the right edge in pixels")] public float minPaddingRight;
+
 #if UNITY_EDITOR || UNITY_STANDALONE
         public bool extraBoarders;
         public float boarderTop = 40;
@@ -20,6 +25,18 @@ namespace Blindsided.Utilities
         {
             _rectTransform = GetComponent<RectTransform>();
             safeArea = Screen.safeArea;
+
+            float left = safeArea.xMin;
+            float right = Screen.width - safeArea.xMax;
+            float top = Screen.height - safeArea.yMax;
+            float bottom = safeArea.yMin;
+
+            left = Mathf.Max(left, minPaddingLeft);
+            right = Mathf.Max(right, minPaddingRight);
+            top = Mathf.Max(top, minPaddingTop);
+            bottom = Mathf.Max(bottom, minPaddingBottom);
+
+            safeArea = new Rect(left, bottom, Screen.width - left - right, Screen.height - top - bottom);
 
 #if UNITY_EDITOR || UNITY_STANDALONE
             // Subtract 40 from the left, right, and bottom


### PR DESCRIPTION
## Summary
- let UI define minimum padding on each side of the safe area
- compute a modified safe area using these padding values

## Testing
- `git status -s`

------
https://chatgpt.com/codex/tasks/task_e_68894f2c7270832e8bdcc25a9ef3e131