### PR TITLE
Add optional auto-pin for quests

### DIFF
--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -78,6 +78,10 @@ namespace Blindsided.SaveData
             public bool StatsFoldout;
             public bool TransparentUi;
             public bool Tutorial;
+            /// <summary>
+            ///     Automatically pin new quests when they become active.
+            /// </summary>
+            public bool AutoPinActiveQuests = true;
             public bool UseScaledTimeForValues;
             public float MasterVolume = 1f;
             public float MusicVolume = 0.25f;

--- a/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
+++ b/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
@@ -127,6 +127,12 @@ namespace Blindsided.SaveData
             }
         }
 
+        public static bool AutoPinActiveQuests
+        {
+            get => oracle.saveData.SavedPreferences.AutoPinActiveQuests;
+            set => oracle.saveData.SavedPreferences.AutoPinActiveQuests = value;
+        }
+
         /// <summary>
         ///     Indicates whether autobuff is enabled. The saved preference can
         ///     temporarily be disabled for the remainder of a run without

--- a/Assets/Scripts/Quests/QuestManager.cs
+++ b/Assets/Scripts/Quests/QuestManager.cs
@@ -12,6 +12,7 @@ using TimelessEchoes.Upgrades;
 using UnityEngine;
 using static Blindsided.Oracle;
 using static Blindsided.EventHandler;
+using static Blindsided.SaveData.StaticReferences;
 using static TimelessEchoes.TELogger;
 
 namespace TimelessEchoes.Quests
@@ -396,6 +397,15 @@ namespace TimelessEchoes.Quests
             inst.ui = null;
 
             active[quest.questId] = inst;
+            if (AutoPinActiveQuests && !IsInstantQuest(quest))
+            {
+                var set = oracle.saveData.PinnedQuests;
+                if (!set.Contains(quest.questId))
+                {
+                    set.Add(quest.questId);
+                    PinnedQuestUIManager.Instance?.RefreshPins();
+                }
+            }
             UpdateProgress(inst);
 
             PinnedQuestUIManager.Instance?.UpdateProgress();


### PR DESCRIPTION
## Summary
- add `AutoPinActiveQuests` preference with default `true`
- expose the preference via `StaticReferences`
- automatically pin newly started quests when enabled

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688992e6f7c4832e989149aa1a6eec60