### PR TITLE
Initialize resource entry before use in console command

### DIFF
--- a/Assets/Scripts/Tools/ConsoleCommands.cs
+++ b/Assets/Scripts/Tools/ConsoleCommands.cs
@@ -45,7 +45,8 @@ namespace TimelessEchoes
             foreach (var res in Resources.LoadAll<Resource>(string.Empty))
             {
                 if (res == null) continue;
-                existing?.TryGetValue(res.name, out var oldEntry);
+                GameData.ResourceEntry oldEntry = null;
+                existing?.TryGetValue(res.name, out oldEntry);
                 dict[res.name] = new GameData.ResourceEntry
                 {
                     Earned = true,


### PR DESCRIPTION
## Summary
- Prevent uninitialized local variable error in SetAllResources by pre-initializing old resource entries

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68906a4a7fe8832e9a61434bf0e190c2