### PR TITLE
Adjust glyph bearings in FloatingTextIcons

### DIFF
--- a/Assets/Fonts/FloatingTextIcons.asset
+++ b/Assets/Fonts/FloatingTextIcons.asset
@@ -515,8 +515,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 0
@@ -531,8 +531,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 16
@@ -547,8 +547,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 32
@@ -563,8 +563,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 48
@@ -579,8 +579,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 64
@@ -595,8 +595,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 80
@@ -611,8 +611,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 96
@@ -627,8 +627,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 112
@@ -643,8 +643,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 128
@@ -659,8 +659,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 0
@@ -675,8 +675,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 16
@@ -691,8 +691,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 32
@@ -707,8 +707,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 48
@@ -723,8 +723,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 64
@@ -739,8 +739,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 80
@@ -755,8 +755,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 96
@@ -771,8 +771,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 112
@@ -787,8 +787,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 128
@@ -803,8 +803,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 0
@@ -819,8 +819,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 16
@@ -835,8 +835,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 32
@@ -851,8 +851,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 48
@@ -867,8 +867,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 64
@@ -883,8 +883,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 80
@@ -899,8 +899,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 96
@@ -915,8 +915,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 112
@@ -931,8 +931,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 128
@@ -947,8 +947,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 0
@@ -963,8 +963,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 16
@@ -979,8 +979,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 32
@@ -995,8 +995,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 48
@@ -1011,8 +1011,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 64
@@ -1027,8 +1027,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 80
@@ -1043,8 +1043,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 96
@@ -1059,8 +1059,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 112
@@ -1075,8 +1075,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 128
@@ -1091,8 +1091,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 0
@@ -1107,8 +1107,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 16
@@ -1123,8 +1123,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 32
@@ -1139,8 +1139,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 48
@@ -1155,8 +1155,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 64
@@ -1171,8 +1171,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 80
@@ -1187,8 +1187,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 96
@@ -1203,8 +1203,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 112
@@ -1219,8 +1219,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 128
@@ -1235,8 +1235,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 0
@@ -1251,8 +1251,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 16
@@ -1267,8 +1267,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 32
@@ -1283,8 +1283,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 48
@@ -1299,8 +1299,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 64
@@ -1315,8 +1315,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 80
@@ -1331,8 +1331,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 96
@@ -1347,8 +1347,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 112
@@ -1363,8 +1363,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 128
@@ -1379,8 +1379,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 0
@@ -1395,8 +1395,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 16
@@ -1411,8 +1411,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 32
@@ -1427,8 +1427,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 48
@@ -1443,8 +1443,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 64
@@ -1459,8 +1459,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 80
@@ -1475,8 +1475,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 96
@@ -1491,8 +1491,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 112
@@ -1507,8 +1507,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 128
@@ -1523,8 +1523,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 0
@@ -1539,8 +1539,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 16
@@ -1555,8 +1555,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 32
@@ -1571,8 +1571,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 48
@@ -1587,8 +1587,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 64
@@ -1603,8 +1603,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 80
@@ -1619,8 +1619,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 96
@@ -1635,8 +1635,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 112
@@ -1651,8 +1651,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 128
@@ -1667,8 +1667,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 0
@@ -1683,8 +1683,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 16
@@ -1699,8 +1699,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 32
@@ -1715,8 +1715,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 48
@@ -1731,8 +1731,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 64
@@ -1747,8 +1747,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 80
@@ -1763,8 +1763,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 96
@@ -1779,8 +1779,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 112
@@ -1795,8 +1795,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 128
@@ -1811,8 +1811,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 0
@@ -1827,8 +1827,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 16
@@ -1843,8 +1843,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 32
@@ -1859,8 +1859,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 48
@@ -1875,8 +1875,8 @@ MonoBehaviour:
     m_Metrics:
       m_Width: 16
       m_Height: 16
-      m_HorizontalBearingX: -8
-      m_HorizontalBearingY: 8
+      m_HorizontalBearingX: 0
+      m_HorizontalBearingY: 12
       m_HorizontalAdvance: 16
     m_GlyphRect:
       m_X: 64


### PR DESCRIPTION
## Summary
- set consistent bearing values for every glyph in **FloatingTextIcons** sprite asset

## Testing
- `grep -n "m_HorizontalBearingX" Assets/Fonts/FloatingTextIcons.asset | tail -n 3`


------
https://chatgpt.com/codex/tasks/task_e_688b14cce280832ea43541eae2b94958