### PR TITLE
Fix enemy health text display

### DIFF
--- a/Assets/Scripts/Enemies/Health.cs
+++ b/Assets/Scripts/Enemies/Health.cs
@@ -73,7 +73,12 @@ namespace TimelessEchoes.Enemies
         private void HandleHealthChanged(float current, float max)
         {
             if (healthText != null)
-                healthText.text = $"{Mathf.FloorToInt(current)} / {Mathf.FloorToInt(max)}";
+            {
+                int shownCurrent = Mathf.FloorToInt(current);
+                if (shownCurrent == 0 && current > 0f)
+                    shownCurrent = 1;
+                healthText.text = $"{shownCurrent} / {Mathf.FloorToInt(max)}";
+            }
         }
 
         protected override void OnZeroHealth()


### PR DESCRIPTION
## Summary
- ensure enemy health text never shows 0 when health is above zero

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688aa7c85ef0832eac0487460cae3956