### PR TITLE
Restrict save slot load and handle active slot deletion

### DIFF
--- a/Assets/Scripts/UI/SettingsPanelUI.cs
+++ b/Assets/Scripts/UI/SettingsPanelUI.cs
@@ -315,10 +315,19 @@ namespace TimelessEchoes.UI
             if (slot.safetyEnabled)
             {
                 DeleteSlot(index);
-                RefreshSlot(index);
+                if (index == Oracle.oracle.CurrentSlot)
+                {
+                    Oracle.oracle.WipeCloudData();
+                }
+                else
+                {
+                    RefreshSlot(index);
+                }
             }
             else
             {
+                if (index == Oracle.oracle.CurrentSlot)
+                    return;
                 Oracle.oracle.SelectSlot(index);
                 EventHandler.ResetData();
                 EventHandler.LoadData();
@@ -379,7 +388,7 @@ namespace TimelessEchoes.UI
                 slot.saveButton.interactable = isCurrent || safety;
 
             if (slot.loadDeleteButton != null)
-                slot.loadDeleteButton.interactable = true;
+                slot.loadDeleteButton.interactable = !isCurrent || safety;
         }
 
         private void RefreshAllSlots()


### PR DESCRIPTION
## Summary
- Disable load button for active save slots unless deletion is enabled
- Reload scene with wipe when deleting the currently active save

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ea68b5320832e9f225cbd0962396e