### PR TITLE
Fix save slot completion label and tracking

### DIFF
--- a/Assets/Scripts/UI/SaveSlotReferences.cs
+++ b/Assets/Scripts/UI/SaveSlotReferences.cs
@@ -36,5 +36,8 @@ namespace TimelessEchoes.UI
         [HideInInspector] public bool safetyEnabled;
 
         public DateTime? lastPlayed;
+
+        // Completion percentage for the slot.
+        public float completionPercentage;
     }
 }

--- a/Assets/Scripts/UI/SettingsPanelUI.cs
+++ b/Assets/Scripts/UI/SettingsPanelUI.cs
@@ -462,9 +462,11 @@ namespace TimelessEchoes.UI
                 slot.lastPlayed = null;
             }
 
-            var display = $"File {index + 1} | {completion:0}%";
+            slot.completionPercentage = completion;
+
+            var display = $"File {index + 1} | {slot.completionPercentage:0}%";
             if (index == oracle.CurrentSlot)
-                display += " | Active";
+                display += " - Active";
             if (slot.fileNameText != null)
                 slot.fileNameText.text = display;
 
@@ -486,6 +488,11 @@ namespace TimelessEchoes.UI
 
             if (index == Oracle.oracle.CurrentSlot)
             {
+                slot.completionPercentage = Oracle.oracle.saveData.CompletionPercentage;
+                if (slot.fileNameText != null)
+                    slot.fileNameText.text =
+                        $"File {index + 1} | {slot.completionPercentage:0}% - Active";
+
                 var playtime = Oracle.oracle.saveData.PlayTime;
                 if (slot.playtimeText != null)
                     slot.playtimeText.text = playtime > 0
@@ -505,6 +512,10 @@ namespace TimelessEchoes.UI
             }
             else
             {
+                if (slot.fileNameText != null)
+                    slot.fileNameText.text =
+                        $"File {index + 1} | {slot.completionPercentage:0}%";
+
                 if (slot.lastPlayed.HasValue)
                 {
                     var date = slot.lastPlayed.Value.ToLocalTime().ToString("g");


### PR DESCRIPTION
## Summary
- track completion percentage on each save slot
- use hyphen in active save slot label and update text dynamically

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_688eb7f245e0832ea2a099f406a63c7e