### PR TITLE
Show enemy name in level text

### DIFF
--- a/Assets/Scripts/Enemies/Enemy.cs
+++ b/Assets/Scripts/Enemies/Enemy.cs
@@ -86,7 +86,12 @@ namespace TimelessEchoes.Enemies
             }
 
             if (levelText != null)
-                levelText.text = $"Lvl {level}";
+            {
+                if (stats != null && !string.IsNullOrEmpty(stats.enemyName))
+                    levelText.text = $"{stats.enemyName} Lvl {level}";
+                else
+                    levelText.text = $"Lvl {level}";
+            }
 
             startTarget = setter.target;
             resourceManager = ResourceManager.Instance;


### PR DESCRIPTION
## Summary
- include the enemy's name before its level text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6889c17bbca8832eaade0a088f2e291f