### PR TITLE
Add keystore credential helper scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,7 @@ crashlytics-build.properties
 
 # Ignore IDE settings
 .idea/
+
+# Local keystore credentials
+.keystore_credentials
+__pycache__/

--- a/Assets/Editor/KeystoreCredentialsLoader.cs
+++ b/Assets/Editor/KeystoreCredentialsLoader.cs
@@ -1,0 +1,44 @@
+#if UNITY_EDITOR
+using System;
+using UnityEditor;
+
+namespace TimelessEchoes.Editor
+{
+    [InitializeOnLoad]
+    public static class KeystoreCredentialsLoader
+    {
+        static KeystoreCredentialsLoader()
+        {
+            Apply();
+        }
+
+        [MenuItem("Tools/Load Keystore Credentials")]
+        public static void Apply()
+        {
+            var keystorePass = Environment.GetEnvironmentVariable("UNITY_KEYSTORE_PASS");
+            if (!string.IsNullOrEmpty(keystorePass))
+            {
+                PlayerSettings.Android.keystorePass = keystorePass;
+            }
+
+            var keyPass = Environment.GetEnvironmentVariable("UNITY_KEY_PASS");
+            if (!string.IsNullOrEmpty(keyPass))
+            {
+                PlayerSettings.Android.keyaliasPass = keyPass;
+            }
+
+            var keystorePath = Environment.GetEnvironmentVariable("UNITY_KEYSTORE_PATH");
+            if (!string.IsNullOrEmpty(keystorePath))
+            {
+                PlayerSettings.Android.keystoreName = keystorePath;
+            }
+
+            var aliasName = Environment.GetEnvironmentVariable("UNITY_KEY_ALIAS_NAME");
+            if (!string.IsNullOrEmpty(aliasName))
+            {
+                PlayerSettings.Android.keyaliasName = aliasName;
+            }
+        }
+    }
+}
+#endif

--- a/README.md
+++ b/README.md
@@ -102,3 +102,18 @@ sets the **steam_display** key with a localization token. Example tokens are
 
 ## Development Guidelines
 Refer to [Unity's official documentation](https://docs.unity3d.com) and ensure all changes work with **Unity 6000.1.6f1**.
+
+## Keystore Credentials
+To avoid storing keystore passwords in the repository, create a local credentials file:
+
+```bash
+python Tools/create_keystore_credentials.py
+```
+
+This script writes a `.keystore_credentials` file which is ignored by Git. Load these credentials in your shell before opening Unity:
+
+```bash
+source Tools/load_keystore_credentials.sh
+```
+
+The editor automatically applies the environment variables to `PlayerSettings` when Unity starts.

--- a/Tools/create_keystore_credentials.py
+++ b/Tools/create_keystore_credentials.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+import os
+import getpass
+
+
+def main():
+    path = input("Keystore path: ").strip()
+    alias = input("Key alias name: ").strip()
+    keystore_pass = getpass.getpass("Keystore password: ")
+    key_pass = getpass.getpass("Key alias password: ")
+
+    with open('.keystore_credentials', 'w') as f:
+        f.write(f"UNITY_KEYSTORE_PATH={path}\n")
+        f.write(f"UNITY_KEY_ALIAS_NAME={alias}\n")
+        f.write(f"UNITY_KEYSTORE_PASS={keystore_pass}\n")
+        f.write(f"UNITY_KEY_PASS={key_pass}\n")
+    os.chmod('.keystore_credentials', 0o600)
+    print('Credentials saved to .keystore_credentials (gitignored).')
+
+
+if __name__ == '__main__':
+    main()

--- a/Tools/load_keystore_credentials.sh
+++ b/Tools/load_keystore_credentials.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Load keystore credentials into the current shell
+CRED_FILE="$(dirname "$0")/../.keystore_credentials"
+if [ -f "$CRED_FILE" ]; then
+    set -a
+    source "$CRED_FILE"
+    set +a
+else
+    echo "Keystore credential file not found: $CRED_FILE" >&2
+fi


### PR DESCRIPTION
## Summary
- ignore local keystore credential file and Python cache
- add helper script to set Android keystore settings from env vars
- provide scripts for storing and loading keystore passwords locally
- document how to use the new tools

## Testing
- `python -m py_compile Tools/create_keystore_credentials.py`
- `bash -n Tools/load_keystore_credentials.sh`


------
https://chatgpt.com/codex/tasks/task_e_68897cda2250832ebfd6e70af7455487