### PR TITLE
Fix enemy drops minX

### DIFF
--- a/Assets/Scripts/Enemies/Enemy.cs
+++ b/Assets/Scripts/Enemies/Enemy.cs
@@ -305,10 +305,12 @@ namespace TimelessEchoes.Enemies
 
             var dropTotals = new Dictionary<Resource, double>();
             var dropOrder = new List<Resource>();
+            var worldX = transform.position.x;
             foreach (var drop in stats.resourceDrops)
             {
                 if (drop.resource == null) continue;
                 if (Random.value > drop.dropChance) continue;
+                if (worldX < drop.minX || worldX > drop.maxX) continue;
 
                 var min = drop.dropRange.x;
                 var max = drop.dropRange.y;


### PR DESCRIPTION
## Summary
- account for `minX`/`maxX` limits when enemies drop resources

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688c52ddfd54832e9ab8c217ef5b03ae