### PR TITLE
Disable Steam locale selector and force English

### DIFF
--- a/Assets/Scripts/ForceEnglishLocale.cs
+++ b/Assets/Scripts/ForceEnglishLocale.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+using UnityEngine.Localization;
+using UnityEngine.Localization.Settings;
+
+/// <summary>
+///     Forces the game to use the English locale on startup.
+/// </summary>
+public static class ForceEnglishLocale
+{
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+    private static void SetEnglishLocale()
+    {
+        var locale = LocalizationSettings.AvailableLocales.GetLocale(new LocaleIdentifier("en"));
+        if (locale != null)
+        {
+            LocalizationSettings.SelectedLocale = locale;
+        }
+    }
+}

--- a/Assets/Scripts/Steamworks.NET/SteamLanguageLocaleSelector.cs
+++ b/Assets/Scripts/Steamworks.NET/SteamLanguageLocaleSelector.cs
@@ -89,11 +89,12 @@ public class SteamLanguageLocaleSelector : IStartupLocaleSelector
 /// </summary>
 public static class SteamLanguageLocaleSelectorInstaller
 {
-    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
-    private static void RegisterSelector()
-    {
-        var selectors = LocalizationSettings.StartupLocaleSelectors;
-        // Insert at the start so it runs before default selectors.
-        selectors.Insert(0, new SteamLanguageLocaleSelector());
-    }
+    // Temporarily disabled. Previously registered the selector at startup.
+    // [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+    // private static void RegisterSelector()
+    // {
+    //     var selectors = LocalizationSettings.StartupLocaleSelectors;
+    //     // Insert at the start so it runs before default selectors.
+    //     selectors.Insert(0, new SteamLanguageLocaleSelector());
+    // }
 }


### PR DESCRIPTION
## Summary
- disable SteamLanguageLocaleSelector installer
- add startup script forcing English locale

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: package has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_689048cdaef4832eaa936b78f33ce822