### PR TITLE
Use LocalizedString in QuestData

### DIFF
--- a/Assets/Scripts/Quests/PinnedQuestUIManager.cs
+++ b/Assets/Scripts/Quests/PinnedQuestUIManager.cs
@@ -6,6 +6,7 @@ using TimelessEchoes.Stats;
 using TimelessEchoes.Upgrades;
 using UnityEngine;
 using UnityEngine.UI;
+using UnityEngine.Localization;
 using static Blindsided.EventHandler;
 using static Blindsided.Oracle;
 using static Blindsided.SaveData.StaticReferences;
@@ -136,7 +137,7 @@ namespace TimelessEchoes.Quests
                 var reqCount = 0;
 
                 var sb = new StringBuilder();
-                sb.AppendLine(data.questName);
+                sb.AppendLine(data.questName.GetLocalizedString());
 
                 foreach (var req in data.requirements)
                 {

--- a/Assets/Scripts/Quests/QuestData.cs
+++ b/Assets/Scripts/Quests/QuestData.cs
@@ -5,6 +5,7 @@ using TimelessEchoes.Upgrades;
 using TimelessEchoes.Enemies;
 using Sirenix.OdinInspector;
 using UnityEngine;
+using UnityEngine.Localization;
 
 namespace TimelessEchoes.Quests
 {
@@ -13,9 +14,9 @@ namespace TimelessEchoes.Quests
     public class QuestData : ScriptableObject
     {
         public string questId;
-        public string questName;
-        [TextArea] public string description;
-        [TextArea] public string rewardDescription;
+        public LocalizedString questName;
+        [TextArea] public LocalizedString description;
+        [TextArea] public LocalizedString rewardDescription;
         public string npcId;
         public List<QuestData> requiredQuests = new();
         public List<Requirement> requirements = new();

--- a/Assets/Scripts/Quests/QuestEntryUI.cs
+++ b/Assets/Scripts/Quests/QuestEntryUI.cs
@@ -8,6 +8,7 @@ using TMPro;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
+using UnityEngine.Localization;
 
 namespace TimelessEchoes.Quests
 {
@@ -39,14 +40,14 @@ namespace TimelessEchoes.Quests
             if (nameText != null)
             {
                 baseNameText = data != null
-                    ? data.questName + (completed ? " | Completed" : string.Empty)
+                    ? data.questName.GetLocalizedString() + (completed ? " | Completed" : string.Empty)
                     : string.Empty;
                 nameText.text = baseNameText;
             }
             if (descriptionText != null)
-                descriptionText.text = data != null ? data.description : string.Empty;
+                descriptionText.text = data != null ? data.description.GetLocalizedString() : string.Empty;
             if (rewardText != null)
-                rewardText.text = data != null ? $"Reward: {data.rewardDescription}" : string.Empty;
+                rewardText.text = data != null ? $"Reward: {data.rewardDescription.GetLocalizedString()}" : string.Empty;
             if (typeText != null)
                 typeText.text = data != null ? $"Type | {GetQuestType(data)}" : string.Empty;
 


### PR DESCRIPTION
## Summary
- update QuestData fields to `LocalizedString`
- show localized quest data in QuestEntryUI
- show localized quest names in PinnedQuestUIManager

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688d2d438aec832eb14217a6a2a0f11c