### PR TITLE
Add kill requirement label and cleanup quest data

### DIFF
--- a/Assets/Scripts/Quests/PinnedQuestUIManager.cs
+++ b/Assets/Scripts/Quests/PinnedQuestUIManager.cs
@@ -156,6 +156,13 @@ namespace TimelessEchoes.Quests
                         else
                             sb.AppendLine($"<size=80%>{name}: {CalcUtils.FormatNumber(current, true)} / {CalcUtils.FormatNumber(target, true)}</size>");
                     }
+                    else if (req.type == QuestData.RequirementType.Kill && !string.IsNullOrEmpty(req.killName))
+                    {
+                        if (target <= 0)
+                            sb.AppendLine($"<size=80%>Kill {req.killName}: {CalcUtils.FormatNumber(current, true)}</size>");
+                        else
+                            sb.AppendLine($"<size=80%>Kill {req.killName}: {CalcUtils.FormatNumber(current, true)} / {CalcUtils.FormatNumber(target, true)}</size>");
+                    }
                     else
                     {
                         if (target <= 0)

--- a/Assets/Scripts/Quests/QuestData.cs
+++ b/Assets/Scripts/Quests/QuestData.cs
@@ -19,8 +19,6 @@ namespace TimelessEchoes.Quests
         public string npcId;
         public List<QuestData> requiredQuests = new();
         public List<Requirement> requirements = new();
-        public GameObject unlockPrefab;
-        public List<GameObject> unlockObjects = new();
         public int unlockBuffSlots;
         public float maxDistanceIncrease;
 
@@ -35,6 +33,8 @@ namespace TimelessEchoes.Quests
             public int amount = 1;
             [ShowIf("type", RequirementType.Kill)]
             public List<EnemyData> enemies = new();
+            [ShowIf("type", RequirementType.Kill)]
+            public string killName;
             [ShowIf("type", RequirementType.Kill)]
             public Sprite killIcon;
             [ShowIf("type", RequirementType.Meet)]

--- a/Assets/Scripts/Quests/QuestManager.cs
+++ b/Assets/Scripts/Quests/QuestManager.cs
@@ -267,11 +267,6 @@ namespace TimelessEchoes.Quests
                         resourceManager.Spend(req.resource, req.amount);
 
             record.Completed = true;
-            if (inst.data.unlockPrefab != null)
-                Instantiate(inst.data.unlockPrefab);
-            foreach (var obj in inst.data.unlockObjects)
-                if (obj != null)
-                    obj.SetActive(true);
             if (inst.data.unlockBuffSlots > 0)
                 BuffManager.Instance?.UnlockSlots(inst.data.unlockBuffSlots);
             if (inst.data.maxDistanceIncrease > 0f)


### PR DESCRIPTION
## Summary
- remove obsolete quest unlock prefab/object fields
- add killName label to `QuestData.Requirement`
- include kill requirement name in pinned quest text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68896fb05ce8832e9595c5b8a397c973