### PR TITLE
ScreenSafeArea mobile behaviour

### DIFF
--- a/Assets/Scripts/Blindsided/Utilities/ScreenSafeArea.cs
+++ b/Assets/Scripts/Blindsided/Utilities/ScreenSafeArea.cs
@@ -21,6 +21,7 @@ namespace Blindsided.Utilities
 
         [SerializeField] private Slider ratioSlider;
         [SerializeField] private Image previewImage;
+        [SerializeField] private GameObject hideOnMobile;
 
         const float minAspect = 16f / 9f;
         const float maxAspect = 32f / 9f;
@@ -59,6 +60,14 @@ namespace Blindsided.Utilities
         {
             _rectTransform = GetComponent<RectTransform>();
             EventHandler.OnLoadData += OnLoadDataHandler;
+
+            if (Application.isMobilePlatform)
+            {
+                if (hideOnMobile != null)
+                    hideOnMobile.SetActive(false);
+                RatioPreference = 1f;
+            }
+
             if (previewImage != null)
                 previewImage.enabled = false;
             StartCoroutine(InitRatio());


### PR DESCRIPTION
## Summary
- hide a referenced GameObject on mobile platforms and set safe area ratio to max

## Testing
- `apt-get update`
- `apt-get install -y mono-devel`

------
https://chatgpt.com/codex/tasks/task_e_688ae3174930832e9a5a8017df017495