### PR TITLE
Add toggle support to town UI windows

### DIFF
--- a/Assets/Scripts/UI/TownWindowManager.cs
+++ b/Assets/Scripts/UI/TownWindowManager.cs
@@ -19,6 +19,7 @@ namespace TimelessEchoes.UI
         {
             [HorizontalGroup("Row")] public Button button;
             [HorizontalGroup("Row")] public GameObject window;
+            [HorizontalGroup("Row")] public Button closeButton;
         }
 
         [Title("References")]
@@ -31,6 +32,7 @@ namespace TimelessEchoes.UI
         [SerializeField] private WindowReference wiki = new();
         [SerializeField] private WindowReference inventory = new();
         [SerializeField] private WindowReference options = new();
+        [SerializeField] private GameObject townButtons;
 
 
 
@@ -39,22 +41,40 @@ namespace TimelessEchoes.UI
             Instance = this;
             if (upgrades.button != null)
                 upgrades.button.onClick.AddListener(OpenUpgrades);
+            if (upgrades.closeButton != null)
+                upgrades.closeButton.onClick.AddListener(() => CloseWindow(upgrades.window));
             if (buffs.button != null)
                 buffs.button.onClick.AddListener(OpenBuffs);
+            if (buffs.closeButton != null)
+                buffs.closeButton.onClick.AddListener(() => CloseWindow(buffs.window));
             if (quests.button != null)
                 quests.button.onClick.AddListener(OpenQuests);
+            if (quests.closeButton != null)
+                quests.closeButton.onClick.AddListener(() => CloseWindow(quests.window));
             if (credits.button != null)
                 credits.button.onClick.AddListener(OpenCredits);
+            if (credits.closeButton != null)
+                credits.closeButton.onClick.AddListener(() => CloseWindow(credits.window));
             if (disciples.button != null)
                 disciples.button.onClick.AddListener(OpenDisciples);
+            if (disciples.closeButton != null)
+                disciples.closeButton.onClick.AddListener(() => CloseWindow(disciples.window));
             if (stats.button != null)
                 stats.button.onClick.AddListener(OpenStats);
+            if (stats.closeButton != null)
+                stats.closeButton.onClick.AddListener(() => CloseWindow(stats.window));
             if (wiki.button != null)
                 wiki.button.onClick.AddListener(OpenWiki);
+            if (wiki.closeButton != null)
+                wiki.closeButton.onClick.AddListener(() => CloseWindow(wiki.window));
             if (options.button != null)
                 options.button.onClick.AddListener(OpenOptions);
+            if (options.closeButton != null)
+                options.closeButton.onClick.AddListener(() => CloseWindow(options.window));
             if (inventory.button != null)
                 inventory.button.onClick.AddListener(ToggleInventory);
+            if (inventory.closeButton != null)
+                inventory.closeButton.onClick.AddListener(() => CloseWindow(inventory.window));
         }
 
         private void Start()
@@ -66,22 +86,40 @@ namespace TimelessEchoes.UI
         {
             if (upgrades.button != null)
                 upgrades.button.onClick.RemoveListener(OpenUpgrades);
+            if (upgrades.closeButton != null)
+                upgrades.closeButton.onClick.RemoveAllListeners();
             if (buffs.button != null)
                 buffs.button.onClick.RemoveListener(OpenBuffs);
+            if (buffs.closeButton != null)
+                buffs.closeButton.onClick.RemoveAllListeners();
             if (quests.button != null)
                 quests.button.onClick.RemoveListener(OpenQuests);
+            if (quests.closeButton != null)
+                quests.closeButton.onClick.RemoveAllListeners();
             if (credits.button != null)
                 credits.button.onClick.RemoveListener(OpenCredits);
+            if (credits.closeButton != null)
+                credits.closeButton.onClick.RemoveAllListeners();
             if (disciples.button != null)
                 disciples.button.onClick.RemoveListener(OpenDisciples);
+            if (disciples.closeButton != null)
+                disciples.closeButton.onClick.RemoveAllListeners();
             if (stats.button != null)
                 stats.button.onClick.RemoveListener(OpenStats);
+            if (stats.closeButton != null)
+                stats.closeButton.onClick.RemoveAllListeners();
             if (wiki.button != null)
                 wiki.button.onClick.RemoveListener(OpenWiki);
+            if (wiki.closeButton != null)
+                wiki.closeButton.onClick.RemoveAllListeners();
             if (options.button != null)
                 options.button.onClick.RemoveListener(OpenOptions);
+            if (options.closeButton != null)
+                options.closeButton.onClick.RemoveAllListeners();
             if (inventory.button != null)
                 inventory.button.onClick.RemoveListener(ToggleInventory);
+            if (inventory.closeButton != null)
+                inventory.closeButton.onClick.RemoveAllListeners();
             if (Instance == this)
                 Instance = null;
         }
@@ -92,25 +130,40 @@ namespace TimelessEchoes.UI
                 CloseAllWindows();
         }
 
-        private void OpenUpgrades() => OpenWindow(upgrades.window);
-        private void OpenBuffs() => OpenWindow(buffs.window);
-        private void OpenQuests() => OpenWindow(quests.window);
-        private void OpenCredits() => OpenWindow(credits.window);
-        private void OpenDisciples() => OpenWindow(disciples.window);
-        private void OpenStats() => OpenWindow(stats.window);
-        private void OpenWiki() => OpenWindow(wiki.window);
-        private void OpenOptions() => OpenWindow(options.window);
+        private void OpenUpgrades() => ToggleWindow(upgrades.window);
+        private void OpenBuffs() => ToggleWindow(buffs.window);
+        private void OpenQuests() => ToggleWindow(quests.window);
+        private void OpenCredits() => ToggleWindow(credits.window);
+        private void OpenDisciples() => ToggleWindow(disciples.window);
+        private void OpenStats() => ToggleWindow(stats.window);
+        private void OpenWiki() => ToggleWindow(wiki.window);
+        private void OpenOptions() => ToggleWindow(options.window);
         private void ToggleInventory()
         {
             if (inventory.window != null)
                 inventory.window.SetActive(!inventory.window.activeSelf);
+            UpdateTownButtonsVisibility();
         }
 
-        private void OpenWindow(GameObject window)
+        private void ToggleWindow(GameObject window)
         {
-            CloseAllWindowsExceptInventory();
+            if (window == null)
+                return;
+
+            bool wasActive = window.activeSelf;
+            if (!wasActive)
+            {
+                CloseAllWindowsExceptInventory();
+            }
+            window.SetActive(!wasActive);
+            UpdateTownButtonsVisibility();
+        }
+
+        private void CloseWindow(GameObject window)
+        {
             if (window != null)
-                window.SetActive(true);
+                window.SetActive(false);
+            UpdateTownButtonsVisibility();
         }
 
         private void CloseAllWindowsExceptInventory()
@@ -153,6 +206,26 @@ namespace TimelessEchoes.UI
                 options.window.SetActive(false);
             if (inventory.window != null)
                 inventory.window.SetActive(false);
+            UpdateTownButtonsVisibility();
+        }
+
+        private bool AnyWindowOpen()
+        {
+            return (upgrades.window != null && upgrades.window.activeSelf)
+                   || (buffs.window != null && buffs.window.activeSelf)
+                   || (quests.window != null && quests.window.activeSelf)
+                   || (credits.window != null && credits.window.activeSelf)
+                   || (disciples.window != null && disciples.window.activeSelf)
+                   || (stats.window != null && stats.window.activeSelf)
+                   || (wiki.window != null && wiki.window.activeSelf)
+                   || (options.window != null && options.window.activeSelf)
+                   || (inventory.window != null && inventory.window.activeSelf);
+        }
+
+        private void UpdateTownButtonsVisibility()
+        {
+            if (townButtons != null)
+                townButtons.SetActive(!AnyWindowOpen());
         }
     }
 }


### PR DESCRIPTION
## Summary
- extend `WindowReference` with close button references
- add town buttons container and toggle helper methods
- update button handlers to toggle windows and control town buttons visibility

## Testing
- `apt-get update`
- `apt-get install -y mono-mcs` *(fails to compile project due to missing Unity references)*

------
https://chatgpt.com/codex/tasks/task_e_68899a318a10832eb483b6afb2f9d2e9