### PR TITLE
Fix quest localization references

### DIFF
--- a/Assets/Resources/Quests/Barkley/A Sturdier Frame.asset
+++ b/Assets/Resources/Quests/Barkley/A Sturdier Frame.asset
@@ -13,10 +13,33 @@ MonoBehaviour:
   m_Name: A Sturdier Frame
   m_EditorClassIdentifier: 
   questId: A Sturdier Frame
-  questName: A Sturdier Frame
-  description: '"Much appreciated lad! Now''s time to reinforce this thing. If you
-    don''t mind fetching me another few logs?" -Barkley'
-  rewardDescription: Reaping distance increased by 10.
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 5582187020288
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 5583185264640
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 5583919267840
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 023383fb0fcbe3b41b7dca4f9ec81b72, type: 2}

--- a/Assets/Resources/Quests/Barkley/Adding A Roof.asset
+++ b/Assets/Resources/Quests/Barkley/Adding A Roof.asset
@@ -13,10 +13,33 @@ MonoBehaviour:
   m_Name: Adding A Roof
   m_EditorClassIdentifier: 
   questId: Adding A Roof
-  questName: Adding A Roof
-  description: '"You''re simply the best. Not much to go now! I''ll get this roof
-    on and then we will get started on the walls" -Barkley '
-  rewardDescription: Gain the Alter Echo of Sticks.
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 6098321293312
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 6099218874368
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 6100049346560
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 77b9a54f17b29c84b8dce9da0940a2a4, type: 2}

--- a/Assets/Resources/Quests/Barkley/Another Magicool Gift.asset
+++ b/Assets/Resources/Quests/Barkley/Another Magicool Gift.asset
@@ -13,10 +13,33 @@ MonoBehaviour:
   m_Name: Another Magicool Gift
   m_EditorClassIdentifier: 
   questId: Another Magicool Gift
-  questName: Another Magicool Gift
-  description: '"Seek out Barkley, he''s been searching for the perfect lumber and
-    you can find him in the Farmlands" - The Vast One'
-  rewardDescription: Access to The Woods, Reaping distance increased by 25.
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 6568989310976
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 6571346509824
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 6572961316864
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: de222d7a217d39841a2a727a9a68563e, type: 2}

--- a/Assets/Resources/Quests/Barkley/Finishing Touches.asset
+++ b/Assets/Resources/Quests/Barkley/Finishing Touches.asset
@@ -13,10 +13,33 @@ MonoBehaviour:
   m_Name: Finishing Touches
   m_EditorClassIdentifier: 
   questId: Finishing Touches
-  questName: Finishing Touches
-  description: '"The Old Timer suggested reinforcing my walls with Stone! What a
-    fantastic idea! You don''t mind helping me out one last time do you?" -Barkley'
-  rewardDescription: Gain the Alter Echo of Feathers.
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 6386549669888
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 6388466466816
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 6390102245376
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 695c73bb2e02fd744a413ce180b92246, type: 2}

--- a/Assets/Resources/Quests/Barkley/Into The Woods.asset
+++ b/Assets/Resources/Quests/Barkley/Into The Woods.asset
@@ -13,13 +13,33 @@ MonoBehaviour:
   m_Name: Into The Woods
   m_EditorClassIdentifier: 
   questId: Into The Woods
-  questName: Into The Woods
-  description: '"Here, take my spare axe and go into them woods we''ll need at least
-    10 logs to get this frame started" -Barkley'
-  rewardDescription: 'Unlocks the Alter-Echoes screen.
-
-    Gain the Alter Echo of
-    Log.'
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 5493825617920
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 5495314595840
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 5496426086400
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: c058038d0557e31478313cc9f9131098, type: 2}

--- a/Assets/Resources/Quests/Barkley/Putting up Walls.asset
+++ b/Assets/Resources/Quests/Barkley/Putting up Walls.asset
@@ -13,10 +13,33 @@ MonoBehaviour:
   m_Name: Putting up Walls
   m_EditorClassIdentifier: 
   questId: Putting up Walls
-  questName: Putting up Walls
-  description: '"Wow you''re a real help! While I get started on these walls would
-    you mind grabbing some more logs for the roof?" -Barkley'
-  rewardDescription: Reaping distance increased by 10.
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 6023255834624
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 6024656732160
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 6025701113856
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 305b32e698de898478ae2a41a5a1322c, type: 2}

--- a/Assets/Resources/Quests/Enemies/A slime in time.asset
+++ b/Assets/Resources/Quests/Enemies/A slime in time.asset
@@ -13,12 +13,33 @@ MonoBehaviour:
   m_Name: A slime in time
   m_EditorClassIdentifier: 
   questId: A Slime in Time
-  questName: A Slime in Time
-  description: '"Drive back the slimes in the surrounding area and I shall allow
-    you to travel further." - Carl'
-  rewardDescription: 'Slime Alter-Echo
-
-    Reaping distance increased by 50'
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 6905842253824
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 6922204233728
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 6943423217664
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: Ivan1
   requiredQuests:
   - {fileID: 11400000, guid: c058038d0557e31478313cc9f9131098, type: 2}

--- a/Assets/Resources/Quests/Enemies/Protect the Town.asset
+++ b/Assets/Resources/Quests/Enemies/Protect the Town.asset
@@ -13,10 +13,33 @@ MonoBehaviour:
   m_Name: Protect the Town
   m_EditorClassIdentifier: 
   questId: Protect the Town
-  questName: Protect the Town
-  description: '"I''ve left an artifact with Ivan, clear out the additional slimes
-    surrounding the town and I am sure he will give it to you" - The Vast One'
-  rewardDescription: Magic dice, provides combat advantages.
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7063816519680
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7083122900992
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7084691570688
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: Ivan1
   requiredQuests:
   - {fileID: 11400000, guid: 001ffd797971b8b4d84531fd428157a8, type: 2}

--- a/Assets/Resources/Quests/Eva/Daily Bread.asset
+++ b/Assets/Resources/Quests/Eva/Daily Bread.asset
@@ -13,13 +13,33 @@ MonoBehaviour:
   m_Name: Daily Bread
   m_EditorClassIdentifier: 
   questId: Daily Bread
-  questName: Daily Bread
-  description: '"Something delicious came to me in a dream last night. I need you
-    to collect some corn for a new recipe. If you do I will teach you to grow Wheat"
-    -Eva'
-  rewardDescription: 'Unlock the Wheat crop
-
-'
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7243521474560
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7244716851200
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7245635403776
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: c83b4b0590bf39a498aef150278941ac, type: 2}

--- a/Assets/Resources/Quests/Eva/Feeding the Masses.asset
+++ b/Assets/Resources/Quests/Eva/Feeding the Masses.asset
@@ -13,11 +13,33 @@ MonoBehaviour:
   m_Name: Feeding the Masses
   m_EditorClassIdentifier: 
   questId: Feeding the Masses
-  questName: Feeding the Masses
-  description: '"You''re getting pretty good at this whole farming thing now. If
-    you get me some more I am sure I could attune an Alter-Echo for you, oh and the
-    farmers would probably be happy to give you some space on their farm!" -Eva'
-  rewardDescription: Radish Alter-Echo
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7357656875008
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7358952914944
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7359963742208
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: c83b4b0590bf39a498aef150278941ac, type: 2}

--- a/Assets/Resources/Quests/Eva/For the Jam.asset
+++ b/Assets/Resources/Quests/Eva/For the Jam.asset
@@ -13,10 +13,33 @@ MonoBehaviour:
   m_Name: For the Jam
   m_EditorClassIdentifier: 
   questId: For the Jam!
-  questName: For the Jam!
-  description: '"The Jam was a real hit! But now everyone in the town wants some.
-    Go get me some more radishes and I will teach you how to farm Corn" -Eva'
-  rewardDescription: Unlock the Corn Crop
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7520072908800
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7521440251904
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7522576908288
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 073c0db0b83221e44a3160de9c840855, type: 2}

--- a/Assets/Resources/Quests/Eva/Unlock Carrot.asset
+++ b/Assets/Resources/Quests/Eva/Unlock Carrot.asset
@@ -13,9 +13,33 @@ MonoBehaviour:
   m_Name: Unlock Carrot
   m_EditorClassIdentifier: 
   questId: Unlock Carrot
-  questName: Unlock Carrot
-  description: Coming Soon!
-  rewardDescription: Unlock the Carrot crop
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7638297755648
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7639480549376
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7640587845632
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: e7b996d2be115c74aae9b52d0808a89f, type: 2}

--- a/Assets/Resources/Quests/Eva/Unlock Chilli.asset
+++ b/Assets/Resources/Quests/Eva/Unlock Chilli.asset
@@ -13,9 +13,33 @@ MonoBehaviour:
   m_Name: Unlock Chilli
   m_EditorClassIdentifier: 
   questId: Unlock Chilli
-  questName: Unlock Chilli
-  description: Coming Soon!
-  rewardDescription: Unlock the Chillie crop
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7872075677696
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7873216528384
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7874336407552
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 28ae2ed17b1546c8a3d5f43e52c3cdb7, type: 2}

--- a/Assets/Resources/Quests/Eva/Unlock Cucumber.asset
+++ b/Assets/Resources/Quests/Eva/Unlock Cucumber.asset
@@ -13,9 +13,33 @@ MonoBehaviour:
   m_Name: Unlock Cucumber
   m_EditorClassIdentifier: 
   questId: Unlock Cucumber
-  questName: Unlock Cucumber
-  description: Coming Soon!
-  rewardDescription: Unlock the Cucumber crop
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7954296619008
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7955139674112
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7955957563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 35982548c6994ba5a00d881db3dac34e, type: 2}

--- a/Assets/Resources/Quests/Eva/Unlock Funion.asset
+++ b/Assets/Resources/Quests/Eva/Unlock Funion.asset
@@ -13,9 +13,33 @@ MonoBehaviour:
   m_Name: Unlock Funion
   m_EditorClassIdentifier: 
   questId: Unlock Funion
-  questName: Unlock Funion
-  description: Coming Soon!
-  rewardDescription: Unlock the Funion crop
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956045563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956046563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956047563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 212e527a951e485c8bc8c31cb639f88a, type: 2}

--- a/Assets/Resources/Quests/Eva/Unlock Leek.asset
+++ b/Assets/Resources/Quests/Eva/Unlock Leek.asset
@@ -13,9 +13,33 @@ MonoBehaviour:
   m_Name: Unlock Leek
   m_EditorClassIdentifier: 
   questId: Unlock Leek
-  questName: Unlock Leek
-  description: Coming Soon!
-  rewardDescription: Unlock the Leek crop
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956051563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956052563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956053563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 2395628c18784e2bab0b7af0b4bbc721, type: 2}

--- a/Assets/Resources/Quests/Eva/Unlock Lettuce.asset
+++ b/Assets/Resources/Quests/Eva/Unlock Lettuce.asset
@@ -13,9 +13,33 @@ MonoBehaviour:
   m_Name: Unlock Lettuce
   m_EditorClassIdentifier: 
   questId: Unlock Lettuce
-  questName: Unlock Lettuce
-  description: Coming Soon!
-  rewardDescription: Unlock the Lettuce crop
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956054563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956055563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956056563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: a01bc0adc87a48bab23d3700a16800e6, type: 2}

--- a/Assets/Resources/Quests/Eva/Unlock Onion.asset
+++ b/Assets/Resources/Quests/Eva/Unlock Onion.asset
@@ -13,9 +13,33 @@ MonoBehaviour:
   m_Name: Unlock Onion
   m_EditorClassIdentifier: 
   questId: Unlock Onion
-  questName: Unlock Onion
-  description: Coming Soon!
-  rewardDescription: Unlock the Onion crop
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956060563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956061563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956062563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: c3c28a1d79264acb8fe05e6880426a43, type: 2}

--- a/Assets/Resources/Quests/Eva/Unlock Parsnip.asset
+++ b/Assets/Resources/Quests/Eva/Unlock Parsnip.asset
@@ -13,9 +13,33 @@ MonoBehaviour:
   m_Name: Unlock Parsnip
   m_EditorClassIdentifier: 
   questId: Unlock Parsnip
-  questName: Unlock Parsnip
-  description: Coming Soon!
-  rewardDescription: Unlock the Parsnip crop
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956063563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956064563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956065563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 959a94840c214b3dae27c81ab2473463, type: 2}

--- a/Assets/Resources/Quests/Eva/Unlock Pepper.asset
+++ b/Assets/Resources/Quests/Eva/Unlock Pepper.asset
@@ -13,9 +13,33 @@ MonoBehaviour:
   m_Name: Unlock Pepper
   m_EditorClassIdentifier: 
   questId: Unlock Pepper
-  questName: Unlock Pepper
-  description: Coming Soon!
-  rewardDescription: Unlock the Pepper crop
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956066563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956067563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956068563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 00568cbce0574f7680580a71be54f90a, type: 2}

--- a/Assets/Resources/Quests/Eva/Unlock Pumpking.asset
+++ b/Assets/Resources/Quests/Eva/Unlock Pumpking.asset
@@ -13,9 +13,33 @@ MonoBehaviour:
   m_Name: Unlock Pumpking
   m_EditorClassIdentifier: 
   questId: Unlock Pumpking
-  questName: Unlock Pumpking
-  description: Coming Soon!
-  rewardDescription: Unlock the Pumking crop
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956069563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956070563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956071563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 4ca1d6c5bf8245df82a7a75168d51f02, type: 2}

--- a/Assets/Resources/Quests/Eva/Unlock Spud.asset
+++ b/Assets/Resources/Quests/Eva/Unlock Spud.asset
@@ -13,9 +13,33 @@ MonoBehaviour:
   m_Name: Unlock Spud
   m_EditorClassIdentifier: 
   questId: Unlock Spud
-  questName: Unlock Spud
-  description: Coming Soon!
-  rewardDescription: Unlock the Spud crop
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956072563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956073563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956074563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 31c43e7b43e9407791103b070abe9e42, type: 2}

--- a/Assets/Resources/Quests/Eva/Unlock Strawberry.asset
+++ b/Assets/Resources/Quests/Eva/Unlock Strawberry.asset
@@ -13,9 +13,33 @@ MonoBehaviour:
   m_Name: Unlock Strawberry
   m_EditorClassIdentifier: 
   questId: Unlock Strawberry
-  questName: Unlock Strawberry
-  description: Coming Soon!
-  rewardDescription: Unlock the Strawberry crop
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956075563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956076563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956077563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 78e6cf2e15964b41b5fcd5833f00d44a, type: 2}

--- a/Assets/Resources/Quests/Eva/Unlock Tomato.asset
+++ b/Assets/Resources/Quests/Eva/Unlock Tomato.asset
@@ -13,9 +13,33 @@ MonoBehaviour:
   m_Name: Unlock Tomato
   m_EditorClassIdentifier: 
   questId: Unlock Tomato
-  questName: Unlock Tomato
-  description: Coming Soon!
-  rewardDescription: Unlock the Tomato crop
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956078563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956079563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956080563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: ba841e2bed264c8bb9226481219ced25, type: 2}

--- a/Assets/Resources/Quests/Eva/Unlock Turnip.asset
+++ b/Assets/Resources/Quests/Eva/Unlock Turnip.asset
@@ -13,9 +13,33 @@ MonoBehaviour:
   m_Name: Unlock Turnip
   m_EditorClassIdentifier: 
   questId: Unlock Turnip
-  questName: Unlock Turnip
-  description: Coming Soon!
-  rewardDescription: Unlock the Turnip crop
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956081563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956082563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956083563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 72c197707d4c4c529d67db6a7e711132, type: 2}

--- a/Assets/Resources/Quests/Eva/Unlock Watermelone.asset
+++ b/Assets/Resources/Quests/Eva/Unlock Watermelone.asset
@@ -13,11 +13,33 @@ MonoBehaviour:
   m_Name: Unlock Watermelone
   m_EditorClassIdentifier: 
   questId: Unlock Watermelone
-  questName: Unlock Watermelone
-  description: Coming Soon!
-  rewardDescription: 'Unlock the Watermelone crop
-
-'
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956087563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956088563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956089563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: ac7e31f0151eed24397bcddbdb709b85, type: 2}

--- a/Assets/Resources/Quests/Gill/Bloopicus MaximusAE.asset
+++ b/Assets/Resources/Quests/Gill/Bloopicus MaximusAE.asset
@@ -13,9 +13,33 @@ MonoBehaviour:
   m_Name: Bloopicus MaximusAE
   m_EditorClassIdentifier: 
   questId: Bloopicus MaximusAE
-  questName: 
-  description: 
-  rewardDescription: 
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7955970563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7955971563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7955972563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 289733cc9f96c56448ed2599984bf8a9, type: 2}

--- a/Assets/Resources/Quests/Gill/Flippy FloppyAE.asset
+++ b/Assets/Resources/Quests/Gill/Flippy FloppyAE.asset
@@ -13,9 +13,33 @@ MonoBehaviour:
   m_Name: Flippy FloppyAE
   m_EditorClassIdentifier: 
   questId: Flippy FloppyAE
-  questName: 
-  description: 
-  rewardDescription: 
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7955994563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7955995563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7955996563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 289733cc9f96c56448ed2599984bf8a9, type: 2}

--- a/Assets/Resources/Quests/Gill/Muddy Muck MuncherAE.asset
+++ b/Assets/Resources/Quests/Gill/Muddy Muck MuncherAE.asset
@@ -13,12 +13,33 @@ MonoBehaviour:
   m_Name: Muddy Muck MuncherAE
   m_EditorClassIdentifier: 
   questId: Muddy Muck MuncherAE
-  questName: Muck-in-the-Mud Mission
-  description: "\u201CMildred\u2019s whiskers twitch whenever a Muddy Muck Muncher
-    surfaces,\u201D Gill chuckles. \u201CHook me 50 of the sludge-suckers so she
-    can roll in the muck\u2014and I\u2019ll show you how to make even swamp water
-    sparkle.\u201D"
-  rewardDescription: Gain the Disciple of Muddy Muck Muncher
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956012563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956013563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956014563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 289733cc9f96c56448ed2599984bf8a9, type: 2}

--- a/Assets/Resources/Quests/Gill/Niblet the BoldAE.asset
+++ b/Assets/Resources/Quests/Gill/Niblet the BoldAE.asset
@@ -13,11 +13,33 @@ MonoBehaviour:
   m_Name: Niblet the BoldAE
   m_EditorClassIdentifier: 
   questId: Niblet the BoldAE
-  questName: "Niblet\u2019s Nerve"
-  description: "\u201CNiblet the Bold swims straight at sharks,\u201D Gill whispers
-    with admiration. \u201CLand 50 of the fearless fry so we can bottle that courage\u2014Mildred
-    could use it for night patrols, and Utoes for a hearty tonic.\u201D"
-  rewardDescription: Gain the Disciple of Niblet the Bold
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956015563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956016563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956017563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 289733cc9f96c56448ed2599984bf8a9, type: 2}

--- a/Assets/Resources/Quests/Gill/SirSplashfordIIIAE.asset
+++ b/Assets/Resources/Quests/Gill/SirSplashfordIIIAE.asset
@@ -13,11 +13,33 @@ MonoBehaviour:
   m_Name: SirSplashfordIIIAE
   m_EditorClassIdentifier: 
   questId: SirSplashfordIIIAE
-  questName: A Splash of Nobility
-  description: "Gill doffs an imaginary crown. \u201CSir Splashford III is royal
-    to the gills. Snare 50 of the pompous puddle-jumpers\u2014Mildred will curtsey,
-    and Utoes swears their scales boost regen if brewed just right.\u201D"
-  rewardDescription: Gain the Disciple of Sir Splashford III
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7955961563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7955962563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7955963563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 289733cc9f96c56448ed2599984bf8a9, type: 2}

--- a/Assets/Resources/Quests/Gill/Snapjaw Jr.AE.asset
+++ b/Assets/Resources/Quests/Gill/Snapjaw Jr.AE.asset
@@ -13,9 +13,33 @@ MonoBehaviour:
   m_Name: Snapjaw Jr.AE
   m_EditorClassIdentifier: 
   questId: Snapjaw Jr.AE
-  questName: 
-  description: 
-  rewardDescription: Gain the Disciple of Snapjaw Jr.
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956003563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956004563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956005563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 289733cc9f96c56448ed2599984bf8a9, type: 2}

--- a/Assets/Resources/Quests/Gill/WigglelittleAE.asset
+++ b/Assets/Resources/Quests/Gill/WigglelittleAE.asset
@@ -13,11 +13,33 @@ MonoBehaviour:
   m_Name: WigglelittleAE
   m_EditorClassIdentifier: 
   questId: WigglelittleAE
-  questName: Wiggle Room
-  description: "\u201CWigglelittles never stop dancing,\u201D Gill says, tail swishing
-    in time. \u201CCatch 50 before they wriggle off\u2014Mildred wants a new music
-    box, and Utoes thinks their rhythm could sync with your heartbeat.\u201D"
-  rewardDescription: Gain the Disciple of Wigglelittle
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956093563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956094563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956095563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 289733cc9f96c56448ed2599984bf8a9, type: 2}

--- a/Assets/Resources/Quests/Mildred/BuffSlot2.asset
+++ b/Assets/Resources/Quests/Mildred/BuffSlot2.asset
@@ -13,9 +13,33 @@ MonoBehaviour:
   m_Name: BuffSlot2
   m_EditorClassIdentifier: 
   questId: BuffSlot2
-  questName: 
-  description: 
-  rewardDescription: Another buff slot!
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7955967563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7955968563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7955969563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 18cb43a77b364b24fb75a31ff790efc5, type: 2}

--- a/Assets/Resources/Quests/Mildred/BuffSlot3.asset
+++ b/Assets/Resources/Quests/Mildred/BuffSlot3.asset
@@ -13,9 +13,33 @@ MonoBehaviour:
   m_Name: BuffSlot3
   m_EditorClassIdentifier: 
   questId: BuffSlot3
-  questName: 
-  description: 
-  rewardDescription: Another buff slot!
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7955964563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7955965563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7955966563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 289733cc9f96c56448ed2599984bf8a9, type: 2}

--- a/Assets/Resources/Quests/Mildred/BuffSlot4.asset
+++ b/Assets/Resources/Quests/Mildred/BuffSlot4.asset
@@ -13,9 +13,33 @@ MonoBehaviour:
   m_Name: BuffSlot4
   m_EditorClassIdentifier: 
   questId: BuffSlot4
-  questName: 
-  description: 
-  rewardDescription: Another buff slot!
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956027563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956028563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956029563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 289733cc9f96c56448ed2599984bf8a9, type: 2}

--- a/Assets/Resources/Quests/Mildred/BuffSlot5.asset
+++ b/Assets/Resources/Quests/Mildred/BuffSlot5.asset
@@ -13,9 +13,33 @@ MonoBehaviour:
   m_Name: BuffSlot5
   m_EditorClassIdentifier: 
   questId: BuffSlot5
-  questName: 
-  description: 
-  rewardDescription: Another buff slot!
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956036563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956037563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956038563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 289733cc9f96c56448ed2599984bf8a9, type: 2}

--- a/Assets/Resources/Quests/Mildred/Echo Casting.asset
+++ b/Assets/Resources/Quests/Mildred/Echo Casting.asset
@@ -13,10 +13,33 @@ MonoBehaviour:
   m_Name: Echo Casting
   m_EditorClassIdentifier: 
   questId: Echo Casting
-  questName: Echo Casting
-  description: '"As you use these buffs more often, my power will feel more natural
-    to you and echoes from your past will cast them for you." - The Vast One'
-  rewardDescription: Autocast buff slot 1 is now togglable.
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7955985563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7955986563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7955987563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 18cb43a77b364b24fb75a31ff790efc5, type: 2}

--- a/Assets/Resources/Quests/Mildred/The 100.asset
+++ b/Assets/Resources/Quests/Mildred/The 100.asset
@@ -13,10 +13,33 @@ MonoBehaviour:
   m_Name: The 100
   m_EditorClassIdentifier: 
   questId: The 100
-  questName: The 100
-  description: '"Each slot will require more casts than the last to unlock. Such
-    is the nature of Echo Casting..." - The Vast One'
-  rewardDescription: Autocast buff slot 2 is now togglable.
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956033563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956034563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956035563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: a04629c010952d741b32db280e62a8eb, type: 2}

--- a/Assets/Resources/Quests/Old Timer/CopiumAE.asset
+++ b/Assets/Resources/Quests/Old Timer/CopiumAE.asset
@@ -13,9 +13,33 @@ MonoBehaviour:
   m_Name: CopiumAE
   m_EditorClassIdentifier: 
   questId: CopiumAE
-  questName: CopiumAE
-  description: 
-  rewardDescription: 
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7955979563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7955980563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7955981563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 289733cc9f96c56448ed2599984bf8a9, type: 2}

--- a/Assets/Resources/Quests/Old Timer/DlogAE.asset
+++ b/Assets/Resources/Quests/Old Timer/DlogAE.asset
@@ -13,9 +13,33 @@ MonoBehaviour:
   m_Name: DlogAE
   m_EditorClassIdentifier: 
   questId: DlogAE
-  questName: DlogAE
-  description: 
-  rewardDescription: 
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7955982563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7955983563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7955984563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 289733cc9f96c56448ed2599984bf8a9, type: 2}

--- a/Assets/Resources/Quests/Old Timer/ErifAE.asset
+++ b/Assets/Resources/Quests/Old Timer/ErifAE.asset
@@ -13,9 +13,33 @@ MonoBehaviour:
   m_Name: ErifAE
   m_EditorClassIdentifier: 
   questId: ErifAE
-  questName: ErifAE
-  description: 
-  rewardDescription: 
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7955988563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7955989563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7955990563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 289733cc9f96c56448ed2599984bf8a9, type: 2}

--- a/Assets/Resources/Quests/Old Timer/EznorbAE.asset
+++ b/Assets/Resources/Quests/Old Timer/EznorbAE.asset
@@ -13,9 +13,33 @@ MonoBehaviour:
   m_Name: EznorbAE
   m_EditorClassIdentifier: 
   questId: EznorbAE
-  questName: EznorbAE
-  description: 
-  rewardDescription: 
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7955991563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7955992563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7955993563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 289733cc9f96c56448ed2599984bf8a9, type: 2}

--- a/Assets/Resources/Quests/Old Timer/IdleAE.asset
+++ b/Assets/Resources/Quests/Old Timer/IdleAE.asset
@@ -13,9 +13,33 @@ MonoBehaviour:
   m_Name: IdleAE
   m_EditorClassIdentifier: 
   questId: IdleAE
-  questName: IdleAE
-  description: 
-  rewardDescription: 
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956000563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956001563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956002563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 289733cc9f96c56448ed2599984bf8a9, type: 2}

--- a/Assets/Resources/Quests/Old Timer/LiriumAE.asset
+++ b/Assets/Resources/Quests/Old Timer/LiriumAE.asset
@@ -13,9 +13,33 @@ MonoBehaviour:
   m_Name: LiriumAE
   m_EditorClassIdentifier: 
   questId: LiriumAE
-  questName: LiriumAE
-  description: 
-  rewardDescription: 
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956009563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956010563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956011563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 289733cc9f96c56448ed2599984bf8a9, type: 2}

--- a/Assets/Resources/Quests/Old Timer/NoriAE.asset
+++ b/Assets/Resources/Quests/Old Timer/NoriAE.asset
@@ -13,9 +13,33 @@ MonoBehaviour:
   m_Name: NoriAE
   m_EditorClassIdentifier: 
   questId: NoriAE
-  questName: NoriAE
-  description: 
-  rewardDescription: 
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956018563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956019563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956020563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 289733cc9f96c56448ed2599984bf8a9, type: 2}

--- a/Assets/Resources/Quests/Old Timer/StoneAE.asset
+++ b/Assets/Resources/Quests/Old Timer/StoneAE.asset
@@ -13,9 +13,33 @@ MonoBehaviour:
   m_Name: StoneAE
   m_EditorClassIdentifier: 
   questId: StoneAE
-  questName: StoneAE
-  description: 
-  rewardDescription: 
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956030563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956031563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956032563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 289733cc9f96c56448ed2599984bf8a9, type: 2}

--- a/Assets/Resources/Quests/Old Timer/VastiumAE.asset
+++ b/Assets/Resources/Quests/Old Timer/VastiumAE.asset
@@ -13,9 +13,33 @@ MonoBehaviour:
   m_Name: VastiumAE
   m_EditorClassIdentifier: 
   questId: VastiumAE
-  questName: VastiumAE
-  description: 
-  rewardDescription: 
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956090563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956091563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956092563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 289733cc9f96c56448ed2599984bf8a9, type: 2}

--- a/Assets/Resources/Quests/Ores/Chunky Business.asset
+++ b/Assets/Resources/Quests/Ores/Chunky Business.asset
@@ -13,13 +13,33 @@ MonoBehaviour:
   m_Name: Chunky Business
   m_EditorClassIdentifier: 
   questId: Chunky Business
-  questName: Chunky Business
-  description: '"*Grumbles* This town could sure use a better footing. Go fetch some
-    Nori Chunks and we will get started on some pathing" -The Old Timer'
-  rewardDescription: 'Unlocks Dlog nodes for mining these start to appear at 150
-    distance.
-
-    Reaping distance increased by 25'
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7955976563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7955977563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7955978563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 2f2ff992f4de15a4bb5263366f3fe554, type: 2}

--- a/Assets/Resources/Quests/Ores/Unlock Copium.asset
+++ b/Assets/Resources/Quests/Ores/Unlock Copium.asset
@@ -13,9 +13,33 @@ MonoBehaviour:
   m_Name: Unlock Copium
   m_EditorClassIdentifier: 
   questId: Unlock Copium
-  questName: Unlock Copium
-  description: Coming soon!
-  rewardDescription: Unlocks Copium nodes
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956039563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956040563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956041563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 8c7a0f27f3d9da0419dab5a969401442, type: 2}

--- a/Assets/Resources/Quests/Ores/Unlock Erif.asset
+++ b/Assets/Resources/Quests/Ores/Unlock Erif.asset
@@ -13,9 +13,33 @@ MonoBehaviour:
   m_Name: Unlock Erif
   m_EditorClassIdentifier: 
   questId: Unlock Erif
-  questName: Unlock Erif
-  description: Coming soon!
-  rewardDescription: Unlocks Erif nodes for mining
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956042563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956043563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956044563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 74ed306672b0a214685903da2dbf07c8, type: 2}

--- a/Assets/Resources/Quests/Ores/Unlock Idle.asset
+++ b/Assets/Resources/Quests/Ores/Unlock Idle.asset
@@ -13,9 +13,33 @@ MonoBehaviour:
   m_Name: Unlock Idle
   m_EditorClassIdentifier: 
   questId: Unlock Idle
-  questName: Unlock Idle
-  description: Coming soon!
-  rewardDescription: Unlocks Idle nodes for mining
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956048563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956049563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956050563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 21c838e0a781dcb4c96d7cb663953ff5, type: 2}

--- a/Assets/Resources/Quests/Ores/Unlock Lirium.asset
+++ b/Assets/Resources/Quests/Ores/Unlock Lirium.asset
@@ -13,9 +13,33 @@ MonoBehaviour:
   m_Name: Unlock Lirium
   m_EditorClassIdentifier: 
   questId: Unlock Lirium
-  questName: Unlock Lirium
-  description: Coming soon!
-  rewardDescription: Unlocks Lirium nodes for mining
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956057563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956058563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956059563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 8881bebf2bb94df4a91353c851ca2b6f, type: 2}

--- a/Assets/Resources/Quests/Ores/Unlock Vastium.asset
+++ b/Assets/Resources/Quests/Ores/Unlock Vastium.asset
@@ -13,9 +13,33 @@ MonoBehaviour:
   m_Name: Unlock Vastium
   m_EditorClassIdentifier: 
   questId: Unlock Vastium
-  questName: Unlock Vastium
-  description: Coming soon!
-  rewardDescription: Unlocks Vastium nodes for mining
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956084563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956085563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956086563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 63ff8ec529640974ab5843c76a2009bf, type: 2}

--- a/Assets/Resources/Quests/Wren/BoneAE.asset
+++ b/Assets/Resources/Quests/Wren/BoneAE.asset
@@ -13,9 +13,33 @@ MonoBehaviour:
   m_Name: BoneAE
   m_EditorClassIdentifier: 
   questId: BoneAE
-  questName: BoneAE
-  description: 
-  rewardDescription: 
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7955973563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7955974563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7955975563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 289733cc9f96c56448ed2599984bf8a9, type: 2}

--- a/Assets/Resources/Quests/Wren/LeatherAE.asset
+++ b/Assets/Resources/Quests/Wren/LeatherAE.asset
@@ -13,9 +13,33 @@ MonoBehaviour:
   m_Name: LeatherAE
   m_EditorClassIdentifier: 
   questId: LeatherAE
-  questName: LeatherAE
-  description: 
-  rewardDescription: 
+  questName:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956006563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  description:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956007563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
+  rewardDescription:
+  m_TableReference:
+    m_TableCollectionName: GUID:f47e1bc3466d50a44a1f557a2552b815
+  m_TableEntryReference:
+    m_KeyId: 7956008563392
+    m_Key:
+  m_FallbackState: 0
+  m_WaitForCompletion: 0
+  m_LocalVariables: []
   npcId: 
   requiredQuests:
   - {fileID: 11400000, guid: 289733cc9f96c56448ed2599984bf8a9, type: 2}


### PR DESCRIPTION
## Summary
- update quest assets under `Assets/Resources/Quests` to use localization table entries

## Testing
- `python3 /tmp/update_quests2.py`

------
https://chatgpt.com/codex/tasks/task_e_688d50bc5e10832ea6623a56721cb2a4