### PR TITLE
Ensure ES3 DeleteSlot removes disk file explicitly

### DIFF
--- a/Assets/Scripts/UI/SettingsPanelUI.cs
+++ b/Assets/Scripts/UI/SettingsPanelUI.cs
@@ -395,7 +395,7 @@ namespace TimelessEchoes.UI
                 var prefix = oracle.beta ? $"Beta{oracle.betaSaveIteration}" : "";
                 var fileName = $"{prefix}Sd{index}.es3";
                 ES3.DeleteFile(fileName, new ES3Settings(ES3.Location.Cache));
-                ES3.DeleteFile(fileName);
+                ES3.DeleteFile(fileName, new ES3Settings(ES3.Location.File));
 
                 PlayerPrefs.DeleteKey(SlotKey(index, "Completion"));
                 PlayerPrefs.DeleteKey(SlotKey(index, "Playtime"));


### PR DESCRIPTION
## Summary
- specify ES3 file location when deleting save slots to remove on-disk files

## Testing
- `mono /tmp/DeleteSlotTest.exe`

------
https://chatgpt.com/codex/tasks/task_e_688edf1a56d8832ebda989969ecaed8d