### PR TITLE
Add windows open indicator to TownWindowManager

### DIFF
--- a/Assets/Scripts/UI/TownWindowManager.cs
+++ b/Assets/Scripts/UI/TownWindowManager.cs
@@ -33,6 +33,7 @@ namespace TimelessEchoes.UI
         [SerializeField] [Space] private WindowReference inventory = new();
         [SerializeField] [Space] private WindowReference options = new();
         [SerializeField] [Space] private GameObject townButtons;
+        [SerializeField] [Space] private GameObject windowsOpenIndicator;
 
 
         private void Awake()
@@ -254,6 +255,8 @@ namespace TimelessEchoes.UI
         {
             if (townButtons != null)
                 townButtons.SetActive(!AnyWindowOpen());
+            if (windowsOpenIndicator != null)
+                windowsOpenIndicator.SetActive(AnyWindowOpen());
         }
     }
 }


### PR DESCRIPTION
## Summary
- expose a new `windowsOpenIndicator` GameObject on `TownWindowManager`
- enable the indicator whenever any window is open and disable it otherwise

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_688adb246120832eb3154a845c14a1d4