### PR TITLE
Handle missing save cache in settings panel

### DIFF
--- a/Assets/Scripts/UI/SettingsPanelUI.cs
+++ b/Assets/Scripts/UI/SettingsPanelUI.cs
@@ -137,8 +137,8 @@ namespace TimelessEchoes.UI
                 for (var i = 0; i < saveSlots.Length; i++)
                 {
                     var file = $"{prefix}Sd{i}.es3";
-                    SteamCloudManager.DownloadFile(file);
-                    ES3.StoreCachedFile(file);
+                    if (SteamCloudManager.DownloadFile(file) || ES3.FileExists(file))
+                        ES3.CacheFile(file);
                 }
 
                 RefreshAllSlots();


### PR DESCRIPTION
## Summary
- Avoid FileNotFoundException when initializing save slots by caching downloaded files only if download succeeds
- Also cache existing local save files when no cloud copy is present

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_688eac634650832e88d1e22dec18acc1