### PR TITLE
Add root object toggle to pinned quest UI

### DIFF
--- a/Assets/Scripts/Quests/PinnedQuestUIManager.cs
+++ b/Assets/Scripts/Quests/PinnedQuestUIManager.cs
@@ -26,6 +26,7 @@ namespace TimelessEchoes.Quests
         [SerializeField] private Image stateImage;
         [SerializeField] private Sprite openSprite;
         [SerializeField] private Sprite closeSprite;
+        [SerializeField] private GameObject rootObject;
 
         private readonly Dictionary<string, QuestPinUI> entries = new();
 
@@ -93,6 +94,9 @@ namespace TimelessEchoes.Quests
                 var ui = Instantiate(entryPrefab, entryParent);
                 entries[id] = ui;
             }
+
+            if (rootObject != null)
+                rootObject.SetActive(entries.Count > 0);
 
             UpdateProgress();
         }


### PR DESCRIPTION
## Summary
- show/hide pinned quest panel using new root object reference

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688bf5fa05f8832e8abf7246da830e10