### PR TITLE
Load Main scene from Oracle

### DIFF
--- a/Assets/Scripts/Blindsided/Oracle.cs.meta
+++ b/Assets/Scripts/Blindsided/Oracle.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: -5
+  executionOrder: 0
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 


### PR DESCRIPTION
## Summary
- ensure `Oracle` is instantiated once and persists across scenes
- set script execution order to 0 and update `.meta` accordingly
- load the `Main` scene after save data is loaded
- invoke the load event one frame after `Main` is loaded

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b58fd2204832eb07604ade10f6392