### PR TITLE
Sort known enemies before unknown

### DIFF
--- a/Assets/Scripts/UI/EnemyStatsPanelUI.cs
+++ b/Assets/Scripts/UI/EnemyStatsPanelUI.cs
@@ -153,7 +153,25 @@ namespace TimelessEchoes.UI
 
             if (sortMode == SortMode.Default)
             {
-                ApplyOrder(defaultOrder);
+                IEnumerable<EnemyData> known = defaultOrder;
+                IEnumerable<EnemyData> unknown = Enumerable.Empty<EnemyData>();
+                if (killTracker != null)
+                {
+                    known = defaultOrder.Where(s => killTracker.GetKills(s) > 0);
+                    unknown = defaultOrder.Where(s => killTracker.GetKills(s) <= 0);
+                }
+
+                var sortedKnown = known
+                    .OrderBy(s => s.displayOrder)
+                    .ThenBy(s => s.enemyName)
+                    .ToList();
+                var sortedUnknown = unknown
+                    .OrderBy(s => s.displayOrder)
+                    .ThenBy(s => s.enemyName)
+                    .ToList();
+
+                var finalDefault = sortedKnown.Concat(sortedUnknown).ToList();
+                ApplyOrder(finalDefault);
                 return;
             }
 


### PR DESCRIPTION
## Summary
- sort known enemies ahead of unknown ones on the stats screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68898d308214832eacf830f7fca3bae7