### PR TITLE
Implement slot-based auto buff

### DIFF
--- a/Assets/Scripts/Blindsided/Oracle.cs
+++ b/Assets/Scripts/Blindsided/Oracle.cs
@@ -247,10 +247,18 @@ namespace Blindsided
             if (saveData.BuffSlots.Count < 5)
                 while (saveData.BuffSlots.Count < 5)
                     saveData.BuffSlots.Add(null);
+            saveData.AutoBuffSlots ??= new List<bool>(new bool[5]);
+            if (saveData.AutoBuffSlots.Count < 5)
+                while (saveData.AutoBuffSlots.Count < 5)
+                    saveData.AutoBuffSlots.Add(false);
             if (saveData.UnlockedBuffSlots <= 0)
                 saveData.UnlockedBuffSlots = 1;
             else if (saveData.UnlockedBuffSlots > 5)
                 saveData.UnlockedBuffSlots = 5;
+            if (saveData.UnlockedAutoBuffSlots < 0)
+                saveData.UnlockedAutoBuffSlots = 0;
+            else if (saveData.UnlockedAutoBuffSlots > 5)
+                saveData.UnlockedAutoBuffSlots = 5;
             saveData.Quests ??= new Dictionary<string, GameData.QuestRecord>();
         }
 

--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -27,10 +27,9 @@ namespace Blindsided.SaveData
         [HideReferenceObjectPicker]
         public List<string> BuffSlots = new() { "MoveSpeed", null, null, null, null };
         public int UnlockedBuffSlots = 1;
-        /// <summary>
-        ///     Automatically cast available buffs when enabled.
-        /// </summary>
-        public bool AutoBuff;
+        public int UnlockedAutoBuffSlots = 0;
+        [HideReferenceObjectPicker]
+        public List<bool> AutoBuffSlots = new() { false, false, false, false, false };
 
         [HideReferenceObjectPicker] public HashSet<string> CompletedNpcTasks = new();
 
@@ -134,6 +133,8 @@ namespace Blindsided.SaveData
             public Dictionary<string, double> KillProgress = new();
             public float DistanceBaseline;
             public bool DistanceBaselineSet;
+            public int BuffCastBaseline;
+            public bool BuffCastBaselineSet;
         }
 
         [HideReferenceObjectPicker]

--- a/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
+++ b/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
@@ -133,35 +133,23 @@ namespace Blindsided.SaveData
             set => oracle.saveData.SavedPreferences.AutoPinActiveQuests = value;
         }
 
-        /// <summary>
-        ///     Indicates whether autobuff is enabled. The saved preference can
-        ///     temporarily be disabled for the remainder of a run without
-        ///     affecting the persisted value.
-        /// </summary>
-        public static bool AutoBuff
+        public static int UnlockedAutoBuffSlots
         {
-            get => oracle.saveData.AutoBuff && !autoBuffDisabledThisRun;
-            set
-            {
-                if (oracle.saveData.AutoBuff != value)
-                {
-                    oracle.saveData.AutoBuff = value;
-                    AutoBuffChanged?.Invoke();
-                }
-            }
+            get => oracle.saveData.UnlockedAutoBuffSlots;
+            set => oracle.saveData.UnlockedAutoBuffSlots = Mathf.Clamp(value, 0, 5);
         }
 
-        private static bool autoBuffDisabledThisRun;
-
-        /// <summary>
-        ///     Temporarily enable or disable autobuff until the next run starts.
-        /// </summary>
-        /// <param name="disabled">True to disable autobuff for the current run.</param>
-        public static void SetAutoBuffRunDisabled(bool disabled)
+        public static bool GetAutoBuffSlot(int index)
         {
-            if (autoBuffDisabledThisRun != disabled)
+            return index >= 0 && index < oracle.saveData.AutoBuffSlots.Count && oracle.saveData.AutoBuffSlots[index];
+        }
+
+        public static void SetAutoBuffSlot(int index, bool value)
+        {
+            if (index < 0 || index >= oracle.saveData.AutoBuffSlots.Count) return;
+            if (oracle.saveData.AutoBuffSlots[index] != value)
             {
-                autoBuffDisabledThisRun = disabled;
+                oracle.saveData.AutoBuffSlots[index] = value;
                 AutoBuffChanged?.Invoke();
             }
         }

--- a/Assets/Scripts/Buffs/BuffUIManager.cs
+++ b/Assets/Scripts/Buffs/BuffUIManager.cs
@@ -63,7 +63,14 @@ namespace TimelessEchoes.Buffs
                         ui.iconImage.color = recipe ? Color.white : transparent;
                 }
                 if (ui != null && ui.activateButton != null)
-                    ui.activateButton.interactable = isAssigning && i < unlocked;
+                {
+                    if (isAssigning)
+                        ui.activateButton.interactable = i < unlocked;
+                    else
+                        ui.activateButton.interactable = buffManager != null && buffManager.IsAutoSlotUnlocked(i);
+                }
+                if (ui != null && ui.autoCastImage != null)
+                    ui.autoCastImage.enabled = buffManager != null && buffManager.IsSlotAutoCasting(i);
             }
 
             bool heroAlive = heroHealth != null && heroHealth.gameObject.activeInHierarchy && heroHealth.CurrentHealth > 0f;
@@ -101,6 +108,8 @@ namespace TimelessEchoes.Buffs
 
                 if (ui.activateButton != null)
                     ui.activateButton.interactable = i < unlocked && recipe != null && canBuy && distanceOk && heroAlive;
+                if (ui.autoCastImage != null)
+                    ui.autoCastImage.enabled = buffManager != null && buffManager.IsSlotAutoCasting(i);
 
                 if (ui.durationText != null)
                 {
@@ -334,8 +343,14 @@ namespace TimelessEchoes.Buffs
 
         private void OnAssignSlot(int slot)
         {
-            if (selectedRecipe != null && buffManager != null && buffManager.IsSlotUnlocked(slot))
+            if (isAssigning && selectedRecipe != null && buffManager != null && buffManager.IsSlotUnlocked(slot))
+            {
                 buffManager.AssignBuff(slot, selectedRecipe);
+            }
+            else
+            {
+                buffManager?.ToggleSlotAutoCast(slot);
+            }
             selectedRecipe = null;
             isAssigning = false;
             RefreshSlots();

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -57,11 +57,6 @@ namespace TimelessEchoes
         [TitleGroup("UI/General")]
         [SerializeField] private TMP_Text returnOnDeathText;
         [TitleGroup("UI/General")]
-        [SerializeField] private GameObject autoBuffRoot;
-        [TitleGroup("UI/General")]
-        [SerializeField] private Button autoBuffButton;
-        [TitleGroup("UI/General")]
-        [SerializeField] private TMP_Text autoBuffText;
         [TitleGroup("UI/General")]
         [SerializeField] [Min(0f)] private float bonusPercentPerKill = 2f;
         [TitleGroup("UI/General")]
@@ -165,8 +160,6 @@ namespace TimelessEchoes
                 deathRunButton.onClick.AddListener(OnDeathRunButton);
             if (deathReturnButton != null)
                 deathReturnButton.onClick.AddListener(OnDeathReturnButton);
-            if (autoBuffButton != null)
-                autoBuffButton.onClick.AddListener(ToggleAutoBuff);
             npcObjectStateController = NpcObjectStateController.Instance;
             if (npcObjectStateController == null)
                 Log("NpcObjectStateController missing", TELogCategory.General, this);
@@ -192,8 +185,6 @@ namespace TimelessEchoes
                 deathRunButton.onClick.RemoveListener(OnDeathRunButton);
             if (deathReturnButton != null)
                 deathReturnButton.onClick.RemoveListener(OnDeathReturnButton);
-            if (autoBuffButton != null)
-                autoBuffButton.onClick.RemoveListener(ToggleAutoBuff);
             foreach (var pair in _buttonActions)
             {
                 if (pair.Key != null)
@@ -221,16 +212,13 @@ namespace TimelessEchoes
             if (returnOnDeathText != null)
                 returnOnDeathText.text = "Return On Death";
             npcObjectStateController?.UpdateObjectStates();
-            UpdateAutoBuffUI();
-            if (autoBuffRoot != null)
-                autoBuffRoot.SetActive(false);
+            
             UpdateGenerationButtonStats();
             nextStatsUpdateTime = Time.time + statsUpdateInterval;
         }
 
         private void Update()
         {
-            UpdateAutoBuffUI();
             if (Time.time >= nextStatsUpdateTime)
             {
                 UpdateGenerationButtonStats();
@@ -287,8 +275,6 @@ namespace TimelessEchoes
                 StartCoroutine(ReturnToTavernRoutine());
             }
 
-            if (autoBuffRoot != null && statTracker != null)
-                autoBuffRoot.SetActive(statTracker.BuffsCast >= 100);
         }
 
         private void HideTooltip()
@@ -298,17 +284,6 @@ namespace TimelessEchoes
                 tooltip.gameObject.SetActive(false);
         }
 
-        private void ToggleAutoBuff()
-        {
-            AutoBuff = !AutoBuff;
-            UpdateAutoBuffUI();
-        }
-
-        private void UpdateAutoBuffUI()
-        {
-            if (autoBuffText != null)
-                autoBuffText.text = AutoBuff ? "Autobuff | On" : "Autobuff | Off";
-        }
 
         private void OnReturnToTavernButton()
         {
@@ -349,8 +324,6 @@ namespace TimelessEchoes
         {
             HideTooltip();
             cloudSpawner?.SetAllowClouds(CurrentGenerationConfig == null || CurrentGenerationConfig.allowClouds);
-            // Re-enable autobuff for the new run based on the saved preference.
-            SetAutoBuffRunDisabled(false);
             heroDead = false;
             returnOnDeathQueued = false;
             retreatQueued = false;
@@ -497,9 +470,6 @@ namespace TimelessEchoes
             if (statTracker != null) statTracker.AddDeath();
 
             BuffManager.Instance?.ClearActiveBuffs();
-            // Temporarily disable autobuff for the remainder of this run.
-            SetAutoBuffRunDisabled(true);
-            UpdateAutoBuffUI();
 
             runEndedByDeath = true;
             runEndedByReaper = distanceReaper;
@@ -570,9 +540,7 @@ namespace TimelessEchoes
         private IEnumerator ReturnToTavernRoutine()
         {
             HideTooltip();
-            // Reactivate autobuff if it was temporarily disabled by death.
-            SetAutoBuffRunDisabled(false);
-            UpdateAutoBuffUI();
+            // Reset state after death.
             heroDead = false;
             returnOnDeathQueued = false;
             retreatQueued = false;

--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -881,7 +881,9 @@ namespace TimelessEchoes.Hero
         private void OnAutoBuffChanged()
         {
             if (AutoBuffAnimator == null) return;
-            AutoBuffAnimator.gameObject.SetActive(AutoBuff && !IsEcho);
+            var manager = TimelessEchoes.Buffs.BuffManager.Instance;
+            bool active = manager != null && manager.AnySlotAutoBuffing && !IsEcho;
+            AutoBuffAnimator.gameObject.SetActive(active);
             if (animator != null && AutoBuffAnimator.isActiveAndEnabled)
             {
                 AutoBuffAnimator.runtimeAnimatorController = animator.runtimeAnimatorController;

--- a/Assets/Scripts/Quests/PinnedQuestUIManager.cs
+++ b/Assets/Scripts/Quests/PinnedQuestUIManager.cs
@@ -137,6 +137,11 @@ namespace TimelessEchoes.Quests
                             if (rec != null)
                                 current -= rec.DistanceBaseline;
                             break;
+                        case QuestData.RequirementType.BuffCast:
+                            current = tracker ? tracker.BuffsCast : 0;
+                            if (rec != null)
+                                current -= rec.BuffCastBaseline;
+                            break;
                         case QuestData.RequirementType.Instant:
                             current = target;
                             break;

--- a/Assets/Scripts/Quests/QuestData.cs
+++ b/Assets/Scripts/Quests/QuestData.cs
@@ -20,6 +20,7 @@ namespace TimelessEchoes.Quests
         public List<QuestData> requiredQuests = new();
         public List<Requirement> requirements = new();
         public int unlockBuffSlots;
+        public int unlockAutoBuffSlots;
         public float maxDistanceIncrease;
 
         [Serializable]
@@ -47,6 +48,7 @@ namespace TimelessEchoes.Quests
             Kill,
             DistanceRun,
             DistanceTravel,
+            BuffCast,
             Instant,
             Meet
         }

--- a/Assets/Scripts/Quests/QuestEntryUI.cs
+++ b/Assets/Scripts/Quests/QuestEntryUI.cs
@@ -123,7 +123,8 @@ namespace TimelessEchoes.Quests
                         if (req.type == QuestData.RequirementType.Instant ||
                             req.type == QuestData.RequirementType.DistanceRun ||
                             req.type == QuestData.RequirementType.DistanceTravel ||
-                            req.type == QuestData.RequirementType.Meet)
+                            req.type == QuestData.RequirementType.Meet ||
+                            req.type == QuestData.RequirementType.BuffCast)
                             continue;
 
                         var slot = Instantiate(costSlotPrefab, costParent);
@@ -150,7 +151,8 @@ namespace TimelessEchoes.Quests
                             }
                             else if (req.type == QuestData.RequirementType.DistanceRun ||
                                      req.type == QuestData.RequirementType.DistanceTravel ||
-                                     req.type == QuestData.RequirementType.Meet)
+                                     req.type == QuestData.RequirementType.Meet ||
+                                     req.type == QuestData.RequirementType.BuffCast)
                             {
                                 slot.iconImage.sprite = null;
                                 slot.iconImage.color = Color.white;
@@ -212,7 +214,8 @@ namespace TimelessEchoes.Quests
                 }
                 else if (req.type == QuestData.RequirementType.DistanceRun ||
                          req.type == QuestData.RequirementType.DistanceTravel ||
-                         req.type == QuestData.RequirementType.Meet)
+                         req.type == QuestData.RequirementType.Meet ||
+                         req.type == QuestData.RequirementType.BuffCast)
                 {
                     slot.iconImage.sprite = null;
                     slot.iconImage.color = Color.white;
@@ -253,6 +256,8 @@ namespace TimelessEchoes.Quests
                     return "Run Distance";
                 case QuestData.RequirementType.DistanceTravel:
                     return "Travel";
+                case QuestData.RequirementType.BuffCast:
+                    return "Buffs";
                 case QuestData.RequirementType.Instant:
                     return "Information";
                 case QuestData.RequirementType.Meet:

--- a/Assets/Scripts/Quests/QuestManager.cs
+++ b/Assets/Scripts/Quests/QuestManager.cs
@@ -229,6 +229,15 @@ namespace TimelessEchoes.Quests
                     if (req.amount > 0)
                         pct = travelled / req.amount;
                 }
+                else if (req.type == QuestData.RequirementType.BuffCast)
+                {
+                    var tracker = GameplayStatTracker.Instance;
+                    var casts = tracker ? tracker.BuffsCast : 0;
+                    if (oracle.saveData.Quests.TryGetValue(inst.data.questId, out var rec) && rec.BuffCastBaselineSet)
+                        casts -= rec.BuffCastBaseline;
+                    if (req.amount > 0)
+                        pct = (float)casts / req.amount;
+                }
                 else if (req.type == QuestData.RequirementType.Instant)
                 {
                     pct = 1f;
@@ -271,6 +280,8 @@ namespace TimelessEchoes.Quests
             record.Completed = true;
             if (inst.data.unlockBuffSlots > 0)
                 BuffManager.Instance?.UnlockSlots(inst.data.unlockBuffSlots);
+            if (inst.data.unlockAutoBuffSlots > 0)
+                BuffManager.Instance?.UnlockAutoSlots(inst.data.unlockAutoBuffSlots);
             if (inst.data.maxDistanceIncrease > 0f)
                 GameplayStatTracker.Instance?.IncreaseMaxRunDistance(inst.data.maxDistanceIncrease);
             if (!string.IsNullOrEmpty(inst.data.npcId))
@@ -381,6 +392,14 @@ namespace TimelessEchoes.Quests
                     {
                         rec.DistanceBaseline = statTracker ? statTracker.DistanceTravelled : 0f;
                         rec.DistanceBaselineSet = true;
+                        break;
+                    }
+            if (!rec.BuffCastBaselineSet)
+                foreach (var req in quest.requirements)
+                    if (req.type == QuestData.RequirementType.BuffCast)
+                    {
+                        rec.BuffCastBaseline = statTracker ? statTracker.BuffsCast : 0;
+                        rec.BuffCastBaselineSet = true;
                         break;
                     }
 

--- a/Assets/Scripts/References/UI/BuffSlotUIReferences.cs
+++ b/Assets/Scripts/References/UI/BuffSlotUIReferences.cs
@@ -11,6 +11,7 @@ namespace References.UI
         public Button activateButton;
         public Image iconImage;
         public TMP_Text durationText;
+        public Image autoCastImage;
 
         public event Action<BuffSlotUIReferences> PointerEnter;
         public event Action<BuffSlotUIReferences> PointerExit;

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ combat using projectile attacks. Combat strength and movement speed are
 modified by stat upgrades.
 
 ### Auto Buff
-After you cast 100 buffs the **Autobuff** toggle becomes available in the
-game's UI. When enabled, any assigned buff that is not currently active will be
-automatically cast as soon as you have enough resources.
+Quests now unlock auto buff slots after you cast a set number of buffs. Each
+unlocked slot can be toggled individually and will automatically cast its
+assigned buff whenever it is available.
 
 ## Echoes
 Clones spawned by milestones are referred to as **Echoes**. An Echo performs


### PR DESCRIPTION
## Summary
- remove global autobuff toggle in GameManager
- introduce auto buff slot tracking
- save auto buff slot status
- support auto buff quest rewards
- display auto buff status in buff slot UI
- update documentation for new system

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6889a53c1b5c832ebd3133a99518459d