### PR TITLE
Fix NullReferenceException in Oracle duplicate destruction

### DIFF
--- a/Assets/Scripts/Blindsided/Oracle.cs
+++ b/Assets/Scripts/Blindsided/Oracle.cs
@@ -111,7 +111,7 @@ namespace Blindsided
         private void OnDisable()
         {
             // This is called when you exit Play Mode in the Editor
-            if (Application.isPlaying && !wipeInProgress)
+            if (Application.isPlaying && !wipeInProgress && oracle == this && _settings != null)
             {
                 SaveToFile(); // save the latest state immediately
                 ES3.StoreCachedFile(_fileName);


### PR DESCRIPTION
## Summary
- prevent SaveToFile from running when this Oracle isn't the active instance

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b5b6298d0832e91df048b4536e896