### PR TITLE
Use StopFishing trigger when interrupted

### DIFF
--- a/Assets/Scripts/Tasks/ContinuousTask.cs
+++ b/Assets/Scripts/Tasks/ContinuousTask.cs
@@ -24,6 +24,7 @@ namespace TimelessEchoes.Tasks
 
         protected abstract string AnimationName { get; }
         protected abstract string InterruptTriggerName { get; }
+        protected virtual string CompletionTriggerName => InterruptTriggerName;
 
         public override bool BlocksMovement => true;
 
@@ -48,7 +49,7 @@ namespace TimelessEchoes.Tasks
         {
             if (ShouldInstantComplete())
             {
-                AnimatorUtils.SetTriggerAndReset(hero, hero.Animator, InterruptTriggerName);
+                AnimatorUtils.SetTriggerAndReset(hero, hero.Animator, CompletionTriggerName);
                 isComplete = true;
                 HideProgressBar();
                 GenerateDrops();
@@ -81,7 +82,7 @@ namespace TimelessEchoes.Tasks
 
             if (timer >= TaskDuration)
             {
-                AnimatorUtils.SetTriggerAndReset(hero, hero.Animator, InterruptTriggerName);
+                AnimatorUtils.SetTriggerAndReset(hero, hero.Animator, CompletionTriggerName);
                 isComplete = true;
                 HideProgressBar();
                 GenerateDrops();

--- a/Assets/Scripts/Tasks/FishingTask.cs
+++ b/Assets/Scripts/Tasks/FishingTask.cs
@@ -8,4 +8,7 @@ namespace TimelessEchoes.Tasks
         public override Transform Target => fishingPoint != null ? fishingPoint : transform;
 
         protected override string AnimationName => "Fishing";
-        protected override string InterruptTriggerName => "CatchFish";    }}
+        protected override string InterruptTriggerName => "StopFishing";
+        protected override string CompletionTriggerName => "CatchFish";
+    }
+}

--- a/Assets/Scripts/Tests/Editor/FishingTaskTests.cs
+++ b/Assets/Scripts/Tests/Editor/FishingTaskTests.cs
@@ -44,7 +44,7 @@ namespace TimelessEchoes.Tests
         }
 
         [Test]
-        public void AnimationAndInterruptNamesAreCorrect()
+        public void AnimationAndTriggerNamesAreCorrect()
         {
             var animationName =
                 (string)typeof(FishingTask).GetProperty("AnimationName", BindingFlags.NonPublic | BindingFlags.Instance)
@@ -52,9 +52,13 @@ namespace TimelessEchoes.Tests
             var interruptName =
                 (string)typeof(FishingTask).GetProperty("InterruptTriggerName", BindingFlags.NonPublic | BindingFlags.Instance)
                     .GetValue(task);
+            var completionName =
+                (string)typeof(FishingTask).GetProperty("CompletionTriggerName", BindingFlags.NonPublic | BindingFlags.Instance)
+                    .GetValue(task);
 
             Assert.AreEqual("Fishing", animationName);
-            Assert.AreEqual("CatchFish", interruptName);
+            Assert.AreEqual("StopFishing", interruptName);
+            Assert.AreEqual("CatchFish", completionName);
         }
 
         [Test]


### PR DESCRIPTION
## Summary
- allow separate completion and interruption triggers for continuous tasks
- make fishing tasks use StopFishing on interrupt and CatchFish on completion
- update fishing task unit tests for new trigger handling

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68903edd0dd8832eb2de91ab6b99ca82