### PR TITLE
Update stat refresh logic

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -116,6 +116,9 @@ namespace TimelessEchoes
         private bool retreatQueued;
         private readonly Dictionary<Button, UnityEngine.Events.UnityAction> _buttonActions = new();
 
+        [SerializeField] private float statsUpdateInterval = 0.1f;
+        private float nextStatsUpdateTime;
+
         private void UpdateGenerationButtonStats()
         {
             if (statTracker == null) return;
@@ -222,11 +225,17 @@ namespace TimelessEchoes
             if (autoBuffRoot != null)
                 autoBuffRoot.SetActive(false);
             UpdateGenerationButtonStats();
+            nextStatsUpdateTime = Time.time + statsUpdateInterval;
         }
 
         private void Update()
         {
             UpdateAutoBuffUI();
+            if (Time.time >= nextStatsUpdateTime)
+            {
+                UpdateGenerationButtonStats();
+                nextStatsUpdateTime = Time.time + statsUpdateInterval;
+            }
             if (returnToTavernButton != null)
             {
                 var active = hero != null && hero.gameObject.activeSelf && !heroDead;

--- a/Assets/Scripts/UI/EnemyStatsPanelUI.cs
+++ b/Assets/Scripts/UI/EnemyStatsPanelUI.cs
@@ -14,6 +14,9 @@ namespace TimelessEchoes.UI
         [SerializeField] private StatPanelReferences references;
         private EnemyKillTracker killTracker;
 
+        [SerializeField] private float updateInterval = 0.1f;
+        private float nextUpdateTime;
+
         private readonly Dictionary<EnemyData, EnemyStatEntryUIReferences> entries = new();
         private List<EnemyData> defaultOrder = new();
 
@@ -41,12 +44,18 @@ namespace TimelessEchoes.UI
         private void OnEnable()
         {
             UpdateEntries();
+            SortEntries();
+            nextUpdateTime = Time.unscaledTime + updateInterval;
         }
 
         private void Update()
         {
-            UpdateEntries();
-            SortEntries();
+            if (Time.unscaledTime >= nextUpdateTime)
+            {
+                UpdateEntries();
+                SortEntries();
+                nextUpdateTime = Time.unscaledTime + updateInterval;
+            }
         }
 
         public void SetSortMode(SortMode mode)

--- a/Assets/Scripts/UI/GeneralStatsPanelUI.cs
+++ b/Assets/Scripts/UI/GeneralStatsPanelUI.cs
@@ -11,6 +11,9 @@ namespace TimelessEchoes.UI
         [SerializeField] private GeneralStatsUIReferences references;
         private GameplayStatTracker statTracker;
 
+        [SerializeField] private float updateInterval = 0.1f;
+        private float nextUpdateTime;
+
         private void Awake()
         {
             if (references == null)
@@ -23,11 +26,16 @@ namespace TimelessEchoes.UI
         private void OnEnable()
         {
             UpdateTexts();
+            nextUpdateTime = Time.unscaledTime + updateInterval;
         }
 
         private void Update()
         {
-            UpdateTexts();
+            if (Time.unscaledTime >= nextUpdateTime)
+            {
+                UpdateTexts();
+                nextUpdateTime = Time.unscaledTime + updateInterval;
+            }
         }
 
         private void UpdateTexts()

--- a/Assets/Scripts/UI/ItemStatsPanelUI.cs
+++ b/Assets/Scripts/UI/ItemStatsPanelUI.cs
@@ -13,6 +13,9 @@ namespace TimelessEchoes.UI
         [SerializeField] private StatPanelReferences references;
         private ResourceManager resourceManager;
 
+        [SerializeField] private float updateInterval = 0.1f;
+        private float nextUpdateTime;
+
         private readonly Dictionary<Resource, ItemEntryUIReferences> entries = new();
         private List<Resource> defaultOrder = new();
 
@@ -39,12 +42,18 @@ namespace TimelessEchoes.UI
         private void OnEnable()
         {
             UpdateEntries();
+            SortEntries();
+            nextUpdateTime = Time.unscaledTime + updateInterval;
         }
 
         private void Update()
         {
-            UpdateEntries();
-            SortEntries();
+            if (Time.unscaledTime >= nextUpdateTime)
+            {
+                UpdateEntries();
+                SortEntries();
+                nextUpdateTime = Time.unscaledTime + updateInterval;
+            }
         }
 
         public void SetSortMode(SortMode mode)

--- a/Assets/Scripts/UI/RunStatsPanelUI.cs
+++ b/Assets/Scripts/UI/RunStatsPanelUI.cs
@@ -38,6 +38,9 @@ namespace TimelessEchoes.UI
         [SerializeField] private Color killsAbandonedBarColor = Color.gray;
         [SerializeField] private Color killsReapedBarColor = Color.magenta;
 
+        [SerializeField] private float updateInterval = 0.1f;
+        private float nextUpdateTime;
+
         public enum GraphMode
         {
             Distance,
@@ -109,6 +112,7 @@ namespace TimelessEchoes.UI
         {
             UpdateGraphLabel();
             UpdateUI();
+            nextUpdateTime = Time.unscaledTime + updateInterval;
         }
 
         private void OnDisable()
@@ -119,7 +123,11 @@ namespace TimelessEchoes.UI
 
         private void Update()
         {
-            UpdateUI();
+            if (Time.unscaledTime >= nextUpdateTime)
+            {
+                UpdateUI();
+                nextUpdateTime = Time.unscaledTime + updateInterval;
+            }
         }
 
         private void OnBarEnter(RunBarUI bar)

--- a/Assets/Scripts/UI/TaskStatsPanelUI.cs
+++ b/Assets/Scripts/UI/TaskStatsPanelUI.cs
@@ -14,6 +14,9 @@ namespace TimelessEchoes.UI
         [SerializeField] private StatPanelReferences references;
         private GameplayStatTracker statTracker;
 
+        [SerializeField] private float updateInterval = 0.1f;
+        private float nextUpdateTime;
+
         private readonly Dictionary<TaskData, TaskStatEntryUIReferences> entries = new();
         private List<TaskData> defaultOrder = new();
 
@@ -40,12 +43,18 @@ namespace TimelessEchoes.UI
         private void OnEnable()
         {
             UpdateEntries();
+            SortEntries();
+            nextUpdateTime = Time.unscaledTime + updateInterval;
         }
 
         private void Update()
         {
-            UpdateEntries();
-            SortEntries();
+            if (Time.unscaledTime >= nextUpdateTime)
+            {
+                UpdateEntries();
+                SortEntries();
+                nextUpdateTime = Time.unscaledTime + updateInterval;
+            }
         }
 
         public void SetSortMode(SortMode mode)


### PR DESCRIPTION
## Summary
- limit stat panel refreshes to 10 times/second
- refresh map generation button stats periodically while in a run

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6889932b6804832e8f97af581146e674