### PR TITLE
Offset enemy level by spawn offset

### DIFF
--- a/Assets/Scripts/Enemies/Enemy.cs
+++ b/Assets/Scripts/Enemies/Enemy.cs
@@ -65,7 +65,12 @@ namespace TimelessEchoes.Enemies
             setter = GetComponent<AIDestinationSetter>();
             health = GetComponent<Health>();
             spawnPos = transform.position;
-            level = stats != null ? stats.GetLevel(spawnPos.x) : 1;
+            float spawnOffset = GameManager.CurrentGenerationConfig != null
+                ? GameManager.CurrentGenerationConfig.taskGeneratorSettings.enemySpawnXOffset
+                : 0f;
+            level = stats != null
+                ? stats.GetLevel(spawnPos.x - spawnOffset - stats.minX)
+                : 1;
 
             var controller = GetComponentInParent<TaskController>();
             if (controller != null)


### PR DESCRIPTION
## Summary
- apply enemy spawn offset when calculating enemy level

## Testing
- `dotnet test` *(fails: MSBUILD error, no project file)*

------
https://chatgpt.com/codex/tasks/task_e_68899feaf748832e8f1eb13a132a1ee8