### PR TITLE
Adjust A* grid bounds for chunk movement

### DIFF
--- a/Assets/Scripts/MapGeneration/SegmentedMapGenerator.cs
+++ b/Assets/Scripts/MapGeneration/SegmentedMapGenerator.cs
@@ -121,9 +121,16 @@ namespace TimelessEchoes.MapGeneration
                 return;
 
             var arr = segments.ToArray();
-            var start = arr[1].startX;
-            gg.SetDimensions(segmentSize.x * 8, segmentSize.y * 2, gg.nodeSize);
-            gg.center = new Vector3(start + segmentSize.x, 9f, 0f);
+
+            // Calculate the leftmost and rightmost bounds one tile in from the
+            // outer segments. The A* grid uses two nodes per tile, so we convert
+            // the tile span into node counts when setting the dimensions.
+            var left = arr[0].startX + 1; // 1 tile in from the left chunk
+            var right = arr[2].startX + segmentSize.x - 1; // 1 tile in from the right chunk
+            var widthTiles = right - left; // total tiles covered by the grid
+
+            gg.SetDimensions(widthTiles * 2, segmentSize.y * 2, gg.nodeSize);
+            gg.center = new Vector3((left + right) * 0.5f, segmentSize.y * 0.5f, 0f);
             pathfinder.Scan();
         }
     }


### PR DESCRIPTION
## Summary
- shift A* grid bounds to start one tile inside the left segment and end one tile inside the right segment when moving chunks
- set grid dimensions based on tiles with two nodes per tile and update center accordingly

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_688dae4e6010832eb5adb891e452c6e5