### PR TITLE
Add configurable floating text settings

### DIFF
--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -101,6 +101,36 @@ namespace Blindsided.SaveData
             /// </summary>
             public float SafeAreaRatio;
 
+            /// <summary>
+            ///     Duration for drop floating text in seconds.
+            /// </summary>
+            public float DropFloatingTextDuration = 1f;
+
+            /// <summary>
+            ///     Duration for player damage floating text in seconds.
+            /// </summary>
+            public float PlayerDamageTextDuration = 1f;
+
+            /// <summary>
+            ///     Duration for enemy damage floating text in seconds.
+            /// </summary>
+            public float EnemyDamageTextDuration = 1f;
+
+            /// <summary>
+            ///     Whether player damage numbers are shown.
+            /// </summary>
+            public bool PlayerFloatingDamage = true;
+
+            /// <summary>
+            ///     Whether enemy damage numbers are shown.
+            /// </summary>
+            public bool EnemyFloatingDamage = true;
+
+            /// <summary>
+            ///     Whether item drop floating text is shown.
+            /// </summary>
+            public bool ItemDropFloatingText = true;
+
         }
 
         [HideReferenceObjectPicker]

--- a/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
+++ b/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
@@ -121,6 +121,42 @@ namespace Blindsided.SaveData
             set => oracle.saveData.SavedPreferences.SafeAreaRatio = Mathf.Clamp01(value);
         }
 
+        public static float DropFloatingTextDuration
+        {
+            get => oracle.saveData.SavedPreferences.DropFloatingTextDuration;
+            set => oracle.saveData.SavedPreferences.DropFloatingTextDuration = Mathf.Clamp(value, 0f, 10f);
+        }
+
+        public static float PlayerDamageTextDuration
+        {
+            get => oracle.saveData.SavedPreferences.PlayerDamageTextDuration;
+            set => oracle.saveData.SavedPreferences.PlayerDamageTextDuration = Mathf.Clamp(value, 0f, 2f);
+        }
+
+        public static float EnemyDamageTextDuration
+        {
+            get => oracle.saveData.SavedPreferences.EnemyDamageTextDuration;
+            set => oracle.saveData.SavedPreferences.EnemyDamageTextDuration = Mathf.Clamp(value, 0f, 2f);
+        }
+
+        public static bool PlayerFloatingDamage
+        {
+            get => oracle.saveData.SavedPreferences.PlayerFloatingDamage;
+            set => oracle.saveData.SavedPreferences.PlayerFloatingDamage = value;
+        }
+
+        public static bool EnemyFloatingDamage
+        {
+            get => oracle.saveData.SavedPreferences.EnemyFloatingDamage;
+            set => oracle.saveData.SavedPreferences.EnemyFloatingDamage = value;
+        }
+
+        public static bool ItemDropFloatingText
+        {
+            get => oracle.saveData.SavedPreferences.ItemDropFloatingText;
+            set => oracle.saveData.SavedPreferences.ItemDropFloatingText = value;
+        }
+
         public static bool ShowLevelText
         {
             get => oracle.saveData.SavedPreferences.ShowLevelText;

--- a/Assets/Scripts/Enemies/Enemy.cs
+++ b/Assets/Scripts/Enemies/Enemy.cs
@@ -344,7 +344,10 @@ namespace TimelessEchoes.Enemies
                 if (line.Length > 0)
                     lines.Add(line);
 
-                FloatingText.Spawn(string.Join("\n", lines), transform.position + Vector3.up, FloatingText.DefaultColor);
+                if (Blindsided.SaveData.StaticReferences.ItemDropFloatingText)
+                    FloatingText.Spawn(string.Join("\n", lines), transform.position + Vector3.up,
+                        FloatingText.DefaultColor, 8f, null,
+                        Blindsided.SaveData.StaticReferences.DropFloatingTextDuration);
             }
 
             var tracker = EnemyKillTracker.Instance;

--- a/Assets/Scripts/Enemies/Health.cs
+++ b/Assets/Scripts/Enemies/Health.cs
@@ -35,6 +35,16 @@ namespace TimelessEchoes.Enemies
 
         protected override float GetFloatingTextSize() => 8f;
 
+        protected override float GetFloatingTextDuration()
+        {
+            return Blindsided.SaveData.StaticReferences.EnemyDamageTextDuration;
+        }
+
+        protected override bool ShouldShowFloatingText()
+        {
+            return Blindsided.SaveData.StaticReferences.EnemyFloatingDamage;
+        }
+
         public override void TakeDamage(float amount, float bonusDamage = 0f)
         {
             if (CurrentHealth <= 0f) return;
@@ -49,11 +59,12 @@ namespace TimelessEchoes.Enemies
             UpdateBar();
             RaiseHealthChanged();
 
-            if (Application.isPlaying)
+            if (Application.isPlaying && ShouldShowFloatingText())
             {
                 // Display only the final damage amount dealt to the enemy.
                 string text = CalcUtils.FormatNumber(total);
-                FloatingText.Spawn(text, transform.position + Vector3.up, GetFloatingTextColor(), GetFloatingTextSize());
+                FloatingText.Spawn(text, transform.position + Vector3.up, GetFloatingTextColor(),
+                    GetFloatingTextSize(), null, GetFloatingTextDuration());
             }
 
             AfterDamage(total);

--- a/Assets/Scripts/FloatingText.cs
+++ b/Assets/Scripts/FloatingText.cs
@@ -1,5 +1,6 @@
 using TMPro;
 using UnityEngine;
+using Blindsided.SaveData;
 
 namespace TimelessEchoes
 {
@@ -17,7 +18,7 @@ namespace TimelessEchoes
         /// <summary>
         /// Spawns a floating text object displaying the given string.
         /// </summary>
-        public static void Spawn(string text, Vector3 position, Color color, float fontSize = 8f, Transform parent = null)
+        public static void Spawn(string text, Vector3 position, Color color, float fontSize = 8f, Transform parent = null, float duration = -1f)
         {
             var obj = new GameObject("FloatingText");
             var offset = Random.insideUnitCircle * 0.25f;
@@ -25,6 +26,7 @@ namespace TimelessEchoes
             if (parent != null)
                 obj.transform.SetParent(parent, true);
             var ft = obj.AddComponent<FloatingText>();
+            ft.lifetime = duration >= 0f ? duration : StaticReferences.DropFloatingTextDuration;
             ft.tmp = obj.AddComponent<TextMeshPro>();
             ft.tmp.alignment = TextAlignmentOptions.Center;
             ft.tmp.fontSize = fontSize;

--- a/Assets/Scripts/HealthBase.cs
+++ b/Assets/Scripts/HealthBase.cs
@@ -31,7 +31,7 @@ namespace TimelessEchoes
             UpdateBar();
             OnHealthChanged?.Invoke(CurrentHealth, MaxHealth);
 
-            if (Application.isPlaying)
+            if (Application.isPlaying && ShouldShowFloatingText())
                 ShowFloatingText(total, bonusDamage);
 
             AfterDamage(total);
@@ -120,11 +120,14 @@ namespace TimelessEchoes
             string text = CalcUtils.FormatNumber(total);
             if (bonusDamage != 0f)
                 text += $"<size=70%><color=#60C560>+{CalcUtils.FormatNumber(bonusDamage)}</color></size>";
-            FloatingText.Spawn(text, transform.position + Vector3.up, GetFloatingTextColor(), GetFloatingTextSize());
+            FloatingText.Spawn(text, transform.position + Vector3.up, GetFloatingTextColor(),
+                GetFloatingTextSize(), null, GetFloatingTextDuration());
         }
 
         protected abstract Color GetFloatingTextColor();
         protected abstract float GetFloatingTextSize();
+        protected abstract float GetFloatingTextDuration();
+        protected virtual bool ShouldShowFloatingText() => true;
 
         [Serializable]
         public struct HealthBarSpriteOption

--- a/Assets/Scripts/Hero/HeroHealth.cs
+++ b/Assets/Scripts/Hero/HeroHealth.cs
@@ -63,6 +63,16 @@ namespace TimelessEchoes.Hero
             return 6f;
         }
 
+        protected override float GetFloatingTextDuration()
+        {
+            return Blindsided.SaveData.StaticReferences.PlayerDamageTextDuration;
+        }
+
+        protected override bool ShouldShowFloatingText()
+        {
+            return Blindsided.SaveData.StaticReferences.PlayerFloatingDamage;
+        }
+
         public override void TakeDamage(float amount, float bonusDamage = 0f)
         {
             if (Immortal) return;

--- a/Assets/Scripts/Tasks/ResourceGeneratingTask.cs
+++ b/Assets/Scripts/Tasks/ResourceGeneratingTask.cs
@@ -85,7 +85,10 @@ namespace TimelessEchoes.Tasks
                 if (line.Length > 0)
                     lines.Add(line);
 
-                FloatingText.Spawn(string.Join("\n", lines), transform.position + Vector3.up, FloatingText.DefaultColor);
+                if (Blindsided.SaveData.StaticReferences.ItemDropFloatingText)
+                    FloatingText.Spawn(string.Join("\n", lines), transform.position + Vector3.up,
+                        FloatingText.DefaultColor, 8f, null,
+                        Blindsided.SaveData.StaticReferences.DropFloatingTextDuration);
             }
         }
     }}

--- a/Assets/Scripts/UI/SettingsPanelUI.cs
+++ b/Assets/Scripts/UI/SettingsPanelUI.cs
@@ -1,5 +1,7 @@
 using Blindsided;
 using Blindsided.SaveData;
+using System.Collections;
+using Blindsided.Utilities;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -16,6 +18,21 @@ namespace TimelessEchoes.UI
         [SerializeField] private Button windowButton;
         [SerializeField] private Button fpsButton;
         [SerializeField] private TMP_Text fpsButtonText;
+        [SerializeField] private Slider dropTextDurationSlider;
+        [SerializeField] private TMP_Text dropTextDurationText;
+        [SerializeField] private Slider playerDamageDurationSlider;
+        [SerializeField] private TMP_Text playerDamageDurationText;
+        [SerializeField] private Slider enemyDamageDurationSlider;
+        [SerializeField] private TMP_Text enemyDamageDurationText;
+        [SerializeField] private Button playerDamageButton;
+        [SerializeField] private Button enemyDamageButton;
+        [SerializeField] private Button dropTextButton;
+        [SerializeField] private Sprite onSprite;
+        [SerializeField] private Sprite offSprite;
+
+        private Image playerDamageImage;
+        private Image enemyDamageImage;
+        private Image dropTextImage;
 
         private const int Fps60 = 60;
         private const int Fps120 = 120;
@@ -28,8 +45,26 @@ namespace TimelessEchoes.UI
                 windowButton.onClick.AddListener(SetWindowed);
             if (fpsButton != null)
                 fpsButton.onClick.AddListener(ToggleFps);
+            if (dropTextDurationSlider != null)
+                dropTextDurationSlider.onValueChanged.AddListener(OnDropDurationChanged);
+            if (playerDamageDurationSlider != null)
+                playerDamageDurationSlider.onValueChanged.AddListener(OnPlayerDurationChanged);
+            if (enemyDamageDurationSlider != null)
+                enemyDamageDurationSlider.onValueChanged.AddListener(OnEnemyDurationChanged);
+            if (playerDamageButton != null)
+                playerDamageButton.onClick.AddListener(TogglePlayerDamage);
+            if (enemyDamageButton != null)
+                enemyDamageButton.onClick.AddListener(ToggleEnemyDamage);
+            if (dropTextButton != null)
+                dropTextButton.onClick.AddListener(ToggleDropText);
+
+            playerDamageImage = playerDamageButton != null ? playerDamageButton.GetComponent<Image>() : null;
+            enemyDamageImage = enemyDamageButton != null ? enemyDamageButton.GetComponent<Image>() : null;
+            dropTextImage = dropTextButton != null ? dropTextButton.GetComponent<Image>() : null;
+
             EventHandler.OnLoadData += ApplyFps;
             ApplyFps();
+            StartCoroutine(DeferredInit());
         }
 
         private void OnDestroy()
@@ -40,6 +75,18 @@ namespace TimelessEchoes.UI
                 windowButton.onClick.RemoveListener(SetWindowed);
             if (fpsButton != null)
                 fpsButton.onClick.RemoveListener(ToggleFps);
+            if (dropTextDurationSlider != null)
+                dropTextDurationSlider.onValueChanged.RemoveListener(OnDropDurationChanged);
+            if (playerDamageDurationSlider != null)
+                playerDamageDurationSlider.onValueChanged.RemoveListener(OnPlayerDurationChanged);
+            if (enemyDamageDurationSlider != null)
+                enemyDamageDurationSlider.onValueChanged.RemoveListener(OnEnemyDurationChanged);
+            if (playerDamageButton != null)
+                playerDamageButton.onClick.RemoveListener(TogglePlayerDamage);
+            if (enemyDamageButton != null)
+                enemyDamageButton.onClick.RemoveListener(ToggleEnemyDamage);
+            if (dropTextButton != null)
+                dropTextButton.onClick.RemoveListener(ToggleDropText);
             EventHandler.OnLoadData -= ApplyFps;
         }
 
@@ -71,6 +118,78 @@ namespace TimelessEchoes.UI
         {
             if (fpsButtonText != null)
                 fpsButtonText.text = $"FPS: {StaticReferences.TargetFps}";
+        }
+
+        private IEnumerator DeferredInit()
+        {
+            yield return null; // wait one frame for data load
+            ApplySettings();
+        }
+
+        private void ApplySettings()
+        {
+            if (dropTextDurationSlider != null)
+                dropTextDurationSlider.value = StaticReferences.DropFloatingTextDuration / 10f;
+            if (playerDamageDurationSlider != null)
+                playerDamageDurationSlider.value = StaticReferences.PlayerDamageTextDuration / 2f;
+            if (enemyDamageDurationSlider != null)
+                enemyDamageDurationSlider.value = StaticReferences.EnemyDamageTextDuration / 2f;
+            UpdateDurationTexts();
+            UpdateButtonVisual(playerDamageImage, StaticReferences.PlayerFloatingDamage);
+            UpdateButtonVisual(enemyDamageImage, StaticReferences.EnemyFloatingDamage);
+            UpdateButtonVisual(dropTextImage, StaticReferences.ItemDropFloatingText);
+        }
+
+        private void OnDropDurationChanged(float value)
+        {
+            StaticReferences.DropFloatingTextDuration = value * 10f;
+            UpdateDurationTexts();
+        }
+
+        private void OnPlayerDurationChanged(float value)
+        {
+            StaticReferences.PlayerDamageTextDuration = value * 2f;
+            UpdateDurationTexts();
+        }
+
+        private void OnEnemyDurationChanged(float value)
+        {
+            StaticReferences.EnemyDamageTextDuration = value * 2f;
+            UpdateDurationTexts();
+        }
+
+        private void TogglePlayerDamage()
+        {
+            StaticReferences.PlayerFloatingDamage = !StaticReferences.PlayerFloatingDamage;
+            UpdateButtonVisual(playerDamageImage, StaticReferences.PlayerFloatingDamage);
+        }
+
+        private void ToggleEnemyDamage()
+        {
+            StaticReferences.EnemyFloatingDamage = !StaticReferences.EnemyFloatingDamage;
+            UpdateButtonVisual(enemyDamageImage, StaticReferences.EnemyFloatingDamage);
+        }
+
+        private void ToggleDropText()
+        {
+            StaticReferences.ItemDropFloatingText = !StaticReferences.ItemDropFloatingText;
+            UpdateButtonVisual(dropTextImage, StaticReferences.ItemDropFloatingText);
+        }
+
+        private void UpdateDurationTexts()
+        {
+            if (dropTextDurationText != null)
+                dropTextDurationText.text = $"Drop floating text duration | {CalcUtils.FormatTime(StaticReferences.DropFloatingTextDuration, true, shortForm: true)}";
+            if (playerDamageDurationText != null)
+                playerDamageDurationText.text = $"Caleb's damage floating text duration | {CalcUtils.FormatTime(StaticReferences.PlayerDamageTextDuration, true, shortForm: true)}";
+            if (enemyDamageDurationText != null)
+                enemyDamageDurationText.text = $"Enemies damage floating text duration | {CalcUtils.FormatTime(StaticReferences.EnemyDamageTextDuration, true, shortForm: true)}";
+        }
+
+        private void UpdateButtonVisual(Image img, bool on)
+        {
+            if (img != null)
+                img.sprite = on ? onSprite : offSprite;
         }
     }
 }


### PR DESCRIPTION
## Summary
- make floating text duration and visibility configurable
- expose new preferences via `StaticReferences`
- respect settings in hero/enemy damage and item drop text
- update `SettingsPanelUI` with sliders and toggle buttons
- show duration values with formatted text

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688b2a74bfc0832e940eeefa8fe01e14