### PR TITLE
Randomize stump and rock sprites

### DIFF
--- a/Assets/Scripts/Tasks/MiningTask.cs
+++ b/Assets/Scripts/Tasks/MiningTask.cs
@@ -11,6 +11,8 @@ namespace TimelessEchoes.Tasks
     {
         [SerializeField] private SpriteRenderer spriteRenderer;
         [SerializeField] private Sprite depletedSprite;
+        [Tooltip("Optional extra depleted sprites chosen at random")] [SerializeField]
+        private Sprite[] depletedSpriteOptions;
         [SerializeField] private Transform miningPoint;
 
         private Sprite originalSprite;
@@ -43,9 +45,26 @@ namespace TimelessEchoes.Tasks
                 isDepleted = true;
                 if (spriteRenderer == null)
                     spriteRenderer = GetComponent<SpriteRenderer>();
-                if (spriteRenderer != null && depletedSprite != null)
-                    spriteRenderer.sprite = depletedSprite;
+                if (spriteRenderer != null)
+                {
+                    var s = ChooseDepletedSprite();
+                    if (s != null)
+                        spriteRenderer.sprite = s;
+                }
             }
+        }
+
+        private Sprite ChooseDepletedSprite()
+        {
+            if (depletedSpriteOptions == null || depletedSpriteOptions.Length == 0)
+                return depletedSprite;
+
+            var count = depletedSpriteOptions.Length + (depletedSprite != null ? 1 : 0);
+            var index = Random.Range(0, count);
+            if (index == 0 && depletedSprite != null)
+                return depletedSprite;
+            var optionIndex = depletedSprite != null ? index - 1 : index;
+            return depletedSpriteOptions[optionIndex];
         }
     }
 }

--- a/Assets/Scripts/Tasks/WoodcuttingTask.cs
+++ b/Assets/Scripts/Tasks/WoodcuttingTask.cs
@@ -11,6 +11,8 @@ namespace TimelessEchoes.Tasks
     {
         [SerializeField] private SpriteRenderer spriteRenderer;
         [SerializeField] private Sprite stumpSprite;
+        [Tooltip("Optional extra stump sprites chosen at random")] [SerializeField]
+        private Sprite[] stumpSpriteOptions;
 
         [SerializeField] private Transform cuttingPoint;
 
@@ -44,9 +46,26 @@ namespace TimelessEchoes.Tasks
                 spawnedStump = true;
                 if (spriteRenderer == null)
                     spriteRenderer = GetComponent<SpriteRenderer>();
-                if (spriteRenderer != null && stumpSprite != null)
-                    spriteRenderer.sprite = stumpSprite;
+                if (spriteRenderer != null)
+                {
+                    var s = ChooseStumpSprite();
+                    if (s != null)
+                        spriteRenderer.sprite = s;
+                }
             }
+        }
+
+        private Sprite ChooseStumpSprite()
+        {
+            if (stumpSpriteOptions == null || stumpSpriteOptions.Length == 0)
+                return stumpSprite;
+
+            var count = stumpSpriteOptions.Length + (stumpSprite != null ? 1 : 0);
+            var index = Random.Range(0, count);
+            if (index == 0 && stumpSprite != null)
+                return stumpSprite;
+            var optionIndex = stumpSprite != null ? index - 1 : index;
+            return stumpSpriteOptions[optionIndex];
         }
     }
 }


### PR DESCRIPTION
## Summary
- support multiple stump sprites for woodcutting tasks
- support multiple depleted rock sprites for mining tasks
- choose a random stump/rock sprite when tasks complete

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688ae8239cc0832e92fb41abc33ec82c