### PR TITLE
Refactor settings save slots to standalone components

### DIFF
--- a/Assets/Scripts/UI/SaveSlotReferences.cs
+++ b/Assets/Scripts/UI/SaveSlotReferences.cs
@@ -5,8 +5,7 @@ using UnityEngine.UI;
 
 namespace TimelessEchoes.UI
 {
-    [Serializable]
-    public class SaveSlotReferences
+    public class SaveSlotReferences : MonoBehaviour
     {
         public int slot;
         public Button saveDeleteButton;

--- a/Assets/Scripts/UI/SettingsPanelUI.cs
+++ b/Assets/Scripts/UI/SettingsPanelUI.cs
@@ -69,6 +69,12 @@ namespace TimelessEchoes.UI
         private Image dropTextImage;
 
         [TabGroup("Settings", "Save Files")] [SerializeField]
+        private SaveSlotReferences saveSlot1;
+        [TabGroup("Settings", "Save Files")] [SerializeField]
+        private SaveSlotReferences saveSlot2;
+        [TabGroup("Settings", "Save Files")] [SerializeField]
+        private SaveSlotReferences saveSlot3;
+
         private SaveSlotReferences[] saveSlots;
 
         private const int Fps60 = 60;
@@ -76,6 +82,8 @@ namespace TimelessEchoes.UI
 
         private void Awake()
         {
+            saveSlots = new[] { saveSlot1, saveSlot2, saveSlot3 };
+
             if (fullscreenWindowButton != null)
                 fullscreenWindowButton.onClick.AddListener(SetFullscreenWindow);
             if (windowButton != null)


### PR DESCRIPTION
## Summary
- Convert `SaveSlotReferences` to a `MonoBehaviour` so each save slot can manage its own UI references
- Update `SettingsPanelUI` to reference three save slot components and assemble them at runtime

## Testing
- `dotnet build` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_688e94cb26a4832e92a7b5cc134669da