### PR TITLE
Download cloud saves only when newer

### DIFF
--- a/Assets/Scripts/UI/SettingsPanelUI.cs
+++ b/Assets/Scripts/UI/SettingsPanelUI.cs
@@ -1,6 +1,10 @@
+#if !(UNITY_STANDALONE_WIN || UNITY_STANDALONE_LINUX || UNITY_STANDALONE_OSX || STEAMWORKS_WIN || STEAMWORKS_LIN_OSX)
+#define DISABLESTEAMWORKS
+#endif
 using System;
 using System.Collections;
 using System.Globalization;
+using System.IO;
 using Blindsided;
 using Blindsided.SaveData;
 using Blindsided.Utilities;
@@ -8,6 +12,9 @@ using Sirenix.OdinInspector;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
+#if !DISABLESTEAMWORKS
+using Steamworks;
+#endif
 using EventHandler = Blindsided.EventHandler;
 
 namespace TimelessEchoes.UI
@@ -150,7 +157,23 @@ namespace TimelessEchoes.UI
                 for (var i = 0; i < saveSlots.Length; i++)
                 {
                     var file = $"{prefix}Sd{i}.es3";
-                    if (SteamCloudManager.DownloadFile(file) || ES3.FileExists(file))
+                    var downloaded = false;
+                    var localExists = ES3.FileExists(file);
+#if !DISABLESTEAMWORKS
+                    var path = Path.Combine(Application.persistentDataPath, file);
+                    if (!localExists)
+                    {
+                        downloaded = SteamCloudManager.DownloadFile(file);
+                    }
+                    else if (SteamManager.Initialized && SteamRemoteStorage.FileExists(file))
+                    {
+                        var cloudTimestamp = SteamRemoteStorage.GetFileTimestamp(file);
+                        var localTimestamp = new DateTimeOffset(File.GetLastWriteTimeUtc(path)).ToUnixTimeSeconds();
+                        if (cloudTimestamp > localTimestamp)
+                            downloaded = SteamCloudManager.DownloadFile(file);
+                    }
+#endif
+                    if (downloaded || localExists)
                         ES3.CacheFile(file);
                 }
 


### PR DESCRIPTION
## Summary
- Guard SettingsPanelUI with Steamworks directives for conditional cloud sync use
- Only download save files from Steam Cloud when missing locally or when the cloud timestamp is newer, caching accordingly

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ed1ae05b0832ebcfd2fec8fee215b