### PR TITLE
Enable farm watering indicator when hero arrives

### DIFF
--- a/Assets/Scripts/Tasks/FarmingTask.cs
+++ b/Assets/Scripts/Tasks/FarmingTask.cs
@@ -30,13 +30,18 @@ namespace TimelessEchoes.Tasks
             base.StartTask();
             if (spriteRenderer == null)
                 spriteRenderer = GetComponent<SpriteRenderer>();
-            if (wetSpriteRenderer != null)
-                wetSpriteRenderer.enabled = true;
             localTimer = 0f;
             currentStage = 0;
             duration = TaskDuration;
             if (spriteRenderer != null && spriteRenderer.enabled == false)
                 spriteRenderer.enabled = true;
+        }
+
+        public override void OnArrival(HeroController hero)
+        {
+            base.OnArrival(hero);
+            if (wetSpriteRenderer != null)
+                wetSpriteRenderer.enabled = true;
         }
 
         public override void Tick(HeroController hero)


### PR DESCRIPTION
## Summary
- let watering indicator only activate upon hero arrival

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688996c8cf6c832e8c8e7989869247d5