### PR TITLE
Limit pinned quests to five

### DIFF
--- a/Assets/Scripts/Quests/PinnedQuestUIManager.cs
+++ b/Assets/Scripts/Quests/PinnedQuestUIManager.cs
@@ -20,6 +20,7 @@ namespace TimelessEchoes.Quests
     public class PinnedQuestUIManager : MonoBehaviour
     {
         public static PinnedQuestUIManager Instance { get; private set; }
+        public const int MaxPins = 5;
 
         [SerializeField] private QuestPinUI entryPrefab;
         [SerializeField] private Transform entryParent;
@@ -75,8 +76,11 @@ namespace TimelessEchoes.Quests
                 Destroy(child.gameObject);
             entries.Clear();
 
+            var count = 0;
             foreach (var id in oracle.saveData.PinnedQuests)
             {
+                if (count >= MaxPins)
+                    break;
                 if (string.IsNullOrEmpty(id))
                     continue;
                 var qm = QuestManager.Instance ?? FindFirstObjectByType<QuestManager>();
@@ -94,6 +98,7 @@ namespace TimelessEchoes.Quests
                     continue;
                 var ui = Instantiate(entryPrefab, entryParent);
                 entries[id] = ui;
+                count++;
             }
 
             if (rootObject != null)

--- a/Assets/Scripts/Quests/QuestManager.cs
+++ b/Assets/Scripts/Quests/QuestManager.cs
@@ -364,7 +364,7 @@ namespace TimelessEchoes.Quests
             var set = oracle.saveData.PinnedQuests;
             if (set.Contains(questId))
                 set.Remove(questId);
-            else
+            else if (set.Count < PinnedQuestUIManager.MaxPins)
                 set.Add(questId);
             PinnedQuestUIManager.Instance?.RefreshPins();
         }

--- a/Assets/Scripts/Tests/Editor/QuestManagerTests.cs
+++ b/Assets/Scripts/Tests/Editor/QuestManagerTests.cs
@@ -112,6 +112,29 @@ namespace TimelessEchoes.Tests
 
             Assert.IsTrue((bool)readyField.GetValue(inst));
         }
+
+        [Test]
+        public void TogglePinned_RespectsMaxPins()
+        {
+            var list = new List<QuestData>();
+            for (var i = 0; i < 6; i++)
+            {
+                var q = ScriptableObject.CreateInstance<QuestData>();
+                q.questId = $"Q{i}";
+                list.Add(q);
+            }
+
+            typeof(QuestManager).GetField("quests", BindingFlags.NonPublic | BindingFlags.Instance)
+                .SetValue(manager, list);
+
+            foreach (var q in list)
+                manager.TogglePinned(q.questId);
+
+            Assert.AreEqual(PinnedQuestUIManager.MaxPins, oracle.saveData.PinnedQuests.Count);
+
+            foreach (var q in list)
+                Object.DestroyImmediate(q);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- constrain quest pin UI to show no more than five entries
- block adding additional pinned quests beyond five
- add test ensuring pin limit respected

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68903f7b1b9c832e8072abb3a50a63f4