### PR TITLE
Fix resource tracker showing with no resources

### DIFF
--- a/Assets/Scripts/Upgrades/RunResourceTrackerUI.cs
+++ b/Assets/Scripts/Upgrades/RunResourceTrackerUI.cs
@@ -78,6 +78,13 @@ namespace TimelessEchoes.Upgrades
         {
             if (slotParent == null || slotPrefab == null)
                 return;
+            if (amounts.Count == 0)
+            {
+                if (window != null)
+                    window.SetActive(false);
+                return;
+            }
+
             ClearSlots();
             foreach (var pair in amounts)
             {
@@ -86,6 +93,13 @@ namespace TimelessEchoes.Upgrades
             }
             if (window != null)
                 window.SetActive(true);
+        }
+
+        private void Update()
+        {
+            if (Input.GetMouseButtonDown(1))
+                if (window != null && window.activeSelf)
+                    window.SetActive(false);
         }
 
         private void SetupSlot(ResourceUIReferences slot, Resource res, double amount)


### PR DESCRIPTION
## Summary
- avoid showing RunResourceTracker when no resources were gained
- hide RunResourceTracker UI when right-clicking

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ab70f0054832ebee17358264be9cc