### PR TITLE
refactor: use Oracle accessors for save data

### DIFF
--- a/Assets/Scripts/Blindsided/Oracle.cs
+++ b/Assets/Scripts/Blindsided/Oracle.cs
@@ -59,6 +59,10 @@ namespace Blindsided
         private string _dataName => (beta ? $"Beta{betaSaveIteration}" : "") + $"Data{CurrentSlot}";
         private string _fileName => (beta ? $"Beta{betaSaveIteration}" : "") + $"Sd{CurrentSlot}.es3";
 
+        public string DataName => _dataName;
+        public string FileName => _fileName;
+        public ES3Settings Settings => _settings;
+
         [TabGroup("SaveData")] public GameData saveData = new();
 
         #endregion

--- a/Assets/Scripts/UI/QuitGameButton.cs
+++ b/Assets/Scripts/UI/QuitGameButton.cs
@@ -59,24 +59,15 @@ namespace TimelessEchoes.UI
 
         private static void SaveGame()
         {
-            if (Oracle.oracle == null)
+            var oracle = Oracle.oracle;
+            if (oracle == null)
                 return;
 
             EventHandler.SaveData();
-            Oracle.oracle.saveData.DateQuitString = DateTime.UtcNow.ToString(CultureInfo.InvariantCulture);
+            oracle.saveData.DateQuitString = DateTime.UtcNow.ToString(CultureInfo.InvariantCulture);
 
-            var beta = Oracle.oracle.beta;
-            var iteration = Oracle.oracle.betaSaveIteration;
-            var slot = Oracle.oracle.CurrentSlot;
-            var dataName = (beta ? $"Beta{iteration}" : "") + $"Data{slot}";
-            var fileName = (beta ? $"Beta{iteration}" : "") + $"Sd{slot}.es3";
-            var settings = new ES3Settings(fileName, ES3.Location.Cache)
-            {
-                bufferSize = 8192
-            };
-
-            ES3.Save(dataName, Oracle.oracle.saveData, settings);
-            ES3.StoreCachedFile(fileName);
+            ES3.Save(oracle.DataName, oracle.saveData, oracle.Settings);
+            ES3.StoreCachedFile(oracle.FileName);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add accessors on Oracle for current slot file/data names and ES3 settings
- use Oracle accessors in QuitGameButton.SaveGame to store current slot data

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688de6484888832ea0e2945593eaebd5