### PR TITLE
Preload save slots to update completion data

### DIFF
--- a/Assets/Scripts/UI/SettingsPanelUI.cs
+++ b/Assets/Scripts/UI/SettingsPanelUI.cs
@@ -132,16 +132,10 @@ namespace TimelessEchoes.UI
                     }
                 }
 
-                var oracle = Oracle.oracle;
-                var prefix = oracle.beta ? $"Beta{oracle.betaSaveIteration}" : "";
                 for (var i = 0; i < saveSlots.Length; i++)
                 {
-                    var file = $"{prefix}Sd{i}.es3";
-                    if (SteamCloudManager.DownloadFile(file) || ES3.FileExists(file))
-                        ES3.CacheFile(file);
+                    StartCoroutine(LoadSlotAsync(i));
                 }
-
-                RefreshAllSlots();
             }
 
             EventHandler.OnLoadData += ApplyFps;
@@ -228,6 +222,39 @@ namespace TimelessEchoes.UI
                 return;
             for (var i = 0; i < saveSlots.Length; i++)
                 UpdateSlotDynamic(i);
+        }
+
+        private IEnumerator LoadSlotAsync(int index)
+        {
+            if (saveSlots == null || index >= saveSlots.Length)
+                yield break;
+
+            var slot = saveSlots[index];
+            if (slot == null)
+                yield break;
+
+            var oracle = Oracle.oracle;
+            var prefix = oracle.beta ? $"Beta{oracle.betaSaveIteration}" : "";
+            var fileName = $"{prefix}Sd{index}.es3";
+
+            if (index != oracle.CurrentSlot)
+            {
+                if (slot.fileNameText != null)
+                    slot.fileNameText.text = $"File {index + 1} | Loading...";
+
+                if (!SteamCloudManager.DownloadFile(fileName) && !ES3.FileExists(fileName))
+                {
+                    RefreshSlot(index);
+                    yield break;
+                }
+
+                while (!ES3.FileExists(fileName))
+                    yield return null;
+
+                ES3.CacheFile(fileName);
+            }
+
+            RefreshSlot(index);
         }
 
         private IEnumerator DeferredInit()


### PR DESCRIPTION
## Summary
- Load each save slot asynchronously when the settings panel opens
- Refresh the UI for a slot once its save file is cached to show playtime and completion

## Testing
- `npm test` *(fails: Could not read package.json)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ebc18204c832ebd287d7f47d0e48f