### PR TITLE
Combine duplicate drop text entries

### DIFF
--- a/Assets/Scripts/Enemies/Enemy.cs
+++ b/Assets/Scripts/Enemies/Enemy.cs
@@ -300,7 +300,8 @@ namespace TimelessEchoes.Enemies
                 gainMult = skillController.GetResourceGainMultiplier();
             }
 
-            var parts = new List<string>();
+            var dropTotals = new Dictionary<Resource, double>();
+            var dropOrder = new List<Resource>();
             foreach (var drop in stats.resourceDrops)
             {
                 if (drop.resource == null) continue;
@@ -317,12 +318,21 @@ namespace TimelessEchoes.Enemies
                     double final = count * mult * gainMult;
                     resourceManager.Add(drop.resource, final);
                     Log($"Dropped {final} {drop.resource.name}", TELogCategory.Resource, this);
-                    parts.Add($"{Blindsided.Utilities.TextStrings.ResourceIcon(drop.resource.resourceID)}{Mathf.FloorToInt((float)final)}");
+                    if (dropTotals.ContainsKey(drop.resource))
+                        dropTotals[drop.resource] += final;
+                    else
+                    {
+                        dropTotals[drop.resource] = final;
+                        dropOrder.Add(drop.resource);
+                    }
                 }
             }
 
-            if (parts.Count > 0)
+            if (dropTotals.Count > 0)
             {
+                var parts = new List<string>();
+                foreach (var res in dropOrder)
+                    parts.Add($"{Blindsided.Utilities.TextStrings.ResourceIcon(res.resourceID)}{Mathf.FloorToInt((float)dropTotals[res])}");
                 var lines = new List<string>();
                 var line = string.Empty;
                 for (var i = 0; i < parts.Count; i++)

--- a/Assets/Scripts/Tasks/ResourceGeneratingTask.cs
+++ b/Assets/Scripts/Tasks/ResourceGeneratingTask.cs
@@ -33,7 +33,8 @@ namespace TimelessEchoes.Tasks
                 return;
 
             var worldX = transform.position.x;
-            var parts = new List<string>();
+            var dropTotals = new Dictionary<Resource, double>();
+            var dropOrder = new List<Resource>();
 
             foreach (var drop in taskData.resourceDrops)
             {
@@ -58,12 +59,21 @@ namespace TimelessEchoes.Tasks
                     }
 
                     resourceManager.Add(drop.resource, final);
-                    parts.Add($"{Blindsided.Utilities.TextStrings.ResourceIcon(drop.resource.resourceID)}{Mathf.FloorToInt((float)final)}");
+                    if (dropTotals.ContainsKey(drop.resource))
+                        dropTotals[drop.resource] += final;
+                    else
+                    {
+                        dropTotals[drop.resource] = final;
+                        dropOrder.Add(drop.resource);
+                    }
                 }
             }
 
-            if (parts.Count > 0)
+            if (dropTotals.Count > 0)
             {
+                var parts = new List<string>();
+                foreach (var res in dropOrder)
+                    parts.Add($"{Blindsided.Utilities.TextStrings.ResourceIcon(res.resourceID)}{Mathf.FloorToInt((float)dropTotals[res])}");
                 var lines = new List<string>();
                 var line = string.Empty;
                 for (var i = 0; i < parts.Count; i++)


### PR DESCRIPTION
## Summary
- combine duplicate resource drops when spawning floating text

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c5271a990832e8bdb0df702e41202