### PR TITLE
Add toggle for pinned quest panel

### DIFF
--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -81,6 +81,10 @@ namespace Blindsided.SaveData
             ///     Automatically pin new quests when they become active.
             /// </summary>
             public bool AutoPinActiveQuests = true;
+            /// <summary>
+            ///     Whether the pinned quest panel is visible.
+            /// </summary>
+            public bool ShowPinnedQuests = true;
             public bool UseScaledTimeForValues;
             public float MasterVolume = 1f;
             public float MusicVolume = 0.25f;

--- a/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
+++ b/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
@@ -140,6 +140,12 @@ namespace Blindsided.SaveData
             set => oracle.saveData.SavedPreferences.AutoPinActiveQuests = value;
         }
 
+        public static bool ShowPinnedQuests
+        {
+            get => oracle.saveData.SavedPreferences.ShowPinnedQuests;
+            set => oracle.saveData.SavedPreferences.ShowPinnedQuests = value;
+        }
+
         public static int UnlockedAutoBuffSlots
         {
             get => oracle.saveData.UnlockedAutoBuffSlots;

--- a/Assets/Scripts/Quests/PinnedQuestUIManager.cs
+++ b/Assets/Scripts/Quests/PinnedQuestUIManager.cs
@@ -8,6 +8,7 @@ using UnityEngine;
 using UnityEngine.UI;
 using static Blindsided.EventHandler;
 using static Blindsided.Oracle;
+using static Blindsided.SaveData.StaticReferences;
 
 namespace TimelessEchoes.Quests
 {
@@ -20,16 +21,31 @@ namespace TimelessEchoes.Quests
 
         [SerializeField] private QuestPinUI entryPrefab;
         [SerializeField] private Transform entryParent;
+        [SerializeField] private Button toggleButton;
+        [SerializeField] private Image stateImage;
+        [SerializeField] private Sprite openSprite;
+        [SerializeField] private Sprite closeSprite;
 
         private readonly Dictionary<string, QuestPinUI> entries = new();
 
         private void Awake()
         {
             Instance = this;
+
+            if (toggleButton == null)
+                toggleButton = GetComponent<Button>();
+
+            if (toggleButton != null)
+                toggleButton.onClick.AddListener(OnToggle);
+
+            ApplySavedState();
         }
 
         private void OnDestroy()
         {
+            if (toggleButton != null)
+                toggleButton.onClick.RemoveListener(OnToggle);
+
             if (Instance == this)
                 Instance = null;
         }
@@ -219,12 +235,35 @@ namespace TimelessEchoes.Quests
         private void OnLoadDataHandler()
         {
             StartCoroutine(DeferredRefresh());
+            ApplySavedState();
         }
 
         private IEnumerator DeferredRefresh()
         {
             yield return null; // wait one frame so data is loaded
             RefreshPins();
+        }
+
+        private void OnToggle()
+        {
+            bool newState = !entryParent.gameObject.activeSelf;
+            entryParent.gameObject.SetActive(newState);
+            UpdateToggleVisual(newState);
+            ShowPinnedQuests = newState;
+        }
+
+        private void ApplySavedState()
+        {
+            bool show = ShowPinnedQuests;
+            if (entryParent != null)
+                entryParent.gameObject.SetActive(show);
+            UpdateToggleVisual(show);
+        }
+
+        private void UpdateToggleVisual(bool show)
+        {
+            if (stateImage != null)
+                stateImage.sprite = show ? closeSprite : openSprite;
         }
     }
 }


### PR DESCRIPTION
## Summary
- store pinned quest panel visibility in `GameData.Preferences`
- expose `ShowPinnedQuests` via `StaticReferences`
- add toggle button to `PinnedQuestUIManager` to show/hide entries and update sprite

## Testing
- `echo "No tests present"`

------
https://chatgpt.com/codex/tasks/task_e_688af2ab774c832eb44e62b3292e5102