### PR TITLE
Ensure current slot saved before switching

### DIFF
--- a/Assets/Scripts/UI/SettingsPanelUI.cs
+++ b/Assets/Scripts/UI/SettingsPanelUI.cs
@@ -328,6 +328,7 @@ namespace TimelessEchoes.UI
             {
                 if (index == Oracle.oracle.CurrentSlot)
                     return;
+                SaveSlot(Oracle.oracle.CurrentSlot);
                 Oracle.oracle.SelectSlot(index);
                 EventHandler.ResetData();
                 EventHandler.LoadData();


### PR DESCRIPTION
## Summary
- save the active slot before loading a different slot in SettingsPanelUI

## Testing
- `mcs Assets/Scripts/UI/SettingsPanelUI.cs` *(fails: Blindsided namespace not found)*

------
https://chatgpt.com/codex/tasks/task_e_688eaa62fa18832e850fe23cbdeebb6e