### PR TITLE
Fix save slot UI interactions and loading

### DIFF
--- a/Assets/Scripts/UI/SaveSlotReferences.cs
+++ b/Assets/Scripts/UI/SaveSlotReferences.cs
@@ -5,18 +5,36 @@ using UnityEngine.UI;
 
 namespace TimelessEchoes.UI
 {
+    /// <summary>
+    ///     References to the UI elements used for each save slot.
+    ///     The "load" button can switch to a delete button when the
+    ///     safety toggle is enabled.
+    /// </summary>
     public class SaveSlotReferences : MonoBehaviour
     {
-        public Button saveDeleteButton;
-        public Button loadButton;
+        // Button used for saving. Disabled on inactive slots unless
+        // safety is enabled.
+        public Button saveButton;
+
+        // Button that loads the slot normally, or deletes it when the
+        // safety toggle is active.
+        public Button loadDeleteButton;
+
+        // Text attached to the load/delete button so its label can be
+        // updated dynamically.
         public TMP_Text loadDeleteText;
+
         public Button toggleSafetyButton;
         public TMP_Text fileNameText;
         public TMP_Text playtimeText;
         public TMP_Text lastPlayedText;
 
-        [HideInInspector] public Image toggleDeleteImage;
-        [HideInInspector] public bool deleteMode;
+        // Visual indicator for the safety toggle state.
+        [HideInInspector] public Image safetyToggleImage;
+
+        // True when the user has enabled the safety switch.
+        [HideInInspector] public bool safetyEnabled;
+
         public DateTime? lastPlayed;
     }
 }


### PR DESCRIPTION
## Summary
- Refactored save slot reference class to expose dedicated save and load/delete buttons with safety toggle support.
- Updated `SettingsPanelUI` to wire new button roles, refresh all slots on load, and guard save/delete actions behind a safety toggle.
- Improved slot loading to reset and reload game data and adjusted interactable states for inactive slots.

## Testing
- `mcs Assets/Scripts/UI/SettingsPanelUI.cs Assets/Scripts/UI/SaveSlotReferences.cs` *(fails: missing Unity and third‑party assemblies)*


------
https://chatgpt.com/codex/tasks/task_e_688e9d28bac8832e868fc912450545f6