### PR TITLE
Fix event invocation for AutoBuffChanged

### DIFF
--- a/Assets/Scripts/Buffs/BuffManager.cs
+++ b/Assets/Scripts/Buffs/BuffManager.cs
@@ -377,8 +377,7 @@ namespace TimelessEchoes.Buffs
             if (slot < 0 || slot >= autoCastSlots.Count) return;
             autoCastSlots[slot] = !autoCastSlots[slot];
             if (oracle != null && oracle.saveData.AutoBuffSlots != null)
-                oracle.saveData.AutoBuffSlots[slot] = autoCastSlots[slot];
-            AutoBuffChanged?.Invoke();
+                SetAutoBuffSlot(slot, autoCastSlots[slot]);
         }
 
         public BuffRecipe GetAssigned(int slot)


### PR DESCRIPTION
## Summary
- when toggling auto buff slots, call `SetAutoBuffSlot` from `StaticReferences`
- removes direct invocation of the `AutoBuffChanged` event which caused a compile error

## Testing
- `N/A`

------
https://chatgpt.com/codex/tasks/task_e_6889aa7bb6a4832e9c455427f95969b7