### PR TITLE
Update screen safe area slider

### DIFF
--- a/Assets/Scripts/Blindsided/Utilities/ScreenSafeArea.cs
+++ b/Assets/Scripts/Blindsided/Utilities/ScreenSafeArea.cs
@@ -1,4 +1,8 @@
 using UnityEngine;
+using UnityEngine.UI;
+using UnityEngine.EventSystems;
+using UnityEngine.Events;
+using System.Collections;
 using static Blindsided.SaveData.StaticReferences;
 
 namespace Blindsided.Utilities
@@ -13,6 +17,10 @@ namespace Blindsided.Utilities
         private Rect lastSafeArea;
 
         private float ratioValue;
+        private bool sliderSetup;
+
+        [SerializeField] private Slider ratioSlider;
+        [SerializeField] private Image previewImage;
 
         const float minAspect = 16f / 9f;
         const float maxAspect = 32f / 9f;
@@ -50,8 +58,22 @@ namespace Blindsided.Utilities
         private void OnEnable()
         {
             _rectTransform = GetComponent<RectTransform>();
-            ratioValue = Mathf.Clamp01(SafeAreaRatio);
-            ApplySafeArea();
+            EventHandler.OnLoadData += OnLoadDataHandler;
+            if (previewImage != null)
+                previewImage.enabled = false;
+            StartCoroutine(InitRatio());
+        }
+
+        private void OnDisable()
+        {
+            EventHandler.OnLoadData -= OnLoadDataHandler;
+            if (sliderSetup && ratioSlider != null)
+            {
+                ratioSlider.onValueChanged.RemoveListener(OnSliderValueChanged);
+                sliderSetup = false;
+            }
+            if (previewImage != null)
+                previewImage.enabled = false;
         }
 
         private void Update()
@@ -60,6 +82,69 @@ namespace Blindsided.Utilities
             {
                 ApplySafeArea();
             }
+        }
+
+        private void OnLoadDataHandler()
+        {
+            StartCoroutine(InitRatio());
+        }
+
+        private IEnumerator InitRatio()
+        {
+            yield return null; // wait one frame for data to load
+            ratioValue = Mathf.Clamp01(SafeAreaRatio);
+            if (ratioSlider != null)
+            {
+                if (!sliderSetup)
+                {
+                    ratioSlider.onValueChanged.AddListener(OnSliderValueChanged);
+                    AddDragTriggers();
+                    sliderSetup = true;
+                }
+                ratioSlider.value = ratioValue;
+            }
+            ApplySafeArea();
+        }
+
+        private void AddDragTriggers()
+        {
+            if (ratioSlider == null)
+                return;
+            var trigger = ratioSlider.GetComponent<EventTrigger>();
+            if (trigger == null)
+                trigger = ratioSlider.gameObject.AddComponent<EventTrigger>();
+
+            AddEvent(trigger, EventTriggerType.BeginDrag, OnBeginDrag);
+            AddEvent(trigger, EventTriggerType.EndDrag, OnEndDrag);
+        }
+
+        private static void AddEvent(EventTrigger trigger, EventTriggerType type, UnityEngine.Events.UnityAction<BaseEventData> action)
+        {
+            foreach (var e in trigger.triggers)
+            {
+                if (e.eventID == type)
+                    return; // already added
+            }
+            var entry = new EventTrigger.Entry { eventID = type };
+            entry.callback.AddListener(action);
+            trigger.triggers.Add(entry);
+        }
+
+        private void OnBeginDrag(BaseEventData _)
+        {
+            if (previewImage != null)
+                previewImage.enabled = true;
+        }
+
+        private void OnEndDrag(BaseEventData _)
+        {
+            if (previewImage != null)
+                previewImage.enabled = false;
+        }
+
+        private void OnSliderValueChanged(float value)
+        {
+            RatioPreference = value;
         }
 
         void ApplySafeArea()


### PR DESCRIPTION
## Summary
- reference slider and preview image in `ScreenSafeArea`
- apply saved safe-area ratio after a one-frame delay
- show preview image while the slider is dragged

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688ad6f80c80832e89563e835f4fdb86