### PR TITLE
Add missing quest localization entries

### DIFF
--- a/Assets/Localization/Tables/Quests/Quests Shared Data.asset
+++ b/Assets/Localization/Tables/Quests/Quests Shared Data.asset
@@ -279,6 +279,558 @@ MonoBehaviour:
     m_Key: Unlock Cucumber.reward
     m_Metadata:
       m_Items: []
+  - m_Id: 7955958563392
+    m_Key: A Fishy Situation.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955959563392
+    m_Key: A Fishy Situation.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955960563392
+    m_Key: A Fishy Situation.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955961563392
+    m_Key: A Splash of Nobility.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955962563392
+    m_Key: A Splash of Nobility.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955963563392
+    m_Key: A Splash of Nobility.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955964563392
+    m_Key: A fin-omenal request.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955965563392
+    m_Key: A fin-omenal request.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955966563392
+    m_Key: A fin-omenal request.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955967563392
+    m_Key: Another Fishy Situation.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955968563392
+    m_Key: Another Fishy Situation.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955969563392
+    m_Key: Another Fishy Situation.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955970563392
+    m_Key: Bloop Goes the Dynamite.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955971563392
+    m_Key: Bloop Goes the Dynamite.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955972563392
+    m_Key: Bloop Goes the Dynamite.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955973563392
+    m_Key: BoneAE.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955974563392
+    m_Key: BoneAE.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955975563392
+    m_Key: BoneAE.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955976563392
+    m_Key: Chunky Business.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955977563392
+    m_Key: Chunky Business.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955978563392
+    m_Key: Chunky Business.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955979563392
+    m_Key: CopiumAE.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955980563392
+    m_Key: CopiumAE.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955981563392
+    m_Key: CopiumAE.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955982563392
+    m_Key: DlogAE.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955983563392
+    m_Key: DlogAE.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955984563392
+    m_Key: DlogAE.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955985563392
+    m_Key: Echo Casting.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955986563392
+    m_Key: Echo Casting.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955987563392
+    m_Key: Echo Casting.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955988563392
+    m_Key: ErifAE.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955989563392
+    m_Key: ErifAE.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955990563392
+    m_Key: ErifAE.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955991563392
+    m_Key: EznorbAE.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955992563392
+    m_Key: EznorbAE.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955993563392
+    m_Key: EznorbAE.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955994563392
+    m_Key: Flip That Flop.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955995563392
+    m_Key: Flip That Flop.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955996563392
+    m_Key: Flip That Flop.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955997563392
+    m_Key: Flipzoid Frenzy.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955998563392
+    m_Key: Flipzoid Frenzy.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955999563392
+    m_Key: Flipzoid Frenzy.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956000563392
+    m_Key: IdleAE.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956001563392
+    m_Key: IdleAE.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956002563392
+    m_Key: IdleAE.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956003563392
+    m_Key: Junior Chompers.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956004563392
+    m_Key: Junior Chompers.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956005563392
+    m_Key: Junior Chompers.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956006563392
+    m_Key: LeatherAE.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956007563392
+    m_Key: LeatherAE.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956008563392
+    m_Key: LeatherAE.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956009563392
+    m_Key: LiriumAE.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956010563392
+    m_Key: LiriumAE.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956011563392
+    m_Key: LiriumAE.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956012563392
+    m_Key: Muck-in-the-Mud Mission.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956013563392
+    m_Key: Muck-in-the-Mud Mission.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956014563392
+    m_Key: Muck-in-the-Mud Mission.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956015563392
+    m_Key: Niblet’s Nerve.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956016563392
+    m_Key: Niblet’s Nerve.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956017563392
+    m_Key: Niblet’s Nerve.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956018563392
+    m_Key: NoriAE.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956019563392
+    m_Key: NoriAE.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956020563392
+    m_Key: NoriAE.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956021563392
+    m_Key: QuestLock.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956022563392
+    m_Key: QuestLock.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956023563392
+    m_Key: QuestLock.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956024563392
+    m_Key: QuestLock 1.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956025563392
+    m_Key: QuestLock 1.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956026563392
+    m_Key: QuestLock 1.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956027563392
+    m_Key: Snap decision.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956028563392
+    m_Key: Snap decision.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956029563392
+    m_Key: Snap decision.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956030563392
+    m_Key: StoneAE.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956031563392
+    m_Key: StoneAE.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956032563392
+    m_Key: StoneAE.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956033563392
+    m_Key: The 100.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956034563392
+    m_Key: The 100.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956035563392
+    m_Key: The 100.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956036563392
+    m_Key: The bloop before the boom.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956037563392
+    m_Key: The bloop before the boom.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956038563392
+    m_Key: The bloop before the boom.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956039563392
+    m_Key: Unlock Copium.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956040563392
+    m_Key: Unlock Copium.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956041563392
+    m_Key: Unlock Copium.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956042563392
+    m_Key: Unlock Erif.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956043563392
+    m_Key: Unlock Erif.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956044563392
+    m_Key: Unlock Erif.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956045563392
+    m_Key: Unlock Funion.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956046563392
+    m_Key: Unlock Funion.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956047563392
+    m_Key: Unlock Funion.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956048563392
+    m_Key: Unlock Idle.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956049563392
+    m_Key: Unlock Idle.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956050563392
+    m_Key: Unlock Idle.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956051563392
+    m_Key: Unlock Leek.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956052563392
+    m_Key: Unlock Leek.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956053563392
+    m_Key: Unlock Leek.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956054563392
+    m_Key: Unlock Lettuce.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956055563392
+    m_Key: Unlock Lettuce.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956056563392
+    m_Key: Unlock Lettuce.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956057563392
+    m_Key: Unlock Lirium.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956058563392
+    m_Key: Unlock Lirium.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956059563392
+    m_Key: Unlock Lirium.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956060563392
+    m_Key: Unlock Onion.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956061563392
+    m_Key: Unlock Onion.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956062563392
+    m_Key: Unlock Onion.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956063563392
+    m_Key: Unlock Parsnip.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956064563392
+    m_Key: Unlock Parsnip.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956065563392
+    m_Key: Unlock Parsnip.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956066563392
+    m_Key: Unlock Pepper.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956067563392
+    m_Key: Unlock Pepper.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956068563392
+    m_Key: Unlock Pepper.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956069563392
+    m_Key: Unlock Pumpking.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956070563392
+    m_Key: Unlock Pumpking.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956071563392
+    m_Key: Unlock Pumpking.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956072563392
+    m_Key: Unlock Spud.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956073563392
+    m_Key: Unlock Spud.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956074563392
+    m_Key: Unlock Spud.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956075563392
+    m_Key: Unlock Strawberry.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956076563392
+    m_Key: Unlock Strawberry.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956077563392
+    m_Key: Unlock Strawberry.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956078563392
+    m_Key: Unlock Tomato.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956079563392
+    m_Key: Unlock Tomato.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956080563392
+    m_Key: Unlock Tomato.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956081563392
+    m_Key: Unlock Turnip.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956082563392
+    m_Key: Unlock Turnip.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956083563392
+    m_Key: Unlock Turnip.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956084563392
+    m_Key: Unlock Vastium.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956085563392
+    m_Key: Unlock Vastium.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956086563392
+    m_Key: Unlock Vastium.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956087563392
+    m_Key: Unlock Watermelone.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956088563392
+    m_Key: Unlock Watermelone.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956089563392
+    m_Key: Unlock Watermelone.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956090563392
+    m_Key: VastiumAE.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956091563392
+    m_Key: VastiumAE.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956092563392
+    m_Key: VastiumAE.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956093563392
+    m_Key: Wiggle Room.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956094563392
+    m_Key: Wiggle Room.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956095563392
+    m_Key: Wiggle Room.reward
+    m_Metadata:
+      m_Items: []
   m_Metadata:
     m_Items: []
   m_KeyGenerator:

--- a/Assets/Localization/Tables/Quests/Quests_en.asset
+++ b/Assets/Localization/Tables/Quests/Quests_en.asset
@@ -324,6 +324,593 @@ MonoBehaviour:
     m_Localized: Unlock the Cucumber crop
     m_Metadata:
       m_Items: []
+  - m_Id: 7955958563392
+    m_Localized: A Fishy Situation
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955959563392
+    m_Localized: '"It looks like Mildred has taken a liking to you! I bet if you give her some of
+  your Flippy Floppy she would more than happily help you out on your travels!" -
+  Eva'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955960563392
+    m_Localized: Mildred follows and provides you with buffs!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955961563392
+    m_Localized: A Splash of Nobility
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955962563392
+    m_Localized: "Gill doffs an imaginary crown. \u201CSir Splashford III is royal to the gills.\
+  \ Snare 50 of the pompous puddle-jumpers\u2014Mildred will curtsey, and Utoes swears\
+  \ their scales boost regen if brewed just right.\u201D"
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955963563392
+    m_Localized: Gain the Disciple of Sir Splashford III
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955964563392
+    m_Localized: A fin-omenal request
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955965563392
+    m_Localized: "Rumour has it that the aristocratic Sir Splashford III swims these waters\u2014\
+  complete with monocle and top-hat! Reel him in (humanely, of course) so Mildred\
+  \ can study his refined scales and unlock deeper piscatory power."
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955966563392
+    m_Localized: Another buff slot!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955967563392
+    m_Localized: Another Fishy Situation
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955968563392
+    m_Localized: '"I am prepping a treat for Mildred, help me fish up some Muddy Muck Munchers"
+  - Gill'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955969563392
+    m_Localized: Another buff slot!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955970563392
+    m_Localized: Bloop Goes the Dynamite
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955971563392
+    m_Localized: "The dock shakes as a distant *BLORP* echoes. \u201CThat\u2019s Bloopicus Maximus\
+  \ announcing dinner,\u201D Gill grins. \u201CHaul in 50 of the boomers\u2014Mildred\
+  \ will nap in the aftershock, and Utoes says their echo can jump-start your veins.\u201D"
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955972563392
+    m_Localized: Gain the Disciple of Bloopicus Maximus
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955973563392
+    m_Localized: BoneAE
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955974563392
+    m_Localized: ''
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955975563392
+    m_Localized: ''
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955976563392
+    m_Localized: Chunky Business
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955977563392
+    m_Localized: '"*Grumbles* This town could sure use a better footing. Go fetch some Nori Chunks
+  and we will get started on some pathing" -The Old Timer'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955978563392
+    m_Localized: 'Unlocks Dlog nodes for mining these start to appear at 150 distance.
+
+  Reaping distance increased by 25'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955979563392
+    m_Localized: CopiumAE
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955980563392
+    m_Localized: ''
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955981563392
+    m_Localized: ''
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955982563392
+    m_Localized: DlogAE
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955983563392
+    m_Localized: ''
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955984563392
+    m_Localized: ''
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955985563392
+    m_Localized: Echo Casting
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955986563392
+    m_Localized: '"As you use these buffs more often, my power will feel more natural to you and
+  echoes from your past will cast them for you." - The Vast One'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955987563392
+    m_Localized: Autocast buff slot 1 is now togglable.
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955988563392
+    m_Localized: ErifAE
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955989563392
+    m_Localized: ''
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955990563392
+    m_Localized: ''
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955991563392
+    m_Localized: EznorbAE
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955992563392
+    m_Localized: ''
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955993563392
+    m_Localized: ''
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955994563392
+    m_Localized: Flip That Flop
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955995563392
+    m_Localized: "Gill whistles a watery tune while Mildred bats at minnows on the dock. \u201C\
+  The lady loves her fishy snacks,\u201D he grins. \u201CNet me 100 Floppy Fish and\
+  \ I\u2019ll teach \u2019em to flop right into her paws\u2014she\u2019ll purr you\
+  \ a tidy buff for the trouble.\u201D"
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955996563392
+    m_Localized: Gain a Floppy Disciple.
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955997563392
+    m_Localized: Flipzoid Frenzy
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955998563392
+    m_Localized: "\u201CFlipzoids launch themselves sky-high to stargaze,\u201D Gill laughs. \u201C\
+  Snag 50 mid-arc and we\u2019ll grind their fins into gliders\u2014Utoes promises\
+  \ they\u2019ll puff your regen, and Mildred just wants the feathers.\u201D"
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7955999563392
+    m_Localized: Gain the Disciple of Flipzoid
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956000563392
+    m_Localized: IdleAE
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956001563392
+    m_Localized: ''
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956002563392
+    m_Localized: ''
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956003563392
+    m_Localized: Junior Chompers
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956004563392
+    m_Localized: "Gill holds up a dented gauntlet. \u201CSnapjaw Jr. bit right through this. Bring\
+  \ me 50 nippers and I\u2019ll forge a brace that even Utoes can\u2019t chew through\u2014\
+  plus Mildred loves the click-clack sound.\u201D"
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956005563392
+    m_Localized: Gain the Disciple of Snapjaw Jr.
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956006563392
+    m_Localized: LeatherAE
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956007563392
+    m_Localized: ''
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956008563392
+    m_Localized: ''
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956009563392
+    m_Localized: LiriumAE
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956010563392
+    m_Localized: ''
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956011563392
+    m_Localized: ''
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956012563392
+    m_Localized: Muck-in-the-Mud Mission
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956013563392
+    m_Localized: "\u201CMildred\u2019s whiskers twitch whenever a Muddy Muck Muncher surfaces,\u201D\
+  \ Gill chuckles. \u201CHook me 50 of the sludge-suckers so she can roll in the muck\u2014\
+  and I\u2019ll show you how to make even swamp water sparkle.\u201D"
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956014563392
+    m_Localized: Gain the Disciple of Muddy Muck Muncher
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956015563392
+    m_Localized: "Niblet\u2019s Nerve"
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956016563392
+    m_Localized: "\u201CNiblet the Bold swims straight at sharks,\u201D Gill whispers with admiration.\
+  \ \u201CLand 50 of the fearless fry so we can bottle that courage\u2014Mildred could\
+  \ use it for night patrols, and Utoes for a hearty tonic.\u201D"
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956017563392
+    m_Localized: Gain the Disciple of Niblet the Bold
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956018563392
+    m_Localized: NoriAE
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956019563392
+    m_Localized: ''
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956020563392
+    m_Localized: ''
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956021563392
+    m_Localized: QuestLock
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956022563392
+    m_Localized: ''
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956023563392
+    m_Localized: ''
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956024563392
+    m_Localized: QuestLock 1
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956025563392
+    m_Localized: ''
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956026563392
+    m_Localized: ''
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956027563392
+    m_Localized: Snap decision
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956028563392
+    m_Localized: "Utoes swears the feisty Snapjaw Jr. can bite straight through anchor chain\u2014\
+  and maybe stubborn gameplay loops. Hook a haul of them so Mildred can crunch the\
+  \ numbers (and the shells) for a sharper edge."
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956029563392
+    m_Localized: Another buff slot!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956030563392
+    m_Localized: StoneAE
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956031563392
+    m_Localized: ''
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956032563392
+    m_Localized: ''
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956033563392
+    m_Localized: The 100
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956034563392
+    m_Localized: '"Each slot will require more casts than the last to unlock. Such is the nature
+  of Echo Casting..." - The Vast One'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956035563392
+    m_Localized: Autocast buff slot 2 is now togglable.
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956036563392
+    m_Localized: The bloop before the boom
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956037563392
+    m_Localized: 'Legends speak of Bloopicus Maximus, a bubbly behemoth whose echoing bloops warp
+  time itself. Capture a chorus of these colossal critters so Mildred can brew a buff
+  that truly makes a splash in every timeline.
+
+  '
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956038563392
+    m_Localized: Another buff slot!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956039563392
+    m_Localized: Unlock Copium
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956040563392
+    m_Localized: Coming soon!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956041563392
+    m_Localized: Unlocks Copium nodes
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956042563392
+    m_Localized: Unlock Erif
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956043563392
+    m_Localized: Coming soon!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956044563392
+    m_Localized: Unlocks Erif nodes for mining
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956045563392
+    m_Localized: Unlock Funion
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956046563392
+    m_Localized: Coming Soon!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956047563392
+    m_Localized: Unlock the Funion crop
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956048563392
+    m_Localized: Unlock Idle
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956049563392
+    m_Localized: Coming soon!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956050563392
+    m_Localized: Unlocks Idle nodes for mining
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956051563392
+    m_Localized: Unlock Leek
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956052563392
+    m_Localized: Coming Soon!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956053563392
+    m_Localized: Unlock the Leek crop
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956054563392
+    m_Localized: Unlock Lettuce
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956055563392
+    m_Localized: Coming Soon!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956056563392
+    m_Localized: Unlock the Lettuce crop
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956057563392
+    m_Localized: Unlock Lirium
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956058563392
+    m_Localized: Coming soon!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956059563392
+    m_Localized: Unlocks Lirium nodes for mining
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956060563392
+    m_Localized: Unlock Onion
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956061563392
+    m_Localized: Coming Soon!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956062563392
+    m_Localized: Unlock the Onion crop
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956063563392
+    m_Localized: Unlock Parsnip
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956064563392
+    m_Localized: Coming Soon!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956065563392
+    m_Localized: Unlock the Parsnip crop
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956066563392
+    m_Localized: Unlock Pepper
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956067563392
+    m_Localized: Coming Soon!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956068563392
+    m_Localized: Unlock the Pepper crop
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956069563392
+    m_Localized: Unlock Pumpking
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956070563392
+    m_Localized: Coming Soon!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956071563392
+    m_Localized: Unlock the Pumking crop
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956072563392
+    m_Localized: Unlock Spud
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956073563392
+    m_Localized: Coming Soon!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956074563392
+    m_Localized: Unlock the Spud crop
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956075563392
+    m_Localized: Unlock Strawberry
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956076563392
+    m_Localized: Coming Soon!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956077563392
+    m_Localized: Unlock the Strawberry crop
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956078563392
+    m_Localized: Unlock Tomato
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956079563392
+    m_Localized: Coming Soon!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956080563392
+    m_Localized: Unlock the Tomato crop
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956081563392
+    m_Localized: Unlock Turnip
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956082563392
+    m_Localized: Coming Soon!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956083563392
+    m_Localized: Unlock the Turnip crop
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956084563392
+    m_Localized: Unlock Vastium
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956085563392
+    m_Localized: Coming soon!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956086563392
+    m_Localized: Unlocks Vastium nodes for mining
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956087563392
+    m_Localized: Unlock Watermelone
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956088563392
+    m_Localized: Coming Soon!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956089563392
+    m_Localized: 'Unlock the Watermelone crop
+
+  '
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956090563392
+    m_Localized: VastiumAE
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956091563392
+    m_Localized: ''
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956092563392
+    m_Localized: ''
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956093563392
+    m_Localized: Wiggle Room
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956094563392
+    m_Localized: "\u201CWigglelittles never stop dancing,\u201D Gill says, tail swishing in time.\
+  \ \u201CCatch 50 before they wriggle off\u2014Mildred wants a new music box, and\
+  \ Utoes thinks their rhythm could sync with your heartbeat.\u201D"
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956095563392
+    m_Localized: Gain the Disciple of Wigglelittle
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []


### PR DESCRIPTION
## Summary
- update `Quests Shared Data.asset` with all quests from Resources folder
- update `Quests_en.asset` with English text for the new quests

## Testing
- `yamllint Assets/Localization/Tables/Quests/Quests_en.asset Assets/Localization/Tables/Quests/Quests\ Shared\ Data.asset` *(fails: trailing spaces, indentation, line length)*

------
https://chatgpt.com/codex/tasks/task_e_688d3767a894832eb25499e544a5c4ab