### PR TITLE
Use offsets instead of anchors for safe area

### DIFF
--- a/Assets/Scripts/Blindsided/Utilities/ScreenSafeArea.cs
+++ b/Assets/Scripts/Blindsided/Utilities/ScreenSafeArea.cs
@@ -10,8 +10,6 @@ namespace Blindsided.Utilities
     public class ScreenSafeArea : MonoBehaviour
     {
         private RectTransform _rectTransform;
-        private Vector2 maxAnchor;
-        private Vector2 minAnchor;
         private Rect safeArea;
         private Vector2Int lastResolution;
         private Rect lastSafeArea;
@@ -185,16 +183,8 @@ namespace Blindsided.Utilities
                 }
             }
 
-            minAnchor = safeArea.position;
-            maxAnchor = minAnchor + safeArea.size;
-
-            minAnchor.x /= Screen.width;
-            minAnchor.y /= Screen.height;
-            maxAnchor.x /= Screen.width;
-            maxAnchor.y /= Screen.height;
-
-            _rectTransform.anchorMin = minAnchor;
-            _rectTransform.anchorMax = maxAnchor;
+            _rectTransform.offsetMin = new Vector2(safeArea.xMin, safeArea.yMin);
+            _rectTransform.offsetMax = new Vector2(-(Screen.width - safeArea.xMax), -(Screen.height - safeArea.yMax));
 
             lastSafeArea = Screen.safeArea;
             lastResolution = new Vector2Int(Screen.width, Screen.height);


### PR DESCRIPTION
## Summary
- stop ScreenSafeArea from rewriting anchors
- apply safe area using RectTransform offsets

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688dd4f93a1c832ebf98b6a78ab394c3