### PR TITLE
Center pathfinding grid on map

### DIFF
--- a/Assets/Scripts/MapGeneration/SegmentedMapGenerator.cs
+++ b/Assets/Scripts/MapGeneration/SegmentedMapGenerator.cs
@@ -130,7 +130,7 @@ namespace TimelessEchoes.MapGeneration
             var widthTiles = right - left; // total tiles covered by the grid
 
             gg.SetDimensions(widthTiles * 2, segmentSize.y * 2, gg.nodeSize);
-            gg.center = new Vector3((left + right) * 0.5f, segmentSize.y * 0.5f, 0f);
+            gg.center = new Vector3(left + widthTiles * 0.5f, segmentSize.y * 0.5f, 0f);
             pathfinder.Scan();
         }
     }


### PR DESCRIPTION
## Summary
- Position A* GridGraph using the trimmed width so it remains centered on the generated segments

## Testing
- `dotnet format Assets/Scripts/MapGeneration/SegmentedMapGenerator.cs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688dafe4bc8c832ebafb0bc1c3b680b3