### PR TITLE
Ensure save slots download before UI refresh

### DIFF
--- a/Assets/Scripts/UI/SettingsPanelUI.cs
+++ b/Assets/Scripts/UI/SettingsPanelUI.cs
@@ -132,6 +132,15 @@ namespace TimelessEchoes.UI
                     }
                 }
 
+                var oracle = Oracle.oracle;
+                var prefix = oracle.beta ? $"Beta{oracle.betaSaveIteration}" : "";
+                for (var i = 0; i < saveSlots.Length; i++)
+                {
+                    var file = $"{prefix}Sd{i}.es3";
+                    SteamCloudManager.DownloadFile(file);
+                    ES3.StoreCachedFile(file);
+                }
+
                 RefreshAllSlots();
             }
 


### PR DESCRIPTION
## Summary
- Download each save slot file from Steam Cloud on awake
- Refresh save slots after ensuring local file copies exist

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688eaa4359c0832e822c0dce5dc2d00c