### PR TITLE
Enable wet overlay for farming tasks

### DIFF
--- a/Assets/Scripts/Tasks/FarmingTask.cs
+++ b/Assets/Scripts/Tasks/FarmingTask.cs
@@ -11,6 +11,8 @@ namespace TimelessEchoes.Tasks
     public class FarmingTask : ContinuousTask
     {
         [SerializeField] private SpriteRenderer spriteRenderer;
+        [Tooltip("Optional overlay sprite used to show watered soil")]
+        [SerializeField] private SpriteRenderer wetSpriteRenderer;
         [SerializeField] private Sprite[] growthStages = new Sprite[3];
         [SerializeField] private Transform wateringPoint;
 
@@ -28,6 +30,8 @@ namespace TimelessEchoes.Tasks
             base.StartTask();
             if (spriteRenderer == null)
                 spriteRenderer = GetComponent<SpriteRenderer>();
+            if (wetSpriteRenderer != null)
+                wetSpriteRenderer.enabled = true;
             localTimer = 0f;
             currentStage = 0;
             duration = TaskDuration;
@@ -66,7 +70,16 @@ namespace TimelessEchoes.Tasks
             if (IsComplete() && spriteRenderer != null && spriteRenderer.enabled)
             {
                 spriteRenderer.enabled = false;
+                if (wetSpriteRenderer != null)
+                    wetSpriteRenderer.enabled = false;
             }
+        }
+
+        public override void OnInterrupt(HeroController hero)
+        {
+            base.OnInterrupt(hero);
+            if (wetSpriteRenderer != null)
+                wetSpriteRenderer.enabled = false;
         }
 
         // TaskDuration property from ContinuousTask provides the duration


### PR DESCRIPTION
## Summary
- add new `wetSpriteRenderer` overlay sprite to `FarmingTask`
- enable wet sprite at start and disable it on completion or interruption

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688993c49c24832eb165dc82d9387b33