### PR TITLE
feat: add save file management to settings

### DIFF
--- a/Assets/Scripts/UI/SaveSlotReferences.cs
+++ b/Assets/Scripts/UI/SaveSlotReferences.cs
@@ -1,0 +1,25 @@
+using System;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TimelessEchoes.UI
+{
+    [Serializable]
+    public class SaveSlotReferences
+    {
+        public int slot;
+        public Button saveDeleteButton;
+        public TMP_Text saveDeleteText;
+        public Button loadButton;
+        public Button toggleDeleteButton;
+        public TMP_Text fileNameText;
+        public TMP_Text playtimeText;
+        public TMP_Text lastPlayedText;
+
+        [HideInInspector] public Image toggleDeleteImage;
+        [HideInInspector] public bool deleteMode;
+        [HideInInspector] public DateTime? lastPlayed;
+    }
+}
+


### PR DESCRIPTION
## Summary
- create `SaveSlotReferences` to hold UI references for save slots
- add Save Files tab in settings panel with Save/Delete/Load controls
- display playtime and last save/played times per slot with toggle-able delete mode

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e91cb1438832e8b3677f59f176d02