### PR TITLE
Improve floating text for drops

### DIFF
--- a/Assets/Scripts/Enemies/Enemy.cs
+++ b/Assets/Scripts/Enemies/Enemy.cs
@@ -300,6 +300,7 @@ namespace TimelessEchoes.Enemies
                 gainMult = skillController.GetResourceGainMultiplier();
             }
 
+            var lines = new List<string>();
             foreach (var drop in stats.resourceDrops)
             {
                 if (drop.resource == null) continue;
@@ -316,7 +317,13 @@ namespace TimelessEchoes.Enemies
                     double final = count * mult * gainMult;
                     resourceManager.Add(drop.resource, final);
                     Log($"Dropped {final} {drop.resource.name}", TELogCategory.Resource, this);
+                    lines.Add($"{Blindsided.Utilities.TextStrings.ResourceIcon(drop.resource.resourceID)} {Mathf.FloorToInt((float)final)}");
                 }
+            }
+
+            if (lines.Count > 0)
+            {
+                FloatingText.Spawn(string.Join("\n", lines), transform.position + Vector3.up, FloatingText.DefaultColor);
             }
 
             var tracker = EnemyKillTracker.Instance;

--- a/Assets/Scripts/FloatingText.cs
+++ b/Assets/Scripts/FloatingText.cs
@@ -8,6 +8,7 @@ namespace TimelessEchoes
     /// </summary>
     public class FloatingText : MonoBehaviour
     {
+        public static readonly Color DefaultColor = new Color32(0xEA, 0xD4, 0xAA, 0xFF);
         [SerializeField] private float speed = 1f;
         [SerializeField] private float lifetime = 1f;
         private TMP_Text tmp;

--- a/Assets/Scripts/Tasks/ResourceGeneratingTask.cs
+++ b/Assets/Scripts/Tasks/ResourceGeneratingTask.cs
@@ -33,6 +33,7 @@ namespace TimelessEchoes.Tasks
                 return;
 
             var worldX = transform.position.x;
+            var lines = new List<string>();
 
             foreach (var drop in taskData.resourceDrops)
             {
@@ -48,18 +49,22 @@ namespace TimelessEchoes.Tasks
 
                 if (count > 0)
                 {
+                    double final = count;
                     if (skillController)
                     {
                         int mult = skillController.GetEffectMultiplier(associatedSkill, TimelessEchoes.Skills.MilestoneType.DoubleResources);
                         float resourceMult = skillController.GetResourceGainMultiplier();
-                        double amount = count * mult * resourceMult;
-                        resourceManager.Add(drop.resource, amount);
+                        final = count * mult * resourceMult;
                     }
-                    else
-                    {
-                        resourceManager.Add(drop.resource, count);
-                    }
+
+                    resourceManager.Add(drop.resource, final);
+                    lines.Add($"{Blindsided.Utilities.TextStrings.ResourceIcon(drop.resource.resourceID)} {Mathf.FloorToInt((float)final)}");
                 }
+            }
+
+            if (lines.Count > 0)
+            {
+                FloatingText.Spawn(string.Join("\n", lines), transform.position + Vector3.up, FloatingText.DefaultColor);
             }
         }
     }}

--- a/Assets/Scripts/Upgrades/RunDropUI.cs
+++ b/Assets/Scripts/Upgrades/RunDropUI.cs
@@ -140,7 +140,7 @@ namespace TimelessEchoes.Upgrades
                     FloatingText.Spawn(
                         $"{Blindsided.Utilities.TextStrings.ResourceIcon(resource.resourceID)} {Mathf.FloorToInt((float)amount)}",
                         slot.transform.position + Vector3.up,
-                        Color.white, 8f, transform);
+                        FloatingText.DefaultColor, 8f, transform);
             }
 
         }
@@ -173,7 +173,7 @@ namespace TimelessEchoes.Upgrades
                 FloatingText.Spawn(
                     $"{Blindsided.Utilities.TextStrings.ResourceIcon(resource.resourceID)} {Mathf.FloorToInt((float)amount)}",
                     slot.transform.position + Vector3.up,
-                    Color.white, 8f, transform);
+                    FloatingText.DefaultColor, 8f, transform);
         }
 
     }


### PR DESCRIPTION
## Summary
- add `FloatingText.DefaultColor` (#EAD4AA)
- use the default color for resource drop UI
- show combined drop text at the world position for tasks and enemy deaths
- keep original colors for enemy and hero health popups

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688b17221bfc832eb18012689bd2a31f