### PR TITLE
Adjust pinned resource text size to 90%

### DIFF
--- a/Assets/Scripts/Quests/PinnedQuestUIManager.cs
+++ b/Assets/Scripts/Quests/PinnedQuestUIManager.cs
@@ -185,9 +185,9 @@ namespace TimelessEchoes.Quests
                     {
                         var name = req.resource ? req.resource.name : "";
                         if (target <= 0)
-                            sb.AppendLine($"<size=80%>{name}: {CalcUtils.FormatNumber(current, true)}</size>");
+                            sb.AppendLine($"<size=90%>{name}: {CalcUtils.FormatNumber(current, true)}</size>");
                         else
-                            sb.AppendLine($"<size=80%>{name}: {CalcUtils.FormatNumber(current, true)} / {CalcUtils.FormatNumber(target, true)}</size>");
+                            sb.AppendLine($"<size=90%>{name}: {CalcUtils.FormatNumber(current, true)} / {CalcUtils.FormatNumber(target, true)}</size>");
                     }
                     else if (req.type == QuestData.RequirementType.Kill && !string.IsNullOrEmpty(req.killName))
                     {


### PR DESCRIPTION
## Summary
- make pinned goal resource text slightly larger

## Testing
- `grep -n "size=90%" -n Assets/Scripts/Quests/PinnedQuestUIManager.cs`

------
https://chatgpt.com/codex/tasks/task_e_688a967423ac832eaf0a826abe319354