### PR TITLE
Add localization entries for new quests

### DIFF
--- a/Assets/Localization/Tables/Quests/Quests Shared Data.asset
+++ b/Assets/Localization/Tables/Quests/Quests Shared Data.asset
@@ -807,6 +807,234 @@ MonoBehaviour:
     m_Key: WigglelittleAE.reward
     m_Metadata:
       m_Items: []
+  - m_Id: 7956096563392
+    m_Key: CarrotAE.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956196563392
+    m_Key: CarrotAE.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956296563392
+    m_Key: CarrotAE.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956396563392
+    m_Key: ChilliAE.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956496563392
+    m_Key: ChilliAE.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956596563392
+    m_Key: ChilliAE.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956696563392
+    m_Key: CornAE.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956796563392
+    m_Key: CornAE.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956896563392
+    m_Key: CornAE.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956996563392
+    m_Key: CucumberAE.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7957096563392
+    m_Key: CucumberAE.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7957196563392
+    m_Key: CucumberAE.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7957296563392
+    m_Key: EchoCast3.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7957396563392
+    m_Key: EchoCast3.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7957496563392
+    m_Key: EchoCast3.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7957596563392
+    m_Key: EchoCast4.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7957696563392
+    m_Key: EchoCast4.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7957796563392
+    m_Key: EchoCast4.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7957896563392
+    m_Key: FunionAE.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7957996563392
+    m_Key: FunionAE.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7958096563392
+    m_Key: FunionAE.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7958196563392
+    m_Key: LeekAE.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7958296563392
+    m_Key: LeekAE.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7958396563392
+    m_Key: LeekAE.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7958496563392
+    m_Key: LettuceAE.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7958596563392
+    m_Key: LettuceAE.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7958696563392
+    m_Key: LettuceAE.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7958796563392
+    m_Key: OnionAE.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7958896563392
+    m_Key: OnionAE.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7958996563392
+    m_Key: OnionAE.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7959096563392
+    m_Key: ParsnipAE.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7959196563392
+    m_Key: ParsnipAE.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7959296563392
+    m_Key: ParsnipAE.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7959396563392
+    m_Key: PepperAE.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7959496563392
+    m_Key: PepperAE.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7959596563392
+    m_Key: PepperAE.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7959696563392
+    m_Key: PumpkingAE.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7959796563392
+    m_Key: PumpkingAE.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7959896563392
+    m_Key: PumpkingAE.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7959996563392
+    m_Key: SpudAE.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7960096563392
+    m_Key: SpudAE.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7960196563392
+    m_Key: SpudAE.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7960296563392
+    m_Key: StrawberryAE.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7960396563392
+    m_Key: StrawberryAE.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7960496563392
+    m_Key: StrawberryAE.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7960596563392
+    m_Key: TomatoAE.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7960696563392
+    m_Key: TomatoAE.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7960796563392
+    m_Key: TomatoAE.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7960896563392
+    m_Key: TurnipAE.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7960996563392
+    m_Key: TurnipAE.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7961096563392
+    m_Key: TurnipAE.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7961196563392
+    m_Key: WatermeloneAE.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7961296563392
+    m_Key: WatermeloneAE.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7961396563392
+    m_Key: WatermeloneAE.reward
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7961496563392
+    m_Key: WheatAE.name
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7961596563392
+    m_Key: WheatAE.desc
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7961696563392
+    m_Key: WheatAE.reward
+    m_Metadata:
+      m_Items: []
   m_Metadata:
     m_Items: []
   m_KeyGenerator:

--- a/Assets/Localization/Tables/Quests/Quests_en.asset
+++ b/Assets/Localization/Tables/Quests/Quests_en.asset
@@ -694,6 +694,234 @@ MonoBehaviour:
     m_Localized: BuffSlot4
     m_Metadata:
       m_Items: []
+  - m_Id: 7956096563392
+    m_Localized: Unlock Carrot
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956196563392
+    m_Localized: Coming Soon!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956296563392
+    m_Localized: Unlock the Carrot crop
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956396563392
+    m_Localized: Unlock Chilli
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956496563392
+    m_Localized: Coming Soon!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956596563392
+    m_Localized: Unlock the Chilli crop
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956696563392
+    m_Localized: Unlock Corn
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956796563392
+    m_Localized: Coming Soon!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956896563392
+    m_Localized: Unlock the Corn crop
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7956996563392
+    m_Localized: Unlock Cucumber
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7957096563392
+    m_Localized: Coming Soon!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7957196563392
+    m_Localized: Unlock the Cucumber crop
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7957296563392
+    m_Localized: Echo Cast 3
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7957396563392
+    m_Localized: Coming Soon!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7957496563392
+    m_Localized: Autocast buff slot 3 is now togglable.
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7957596563392
+    m_Localized: Echo Cast 4
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7957696563392
+    m_Localized: Coming Soon!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7957796563392
+    m_Localized: Autocast buff slot 4 is now togglable.
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7957896563392
+    m_Localized: Unlock Funion
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7957996563392
+    m_Localized: Coming Soon!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7958096563392
+    m_Localized: Unlock the Funion crop
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7958196563392
+    m_Localized: Unlock Leek
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7958296563392
+    m_Localized: Coming Soon!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7958396563392
+    m_Localized: Unlock the Leek crop
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7958496563392
+    m_Localized: Unlock Lettuce
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7958596563392
+    m_Localized: Coming Soon!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7958696563392
+    m_Localized: Unlock the Lettuce crop
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7958796563392
+    m_Localized: Unlock Onion
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7958896563392
+    m_Localized: Coming Soon!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7958996563392
+    m_Localized: Unlock the Onion crop
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7959096563392
+    m_Localized: Unlock Parsnip
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7959196563392
+    m_Localized: Coming Soon!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7959296563392
+    m_Localized: Unlock the Parsnip crop
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7959396563392
+    m_Localized: Unlock Pepper
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7959496563392
+    m_Localized: Coming Soon!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7959596563392
+    m_Localized: Unlock the Pepper crop
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7959696563392
+    m_Localized: Unlock Pumpking
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7959796563392
+    m_Localized: Coming Soon!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7959896563392
+    m_Localized: Unlock the Pumpking crop
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7959996563392
+    m_Localized: Unlock Spud
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7960096563392
+    m_Localized: Coming Soon!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7960196563392
+    m_Localized: Unlock the Spud crop
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7960296563392
+    m_Localized: Unlock Strawberry
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7960396563392
+    m_Localized: Coming Soon!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7960496563392
+    m_Localized: Unlock the Strawberry crop
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7960596563392
+    m_Localized: Unlock Tomato
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7960696563392
+    m_Localized: Coming Soon!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7960796563392
+    m_Localized: Unlock the Tomato crop
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7960896563392
+    m_Localized: Unlock Turnip
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7960996563392
+    m_Localized: Coming Soon!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7961096563392
+    m_Localized: Unlock the Turnip crop
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7961196563392
+    m_Localized: Unlock Watermelone
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7961296563392
+    m_Localized: Coming Soon!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7961396563392
+    m_Localized: Unlock the Watermelone crop
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7961496563392
+    m_Localized: Unlock Wheat
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7961596563392
+    m_Localized: Coming Soon!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 7961696563392
+    m_Localized: Unlock the Wheat crop
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []


### PR DESCRIPTION
## Summary
- add localization shared data keys for new quest IDs (e.g., CarrotAE, ChilliAE, EchoCast3)
- populate English quest table with placeholder name/description/reward text for these quests

## Testing
- `npm test` *(fails: no package.json)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688dd0f61cb0832eaba56e0ba7900425