### PR TITLE
feat: enable panning in quest flow window

### DIFF
--- a/Assets/Editor/QuestFlowWindow.cs
+++ b/Assets/Editor/QuestFlowWindow.cs
@@ -110,7 +110,16 @@ namespace TimelessEchoes.Editor
             float height = nodeRects.Count > 0 ? nodeRects.Values.Max(r => r.yMax) + 100f : position.height;
             var contentRect = new Rect(0, 0, width, height);
 
-            var area = GUILayoutUtility.GetRect(width, height);
+            var area = GUILayoutUtility.GetRect(0, 0, GUILayout.ExpandWidth(true), GUILayout.ExpandHeight(true));
+
+            var e = Event.current;
+            if (area.Contains(e.mousePosition) && e.type == EventType.MouseDrag && e.button == 2)
+            {
+                scroll -= e.delta;
+                e.Use();
+                Repaint();
+            }
+
             scroll = GUI.BeginScrollView(area, scroll, contentRect);
 
             Handles.BeginGUI();


### PR DESCRIPTION
## Summary
- enable panning in Quest Flow window
- allow middle mouse drag to move quest graph

## Testing
- `dotnet test` (fails: no project file)


------
https://chatgpt.com/codex/tasks/task_e_688d86aacdbc832e932b789e482eda3f