### PR TITLE
Ensure cloud sync uses slot-specific files

### DIFF
--- a/Assets/Scripts/Blindsided/Oracle.cs
+++ b/Assets/Scripts/Blindsided/Oracle.cs
@@ -148,6 +148,7 @@ namespace Blindsided
                 bufferSize = 8192
             };
             SteamCloudSync.Instance.SetFileName(_fileName);
+            SteamCloudSync.Instance.Download(); // ensure local copy is up-to-date
             Load();
         }
 


### PR DESCRIPTION
## Summary
- Refresh selected save slot from Steam Cloud before loading
- Confirm cloud uploads and backups operate on slot-specific filenames

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688de5d25a0c832ea1353dd721be0a95