### PR TITLE
Gate save slot deletion by town state

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -355,6 +355,7 @@ namespace TimelessEchoes
             BuffManager.Instance?.ClearActiveBuffs();
             BuffManager.Instance?.UpdateDistance(0f);
             StartCoroutine(StartRunRoutine());
+            SettingsPanelUI.RefreshAllSlots();
         }
 
         private IEnumerator StartRunRoutine()
@@ -612,6 +613,7 @@ namespace TimelessEchoes
             RichPresenceManager.Instance?.SetInTown();
 #endif
             Log("Returned to tavern", TELogCategory.Run, this);
+            SettingsPanelUI.RefreshAllSlots();
         }
 
         private void CleanupMap()

--- a/Assets/Scripts/UI/SettingsPanelUI.cs
+++ b/Assets/Scripts/UI/SettingsPanelUI.cs
@@ -141,11 +141,11 @@ namespace TimelessEchoes.UI
                         ES3.CacheFile(file);
                 }
 
-                RefreshAllSlots();
+                RefreshAllSlotsInstance();
             }
 
             EventHandler.OnLoadData += ApplyFps;
-            EventHandler.OnLoadData += RefreshAllSlots;
+            EventHandler.OnLoadData += RefreshAllSlotsInstance;
             ApplyFps();
             StartCoroutine(DeferredInit());
         }
@@ -184,7 +184,7 @@ namespace TimelessEchoes.UI
                 }
 
             EventHandler.OnLoadData -= ApplyFps;
-            EventHandler.OnLoadData -= RefreshAllSlots;
+            EventHandler.OnLoadData -= RefreshAllSlotsInstance;
         }
 
         private static void SetFullscreenWindow()
@@ -341,7 +341,7 @@ namespace TimelessEchoes.UI
                 Oracle.oracle.SelectSlot(index);
                 EventHandler.ResetData();
                 EventHandler.LoadData();
-                RefreshAllSlots();
+                RefreshAllSlotsInstance();
             }
         }
 
@@ -400,11 +400,17 @@ namespace TimelessEchoes.UI
             if (slot.loadDeleteButton != null)
             {
                 var inTown = GameManager.Instance == null || GameManager.Instance.CurrentMap == null;
-                slot.loadDeleteButton.interactable = safety || (inTown && !isCurrent);
+                slot.loadDeleteButton.interactable = inTown && (!isCurrent || safety);
             }
         }
 
-        private void RefreshAllSlots()
+        public static void RefreshAllSlots()
+        {
+            var instance = Object.FindFirstObjectByType<SettingsPanelUI>();
+            instance?.RefreshAllSlotsInstance();
+        }
+
+        private void RefreshAllSlotsInstance()
         {
             if (saveSlots == null)
                 return;


### PR DESCRIPTION
## Summary
- Restrict save-slot delete/load button to only function when in town and not on the active slot unless safety is enabled.
- Expose `SettingsPanelUI.RefreshAllSlots` and invoke it on run start and return to town so slot interactivity updates with game state.

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_688ebd5341a0832e9c084af85fc6c91a