### PR TITLE
Add quest autopin flag

### DIFF
--- a/Assets/Scripts/Quests/QuestData.cs
+++ b/Assets/Scripts/Quests/QuestData.cs
@@ -18,6 +18,10 @@ namespace TimelessEchoes.Quests
         public LocalizedString description;
         public LocalizedString rewardDescription;
         public string npcId;
+        /// <summary>
+        ///     Automatically pin this quest when it becomes active.
+        /// </summary>
+        public bool autoPin;
         public List<QuestData> requiredQuests = new();
         public List<Requirement> requirements = new();
         public int unlockBuffSlots;

--- a/Assets/Scripts/Quests/QuestManager.cs
+++ b/Assets/Scripts/Quests/QuestManager.cs
@@ -417,7 +417,7 @@ namespace TimelessEchoes.Quests
             inst.ui = null;
 
             active[quest.questId] = inst;
-            if (AutoPinActiveQuests && !IsInstantQuest(quest))
+            if ((AutoPinActiveQuests || quest.autoPin) && !IsInstantQuest(quest))
             {
                 var set = oracle.saveData.PinnedQuests;
                 if (!set.Contains(quest.questId))


### PR DESCRIPTION
## Summary
- allow quests to define if they should be pinned automatically
- autopin quests when they become active if player preference or quest flag is set

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688d5dc75b20832eb46582d472db7f86