### PR TITLE
Fix QuestFlowWindow GUI setup

### DIFF
--- a/Assets/Editor/QuestFlowWindow.cs
+++ b/Assets/Editor/QuestFlowWindow.cs
@@ -33,10 +33,11 @@ namespace TimelessEchoes.Editor
         {
             base.OnEnable();
             titleContent = new GUIContent("Quest Flow");
+            SetupUI();
             Refresh();
         }
 
-        public override void CreateGUI()
+        private void SetupUI()
         {
             rootVisualElement.Clear();
 


### PR DESCRIPTION
## Summary
- Replace QuestFlowWindow's `CreateGUI` override with `SetupUI` method
- Call `SetupUI` from `OnEnable` to initialize UI without overriding sealed method

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_688d8cd76fb4832e952ea06544073bc3