### PR TITLE
Update floating text location and resource IDs

### DIFF
--- a/Assets/Scripts/Blindsided/Utilities/TextStrings.cs
+++ b/Assets/Scripts/Blindsided/Utilities/TextStrings.cs
@@ -13,11 +13,16 @@ namespace Blindsided.Utilities
         public const string IconWithColour = "<sprite=0 color=#00000>";
         public const string EndColour = "</color>";
 
-        public const string HealthIcon = "<sprite=0>";
-        public const string DamageIcon = "<sprite=24>";
-        public const string AttackSpeedIcon = "<sprite=150>";
-        public const string RangeIcon = "<sprite=5>";
-        public const string MoveSpeedIcon = "<sprite=11>";
-        public const string GoldIcon = "<sprite=4>";
+        /// <summary>
+        /// Returns a TextMeshPro sprite tag for the given sprite ID.
+        /// </summary>
+        public static string SpriteTag(int id) => $"<sprite={id}>";
+
+        public const int HealthIcon = 0;
+        public const int DamageIcon = 24;
+        public const int AttackSpeedIcon = 150;
+        public const int RangeIcon = 5;
+        public const int MoveSpeedIcon = 11;
+        public const int GoldIcon = 4;
     }
 }

--- a/Assets/Scripts/Enemies/Enemy.cs
+++ b/Assets/Scripts/Enemies/Enemy.cs
@@ -300,6 +300,7 @@ namespace TimelessEchoes.Enemies
                 gainMult = skillController.GetResourceGainMultiplier();
             }
 
+            var lines = new List<string>();
             foreach (var drop in stats.resourceDrops)
             {
                 if (drop.resource == null) continue;
@@ -314,10 +315,14 @@ namespace TimelessEchoes.Enemies
                 if (count > 0)
                 {
                     double final = count * mult * gainMult;
-                    resourceManager.Add(drop.resource, final);
+                    resourceManager.Add(drop.resource, final, transform.position);
                     Log($"Dropped {final} {drop.resource.name}", TELogCategory.Resource, this);
+                    lines.Add($"{TextStrings.SpriteTag(drop.resource.resourceID)}+{Mathf.FloorToInt((float)final)}");
                 }
             }
+
+            if (lines.Count > 0)
+                FloatingText.Spawn(string.Join("\n", lines), transform.position + Vector3.up, Color.white, 8f);
 
             var tracker = EnemyKillTracker.Instance;
             if (tracker == null)

--- a/Assets/Scripts/ResourceIDs.cs
+++ b/Assets/Scripts/ResourceIDs.cs
@@ -1,0 +1,65 @@
+namespace TimelessEchoes.Upgrades
+{
+    /// <summary>
+    /// IDs used by Resource assets. Values are placeholders and can be edited in the Unity editor.
+    /// </summary>
+    public static class ResourceIDs
+    {
+        public const int ResourceID1 = 0;
+        public const int ResourceID2 = 0;
+        public const int ResourceID3 = 0;
+        public const int ResourceID4 = 0;
+        public const int ResourceID5 = 0;
+        public const int ResourceID6 = 0;
+        public const int ResourceID7 = 0;
+        public const int ResourceID8 = 0;
+        public const int ResourceID9 = 0;
+        public const int ResourceID10 = 0;
+        public const int ResourceID11 = 0;
+        public const int ResourceID12 = 0;
+        public const int ResourceID13 = 0;
+        public const int ResourceID14 = 0;
+        public const int ResourceID15 = 0;
+        public const int ResourceID16 = 0;
+        public const int ResourceID17 = 0;
+        public const int ResourceID18 = 0;
+        public const int ResourceID19 = 0;
+        public const int ResourceID20 = 0;
+        public const int ResourceID21 = 0;
+        public const int ResourceID22 = 0;
+        public const int ResourceID23 = 0;
+        public const int ResourceID24 = 0;
+        public const int ResourceID25 = 0;
+        public const int ResourceID26 = 0;
+        public const int ResourceID27 = 0;
+        public const int ResourceID28 = 0;
+        public const int ResourceID29 = 0;
+        public const int ResourceID30 = 0;
+        public const int ResourceID31 = 0;
+        public const int ResourceID32 = 0;
+        public const int ResourceID33 = 0;
+        public const int ResourceID34 = 0;
+        public const int ResourceID35 = 0;
+        public const int ResourceID36 = 0;
+        public const int ResourceID37 = 0;
+        public const int ResourceID38 = 0;
+        public const int ResourceID39 = 0;
+        public const int ResourceID40 = 0;
+        public const int ResourceID41 = 0;
+        public const int ResourceID42 = 0;
+        public const int ResourceID43 = 0;
+        public const int ResourceID44 = 0;
+        public const int ResourceID45 = 0;
+        public const int ResourceID46 = 0;
+        public const int ResourceID47 = 0;
+        public const int ResourceID48 = 0;
+        public const int ResourceID49 = 0;
+        public const int ResourceID50 = 0;
+        public const int ResourceID51 = 0;
+        public const int ResourceID52 = 0;
+        public const int ResourceID53 = 0;
+        public const int ResourceID54 = 0;
+        public const int ResourceID55 = 0;
+        public const int ResourceID56 = 0;
+        public const int ResourceID57 = 0;
+    }\n}

--- a/Assets/Scripts/Tasks/ResourceGeneratingTask.cs
+++ b/Assets/Scripts/Tasks/ResourceGeneratingTask.cs
@@ -33,6 +33,7 @@ namespace TimelessEchoes.Tasks
                 return;
 
             var worldX = transform.position.x;
+            var lines = new List<string>();
 
             foreach (var drop in taskData.resourceDrops)
             {
@@ -48,18 +49,23 @@ namespace TimelessEchoes.Tasks
 
                 if (count > 0)
                 {
+                    double final = count;
                     if (skillController)
                     {
                         int mult = skillController.GetEffectMultiplier(associatedSkill, TimelessEchoes.Skills.MilestoneType.DoubleResources);
                         float resourceMult = skillController.GetResourceGainMultiplier();
-                        double amount = count * mult * resourceMult;
-                        resourceManager.Add(drop.resource, amount);
+                        final = count * mult * resourceMult;
                     }
-                    else
-                    {
-                        resourceManager.Add(drop.resource, count);
-                    }
+
+                    resourceManager.Add(drop.resource, final, transform.position);
+                    lines.Add($"{TextStrings.SpriteTag(drop.resource.resourceID)}+{Mathf.FloorToInt((float)final)}");
                 }
+            }
+
+            if (lines.Count > 0)
+            {
+                var text = string.Join("\n", lines);
+                FloatingText.Spawn(text, transform.position + Vector3.up, Color.white, 8f);
             }
         }
     }}

--- a/Assets/Scripts/Upgrades/ResourceManager.cs
+++ b/Assets/Scripts/Upgrades/ResourceManager.cs
@@ -24,7 +24,7 @@ namespace TimelessEchoes.Upgrades
         /// <summary>
         ///     Invoked whenever resources are added via <see cref="Add" />.
         /// </summary>
-        public event Action<Resource, double> OnResourceAdded;
+        public event Action<Resource, double, Vector3> OnResourceAdded;
 
         [Title("Debug Controls")] [SerializeField]
         private Resource debugResource;
@@ -78,6 +78,11 @@ namespace TimelessEchoes.Upgrades
 
         public void Add(Resource resource, double amount, bool bonus = false)
         {
+            Add(resource, amount, Vector3.zero, bonus);
+        }
+
+        public void Add(Resource resource, double amount, Vector3 worldPosition, bool bonus = false)
+        {
             if (resource == null || amount <= 0) return;
             unlocked.Add(resource);
             if (amounts.ContainsKey(resource))
@@ -90,7 +95,7 @@ namespace TimelessEchoes.Upgrades
                 Log("GameplayStatTracker missing", TELogCategory.Resource, this);
             else
                 tracker.AddResources(amount, bonus);
-            OnResourceAdded?.Invoke(resource, amount);
+            OnResourceAdded?.Invoke(resource, amount, worldPosition);
             InvokeInventoryChanged();
         }
 

--- a/Assets/Scripts/Upgrades/RunDropUI.cs
+++ b/Assets/Scripts/Upgrades/RunDropUI.cs
@@ -76,7 +76,7 @@ namespace TimelessEchoes.Upgrades
         }
 
 
-        private void OnResourceAdded(Resource resource, double amount)
+        private void OnResourceAdded(Resource resource, double amount, Vector3 position)
         {
             if (resource == null || amount <= 0) return;
 
@@ -132,16 +132,7 @@ namespace TimelessEchoes.Upgrades
 
             UpdateSlot(resources.IndexOf(resource));
 
-            if (slot != null)
-            {
-                if (newSlot || moved)
-                    StartCoroutine(SpawnFloatingTextNextFrame(slot, amount));
-                else
-                    FloatingText.Spawn(
-                        $"+{Mathf.FloorToInt((float)amount)}",
-                        slot.transform.position + Vector3.up,
-                        Color.white, 8f, transform);
-            }
+            // Floating text is now spawned at the drop location instead of the UI
 
         }
 
@@ -166,13 +157,7 @@ namespace TimelessEchoes.Upgrades
             }
         }
 
-        private IEnumerator SpawnFloatingTextNextFrame(ResourceUIReferences slot, double amount)
-        {
-            yield return null; // wait one frame for layout groups to update
-            if (slot != null)
-                FloatingText.Spawn($"+{Mathf.FloorToInt((float)amount)}", slot.transform.position + Vector3.up,
-                    Color.white, 8f, transform);
-        }
+        // Floating text display handled at drop location; UI no longer spawns it
 
     }
 }

--- a/Assets/Scripts/Upgrades/RunResourceTrackerUI.cs
+++ b/Assets/Scripts/Upgrades/RunResourceTrackerUI.cs
@@ -61,7 +61,7 @@ namespace TimelessEchoes.Upgrades
                 Destroy(child.gameObject);
         }
 
-        private void OnResourceAdded(Resource resource, double amount)
+        private void OnResourceAdded(Resource resource, double amount, Vector3 position)
         {
             if (resource == null || amount <= 0)
                 return;


### PR DESCRIPTION
## Summary
- change `TextStrings` to expose a helper for sprite tags and use integer icons
- allow `ResourceManager.Add` to accept a drop position
- show resource floating text at task or enemy drop location
- stop UI drop panel from spawning floating text
- add placeholder `ResourceIDs` constants for resource item IDs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b03b22ca4832eb929be6f9773c5b6