### PR TITLE
Mark QuestFlowWindow OnGUI override as obsolete

### DIFF
--- a/Assets/Editor/QuestFlowWindow.cs
+++ b/Assets/Editor/QuestFlowWindow.cs
@@ -1,4 +1,5 @@
 #if UNITY_EDITOR
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Sirenix.OdinInspector.Editor;
@@ -92,6 +93,7 @@ namespace TimelessEchoes.Editor
             return max;
         }
 
+        [Obsolete]
         protected override void OnGUI()
         {
             SirenixEditorGUI.Title("Quest Flow", null, TextAlignment.Left, true);


### PR DESCRIPTION
## Summary
- annotate QuestFlowWindow.OnGUI with [Obsolete] to satisfy OdinEditorWindow override requirements
- include System namespace for Obsolete attribute

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_688d859fe7cc832ead989215470c3945