### PR TITLE
feat: add completion percentage tracking

### DIFF
--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -46,6 +46,7 @@ namespace Blindsided.SaveData
         [HideReferenceObjectPicker] public Dictionary<string, MapStatistics> MapStats = new();
 
         [HideReferenceObjectPicker] public GeneralStats General = new();
+        public float CompletionPercentage;
 
 
         [HideReferenceObjectPicker]

--- a/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
+++ b/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
@@ -208,5 +208,30 @@ namespace Blindsided.SaveData
         public static Dictionary<string, bool> Foldouts => oracle.saveData.SavedPreferences.Foldouts;
         public static event Action ShowLevelTextChanged;
         public static event Action AutoBuffChanged;
+
+        public static void UpdateCompletionPercentage()
+        {
+            if (oracle == null) return;
+
+            var completedQuests = 0;
+            if (oracle.saveData.Quests != null)
+                foreach (var q in oracle.saveData.Quests.Values)
+                    if (q.Completed)
+                        completedQuests++;
+
+            var unlockedResources = 0;
+            if (oracle.saveData.Resources != null)
+                foreach (var r in oracle.saveData.Resources.Values)
+                    if (r.Earned)
+                        unlockedResources++;
+
+            var totalQuests = UnityEngine.Resources.LoadAll<TimelessEchoes.Quests.QuestData>("Quests").Length;
+            var totalResources = UnityEngine.Resources.LoadAll<TimelessEchoes.Upgrades.Resource>("").Length;
+
+            var total = totalQuests + totalResources;
+            var completed = completedQuests + unlockedResources;
+
+            oracle.saveData.CompletionPercentage = total > 0 ? completed / (float)total * 100f : 0f;
+        }
     }
 }

--- a/Assets/Scripts/Quests/QuestManager.cs
+++ b/Assets/Scripts/Quests/QuestManager.cs
@@ -103,6 +103,7 @@ namespace TimelessEchoes.Quests
             active.Clear();
             StartAvailableQuests();
             RefreshNoticeboard();
+            UpdateCompletionPercentage();
         }
 
         private void OnKill(EnemyData stats)
@@ -294,6 +295,7 @@ namespace TimelessEchoes.Quests
             RefreshNoticeboard();
             Log($"Quest {id} completed", TELogCategory.Quest, this);
             QuestHandin(id);
+            UpdateCompletionPercentage();
             if (oracle.saveData.PinnedQuests.Remove(id))
                 PinnedQuestUIManager.Instance?.RefreshPins();
             else

--- a/Assets/Scripts/Upgrades/ResourceManager.cs
+++ b/Assets/Scripts/Upgrades/ResourceManager.cs
@@ -7,6 +7,7 @@ using UnityEngine;
 using static Blindsided.EventHandler;
 using static Blindsided.Oracle;
 using static TimelessEchoes.TELogger;
+using static Blindsided.SaveData.StaticReferences;
 
 namespace TimelessEchoes.Upgrades
 {
@@ -81,7 +82,7 @@ namespace TimelessEchoes.Upgrades
         public void Add(Resource resource, double amount, bool bonus = false)
         {
             if (resource == null || amount <= 0) return;
-            unlocked.Add(resource);
+            var newlyUnlocked = unlocked.Add(resource);
             if (amounts.ContainsKey(resource))
                 amounts[resource] += amount;
             else
@@ -94,6 +95,8 @@ namespace TimelessEchoes.Upgrades
                 tracker.AddResources(amount, bonus);
             OnResourceAdded?.Invoke(resource, amount, bonus);
             InvokeInventoryChanged();
+            if (newlyUnlocked)
+                UpdateCompletionPercentage();
         }
 
         public bool Spend(Resource resource, double amount)
@@ -177,6 +180,7 @@ namespace TimelessEchoes.Upgrades
                 }
 
             InvokeInventoryChanged();
+            UpdateCompletionPercentage();
         }
 
         private static void EnsureLookup()


### PR DESCRIPTION
## Summary
- add completion percentage field to save data
- compute completion from quests and resource unlocks
- refresh completion when turning in quests or unlocking resources

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_688eac0f7570832e9ff4e4a5b95c62bb