### PR TITLE
Avoid health bar reset when spawning echoes

### DIFF
--- a/Assets/Scripts/Hero/EchoManager.cs
+++ b/Assets/Scripts/Hero/EchoManager.cs
@@ -40,6 +40,10 @@ namespace TimelessEchoes.Hero
                 if (hp != null)
                     hp.Immortal = false; // ensure damage can be forwarded
 
+                // Refresh the main hero's health bar since the shared
+                // HeroHealth component on the echo skips UI updates.
+                HeroHealth.Instance?.TakeDamage(0f);
+
                 var combat = type == EchoType.Combat || type == EchoType.All;
                 var disableSkills = type == EchoType.Combat;
 

--- a/Assets/Scripts/Hero/HeroHealth.cs
+++ b/Assets/Scripts/Hero/HeroHealth.cs
@@ -20,8 +20,14 @@ namespace TimelessEchoes.Hero
             {
                 if (Instance != null && Instance != this) Destroy(Instance.gameObject);
                 Instance = this;
+                base.Awake();
             }
-            base.Awake();
+            else
+            {
+                healthBar = null;
+                if (Instance != null)
+                    CurrentHealth = Instance.CurrentHealth;
+            }
         }
 
         private void OnDestroy()


### PR DESCRIPTION
## Summary
- Skip `HeroHealth` base initialization for echo clones to avoid updating shared UI
- Sync echo health from main hero and refresh main hero's health bar after echo spawn

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689046467e18832e9548b51030c19bf0