### PR TITLE
Fix stats window indicator

### DIFF
--- a/Assets/Scripts/UI/TownWindowManager.cs
+++ b/Assets/Scripts/UI/TownWindowManager.cs
@@ -254,12 +254,29 @@ namespace TimelessEchoes.UI
                    || (inventory.window != null && inventory.window.activeSelf);
         }
 
+        /// <summary>
+        ///     Determines whether any window other than the stats window is open.
+        ///     Used for the windows open indicator so that opening the stats
+        ///     screen does not activate it.
+        /// </summary>
+        private bool AnyWindowOpenForIndicator()
+        {
+            return (upgrades.window != null && upgrades.window.activeSelf)
+                   || (buffs.window != null && buffs.window.activeSelf)
+                   || (quests.window != null && quests.window.activeSelf)
+                   || (credits.window != null && credits.window.activeSelf)
+                   || (disciples.window != null && disciples.window.activeSelf)
+                   || (wiki.window != null && wiki.window.activeSelf)
+                   || (options.window != null && options.window.activeSelf)
+                   || (inventory.window != null && inventory.window.activeSelf);
+        }
+
         private void UpdateTownButtonsVisibility()
         {
             if (townButtons != null)
                 townButtons.SetActive(!AnyWindowOpen());
             if (windowsOpenIndicator != null)
-                windowsOpenIndicator.SetActive(AnyWindowOpen());
+                windowsOpenIndicator.SetActive(AnyWindowOpenForIndicator());
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure the window open indicator is not displayed when only the Stats screen is open

## Testing
- `dotnet --version` *(fails: command not found)*
- `mcs -version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_688ae2a1b6e4832eb99e75821361f031