### PR TITLE
Fix QuestFlowWindow UI toolkit usage

### DIFF
--- a/Assets/Editor/QuestFlowWindow.cs
+++ b/Assets/Editor/QuestFlowWindow.cs
@@ -49,7 +49,10 @@ namespace TimelessEchoes.Editor
             toolbar.Add(refreshButton);
             rootVisualElement.Add(toolbar);
 
-            scrollView = new ScrollView(ScrollViewMode.Both)
+            // Use a ScrollView that supports scrolling in both directions.
+            // ScrollViewMode.Both has been deprecated; VerticalAndHorizontal
+            // provides equivalent functionality in modern Unity versions.
+            scrollView = new ScrollView(ScrollViewMode.VerticalAndHorizontal)
             {
                 style = { flexGrow = 1 }
             };
@@ -121,7 +124,9 @@ namespace TimelessEchoes.Editor
             content.style.width = width;
             content.style.height = height;
 
-            var lines = new ImmediateModeElement(() =>
+            // IMGUIContainer allows drawing with Handles in the UI Toolkit
+            // hierarchy without instantiating the abstract ImmediateModeElement.
+            var lines = new IMGUIContainer(() =>
             {
                 Handles.color = Color.white;
                 foreach (var quest in quests)


### PR DESCRIPTION
## Summary
- replace deprecated `ScrollViewMode.Both` with `ScrollViewMode.VerticalAndHorizontal`
- use `IMGUIContainer` instead of abstract `ImmediateModeElement` to draw quest lines

## Testing
- `mcs Assets/Editor/QuestFlowWindow.cs` *(fails: Program `QuestFlowWindow.exe' does not contain a static `Main' method suitable for an entry point)*

------
https://chatgpt.com/codex/tasks/task_e_688d8fb8fd48832e88df4f6fdc6cc85e