### PR TITLE
Disable automatic quest pinning by default

### DIFF
--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -81,7 +81,7 @@ namespace Blindsided.SaveData
             /// <summary>
             ///     Automatically pin new quests when they become active.
             /// </summary>
-            public bool AutoPinActiveQuests = true;
+            public bool AutoPinActiveQuests = false;
             /// <summary>
             ///     Whether the pinned quest panel is visible.
             /// </summary>

--- a/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
+++ b/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
@@ -17,6 +17,7 @@ namespace Blindsided.SaveData
         private const string PlayerFloatingDamageKey = "PlayerFloatingDamage";
         private const string EnemyFloatingDamageKey = "EnemyFloatingDamage";
         private const string ItemDropFloatingTextKey = "ItemDropFloatingText";
+        private const string AutoPinActiveQuestsKey = "AutoPinActiveQuests";
         public static Dictionary<string, int> UpgradeLevels => oracle.saveData.UpgradeLevels;
         public static Dictionary<string, ResourceEntry> Resources => oracle.saveData.Resources;
         public static Dictionary<string, double> EnemyKills => oracle.saveData.EnemyKills;
@@ -181,8 +182,19 @@ namespace Blindsided.SaveData
 
         public static bool AutoPinActiveQuests
         {
-            get => oracle.saveData.SavedPreferences.AutoPinActiveQuests;
-            set => oracle.saveData.SavedPreferences.AutoPinActiveQuests = value;
+            get
+            {
+                var defaultVal = oracle.saveData.SavedPreferences.AutoPinActiveQuests ? 1 : 0;
+                var value = PlayerPrefs.GetInt(AutoPinActiveQuestsKey, defaultVal) == 1;
+                oracle.saveData.SavedPreferences.AutoPinActiveQuests = value;
+                return value;
+            }
+            set
+            {
+                PlayerPrefs.SetInt(AutoPinActiveQuestsKey, value ? 1 : 0);
+                PlayerPrefs.Save();
+                oracle.saveData.SavedPreferences.AutoPinActiveQuests = value;
+            }
         }
 
         public static bool ShowPinnedQuests


### PR DESCRIPTION
## Summary
- Default auto pinning of quests to disabled in saved preferences
- Persist auto pin preference via PlayerPrefs so player choice is remembered

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689041674500832eb517d182b062fff0