### PR TITLE
Add right-click closure for skills window

### DIFF
--- a/Assets/Scripts/UI/RunCalebUIManager.cs
+++ b/Assets/Scripts/UI/RunCalebUIManager.cs
@@ -82,6 +82,9 @@ namespace TimelessEchoes.UI
         private void Update()
         {
             UpdateStats();
+            if (Input.GetMouseButtonDown(1))
+                if (skillsWindow != null && skillsWindow.activeSelf)
+                    skillsWindow.SetActive(false);
         }
 
         private void ToggleSkills()


### PR DESCRIPTION
## Summary
- close the skills window when right clicking during a run

## Testing
- `pytest -q`
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ae7e3a1cc832eadbb740657c4d35c