### PR TITLE
Automatically show quests on first game load

### DIFF
--- a/Assets/Scripts/UI/TownWindowManager.cs
+++ b/Assets/Scripts/UI/TownWindowManager.cs
@@ -3,6 +3,7 @@ using Sirenix.OdinInspector;
 using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.UI;
+using Blindsided;
 
 namespace TimelessEchoes.UI
 {
@@ -79,6 +80,16 @@ namespace TimelessEchoes.UI
                 inventory.closeButton.onClick.AddListener(CloseAllWindows);
         }
 
+        private void OnEnable()
+        {
+            EventHandler.OnLoadData += HandleLoadData;
+        }
+
+        private void OnDisable()
+        {
+            EventHandler.OnLoadData -= HandleLoadData;
+        }
+
         private void Start()
         {
             CloseAllWindows();
@@ -130,6 +141,24 @@ namespace TimelessEchoes.UI
         {
             if (Mouse.current != null && Mouse.current.rightButton.wasPressedThisFrame)
                 CloseAllWindows();
+        }
+
+        private void HandleLoadData()
+        {
+            if (Oracle.oracle == null)
+                return;
+
+            if (!Oracle.oracle.saveData.SavedPreferences.Tutorial)
+            {
+                CloseAllWindows();
+                if (quests.window != null)
+                    quests.window.SetActive(true);
+                if (inventory.window != null)
+                    inventory.window.SetActive(false);
+                UpdateTownButtonsVisibility();
+                Oracle.oracle.saveData.SavedPreferences.Tutorial = true;
+                EventHandler.SaveData();
+            }
         }
 
         private void OpenUpgrades()


### PR DESCRIPTION
## Summary
- open Quests window when game data is first loaded
- ensure inventory is not shown when quests open automatically
- store flag in save data preferences to keep this from repeating

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b5ecf4764832eb53a44b1989bcd7c