### PR TITLE
Refactor disciple generation to resource-based system

### DIFF
--- a/Assets/Scripts/Blindsided/Oracle.cs
+++ b/Assets/Scripts/Blindsided/Oracle.cs
@@ -272,6 +272,8 @@ namespace Blindsided
                 saveData.UnlockedAutoBuffSlots = 0;
             else if (saveData.UnlockedAutoBuffSlots > 5)
                 saveData.UnlockedAutoBuffSlots = 5;
+            if (saveData.DisciplePercent <= 0f)
+                saveData.DisciplePercent = 0.1f;
             saveData.Quests ??= new Dictionary<string, GameData.QuestRecord>();
         }
 

--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -47,6 +47,7 @@ namespace Blindsided.SaveData
 
         [HideReferenceObjectPicker] public GeneralStats General = new();
         public float CompletionPercentage;
+        public float DisciplePercent = 0.1f;
 
 
         [HideReferenceObjectPicker]

--- a/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
+++ b/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
@@ -28,6 +28,12 @@ namespace Blindsided.SaveData
         /// </summary>
         public static HashSet<string> ActiveNpcMeetings { get; } = new();
 
+        public static float DisciplePercent
+        {
+            get => oracle.saveData.DisciplePercent;
+            set => oracle.saveData.DisciplePercent = value;
+        }
+
 
         public static BuyMode PurchaseMode
         {

--- a/Assets/Scripts/NpcGeneration/DiscipleCropGrowth.cs
+++ b/Assets/Scripts/NpcGeneration/DiscipleCropGrowth.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using TimelessEchoes.Upgrades;
 
 namespace TimelessEchoes.NpcGeneration
 {
@@ -7,7 +8,7 @@ namespace TimelessEchoes.NpcGeneration
     /// </summary>
     public class DiscipleCropGrowth : MonoBehaviour
     {
-        [SerializeField] private Disciple disciple;
+        [SerializeField] private Resource resource;
         [SerializeField] private DiscipleGenerator generator;
         [SerializeField] private SpriteRenderer spriteRenderer;
         [SerializeField] private Sprite[] growthStages = new Sprite[4];
@@ -24,6 +25,9 @@ namespace TimelessEchoes.NpcGeneration
         {
             if (generator == null)
                 FindGenerator();
+            var manager = DiscipleGenerationManager.Instance;
+            if (manager != null)
+                manager.OnGeneratorsRebuilt += OnGeneratorsRebuilt;
         }
 
         private void Update()
@@ -51,7 +55,7 @@ namespace TimelessEchoes.NpcGeneration
 
         private void FindGenerator()
         {
-            if (disciple == null)
+            if (resource == null)
                 return;
 
             var manager = DiscipleGenerationManager.Instance;
@@ -60,12 +64,24 @@ namespace TimelessEchoes.NpcGeneration
 
             foreach (var gen in manager.Generators)
             {
-                if (gen != null && gen.DiscipleName == disciple.name)
+                if (gen != null && gen.Resource == resource)
                 {
                     generator = gen;
                     break;
                 }
             }
+        }
+
+        private void OnDestroy()
+        {
+            var manager = DiscipleGenerationManager.Instance;
+            if (manager != null)
+                manager.OnGeneratorsRebuilt -= OnGeneratorsRebuilt;
+        }
+
+        private void OnGeneratorsRebuilt()
+        {
+            FindGenerator();
         }
     }
 }

--- a/Assets/Scripts/NpcGeneration/DiscipleGenerationManager.cs
+++ b/Assets/Scripts/NpcGeneration/DiscipleGenerationManager.cs
@@ -1,11 +1,11 @@
 using System.Collections;
 using System.Collections.Generic;
 using Blindsided.SaveData;
-using TimelessEchoes.Quests;
+using TimelessEchoes.Upgrades;
+using TimelessEchoes.Stats;
 using UnityEngine;
 using static Blindsided.EventHandler;
 using static Blindsided.Oracle;
-using static TimelessEchoes.Quests.QuestUtils;
 
 namespace TimelessEchoes.NpcGeneration
 {
@@ -17,25 +17,61 @@ namespace TimelessEchoes.NpcGeneration
     {
         public static DiscipleGenerationManager Instance { get; private set; }
         [SerializeField] private DiscipleGenerator generatorPrefab;
-        [SerializeField] private string disciplePath = "Disciples";
 
         private readonly List<DiscipleGenerator> generators = new();
 
+        private ResourceManager resourceManager;
+        private GameplayStatTracker statTracker;
+        private int lastUnlockedCount;
+
         public IReadOnlyList<DiscipleGenerator> Generators => generators;
+
+        public event System.Action OnGeneratorsRebuilt;
+
+        private static Dictionary<string, Resource> lookup;
 
         private void Awake()
         {
             Instance = this;
+            resourceManager = ResourceManager.Instance;
+            statTracker = GameplayStatTracker.Instance;
+            if (resourceManager != null)
+                resourceManager.OnInventoryChanged += OnInventoryChanged;
+            if (statTracker != null)
+                statTracker.OnRunEnded += OnRunEnded;
             OnLoadData += OnLoadDataHandler;
             OnQuestHandin += OnQuestHandinHandler;
         }
 
         private void OnDestroy()
         {
+            if (resourceManager != null)
+                resourceManager.OnInventoryChanged -= OnInventoryChanged;
+            if (statTracker != null)
+                statTracker.OnRunEnded -= OnRunEnded;
             OnLoadData -= OnLoadDataHandler;
             OnQuestHandin -= OnQuestHandinHandler;
             if (Instance == this)
                 Instance = null;
+        }
+
+        private void OnRunEnded(bool died)
+        {
+            RefreshRates();
+        }
+
+        private void OnInventoryChanged()
+        {
+            if (oracle == null) return;
+            oracle.saveData.Resources ??= new Dictionary<string, GameData.ResourceEntry>();
+            var count = 0;
+            foreach (var entry in oracle.saveData.Resources.Values)
+                if (entry.Earned) count++;
+            if (count != lastUnlockedCount)
+            {
+                lastUnlockedCount = count;
+                StartCoroutine(DeferredBuild());
+            }
         }
 
         private void OnLoadDataHandler()
@@ -54,6 +90,15 @@ namespace TimelessEchoes.NpcGeneration
             BuildGenerators();
         }
 
+        private static void EnsureLookup()
+        {
+            if (lookup != null) return;
+            lookup = new Dictionary<string, Resource>();
+            foreach (var res in Resources.LoadAll<Resource>(string.Empty))
+                if (res != null && !lookup.ContainsKey(res.name))
+                    lookup[res.name] = res;
+        }
+
         private void BuildGenerators()
         {
             foreach (var gen in generators)
@@ -61,25 +106,49 @@ namespace TimelessEchoes.NpcGeneration
                     Destroy(gen.gameObject);
             generators.Clear();
 
-            if (generatorPrefab == null)
+            if (generatorPrefab == null || oracle == null)
                 return;
 
-            var loadedDisciples = Resources.LoadAll<Disciple>(disciplePath);
-            foreach (var d in loadedDisciples)
+            EnsureLookup();
+            oracle.saveData.Resources ??= new Dictionary<string, GameData.ResourceEntry>();
+            oracle.saveData.Disciples ??= new Dictionary<string, GameData.DiscipleGenerationRecord>();
+
+            // purge legacy entries that no longer map to resources
+            var toRemove = new List<string>();
+            foreach (var key in oracle.saveData.Disciples.Keys)
+                if (!oracle.saveData.Resources.ContainsKey(key))
+                    toRemove.Add(key);
+            foreach (var k in toRemove)
+                oracle.saveData.Disciples.Remove(k);
+
+            lastUnlockedCount = 0;
+            foreach (var pair in oracle.saveData.Resources)
             {
-                if (d == null) continue;
-                if (!QuestCompleted(d.requiredQuest))
+                if (!pair.Value.Earned) continue;
+                lastUnlockedCount++;
+                if (!lookup.TryGetValue(pair.Key, out var res) || res == null)
                     continue;
 
                 var gen = Instantiate(generatorPrefab, transform);
-                gen.name = d.name;
-                gen.SetData(d);
+                gen.name = res.name;
+                var rate = pair.Value.BestPerMinute * oracle.saveData.DisciplePercent;
+                gen.Configure(res, rate);
                 generators.Add(gen);
             }
+
+            OnGeneratorsRebuilt?.Invoke();
         }
 
-
-
+        public void RefreshRates()
+        {
+            if (oracle == null) return;
+            foreach (var gen in generators)
+            {
+                if (gen == null || gen.Resource == null) continue;
+                if (oracle.saveData.Resources.TryGetValue(gen.Resource.name, out var entry))
+                    gen.UpdateRate(entry.BestPerMinute * oracle.saveData.DisciplePercent);
+            }
+        }
 
         private void Update()
         {

--- a/Assets/Scripts/NpcGeneration/DiscipleGeneratorUIManager.cs
+++ b/Assets/Scripts/NpcGeneration/DiscipleGeneratorUIManager.cs
@@ -28,6 +28,8 @@ namespace TimelessEchoes.NpcGeneration
             generationManager = DiscipleGenerationManager.Instance;
             if (collectAllButton != null)
                 collectAllButton.onClick.AddListener(CollectAll);
+            if (generationManager != null)
+                generationManager.OnGeneratorsRebuilt += OnGeneratorsRebuilt;
             BuildEntries();
         }
 
@@ -53,6 +55,8 @@ namespace TimelessEchoes.NpcGeneration
         {
             if (collectAllButton != null)
                 collectAllButton.onClick.RemoveListener(CollectAll);
+            if (generationManager != null)
+                generationManager.OnGeneratorsRebuilt -= OnGeneratorsRebuilt;
             if (Instance == this)
                 Instance = null;
             OnQuestHandin -= OnQuestHandinHandler;
@@ -98,6 +102,11 @@ namespace TimelessEchoes.NpcGeneration
             StartCoroutine(DeferredBuild());
         }
 
+        private void OnGeneratorsRebuilt()
+        {
+            StartCoroutine(DeferredBuild());
+        }
+
         private IEnumerator DeferredBuild()
         {
             yield return null;
@@ -124,14 +133,12 @@ namespace TimelessEchoes.NpcGeneration
                     if (gen == null || !gen.RequirementsMet)
                         continue;
 
-                    foreach (var entry in gen.ResourceEntries)
-                    {
-                        if (entry.resource == null) continue;
-                        var stored = gen.GetStoredAmount(entry.resource);
-                        totalAvailable += stored;
-                        if (!canCollect && stored > 0)
-                            canCollect = true;
-                    }
+                    var res = gen.Resource;
+                    if (res == null) continue;
+                    var stored = gen.GetStoredAmount(res);
+                    totalAvailable += stored;
+                    if (!canCollect && stored > 0)
+                        canCollect = true;
                 }
 
             if (collectAllButton != null)

--- a/Assets/Scripts/Quests/QuestData.cs
+++ b/Assets/Scripts/Quests/QuestData.cs
@@ -27,6 +27,7 @@ namespace TimelessEchoes.Quests
         public int unlockBuffSlots;
         public int unlockAutoBuffSlots;
         public float maxDistanceIncrease;
+        public float disciplePercentReward;
 
         [Serializable]
         public class Requirement

--- a/Assets/Scripts/Quests/QuestManager.cs
+++ b/Assets/Scripts/Quests/QuestManager.cs
@@ -285,6 +285,11 @@ namespace TimelessEchoes.Quests
                 BuffManager.Instance?.UnlockAutoSlots(inst.data.unlockAutoBuffSlots);
             if (inst.data.maxDistanceIncrease > 0f)
                 GameplayStatTracker.Instance?.IncreaseMaxRunDistance(inst.data.maxDistanceIncrease);
+            if (inst.data.disciplePercentReward > 0f)
+            {
+                oracle.saveData.DisciplePercent += inst.data.disciplePercentReward;
+                DiscipleGenerationManager.Instance?.RefreshRates();
+            }
             if (!string.IsNullOrEmpty(inst.data.npcId))
                 CompletedNpcTasks.Add(inst.data.npcId);
             if (inst.ui != null)

--- a/Assets/Scripts/Tools/ConsoleCommands.cs
+++ b/Assets/Scripts/Tools/ConsoleCommands.cs
@@ -170,6 +170,7 @@ namespace TimelessEchoes
             var oracle = Blindsided.Oracle.oracle;
             if (oracle == null) return;
             oracle.saveData.Disciples = new Dictionary<string, GameData.DiscipleGenerationRecord>();
+            oracle.saveData.DisciplePercent = 0.1f;
             Blindsided.EventHandler.LoadData();
         }
 

--- a/Assets/Scripts/Upgrades/ResourceManager.cs
+++ b/Assets/Scripts/Upgrades/ResourceManager.cs
@@ -169,6 +169,14 @@ namespace TimelessEchoes.Upgrades
             if (oracle == null) return;
             oracle.saveData.Resources ??= new Dictionary<string, GameData.ResourceEntry>();
             oracle.saveData.ResourceStats ??= new Dictionary<string, GameData.ResourceRecord>();
+            oracle.saveData.Disciples ??= new Dictionary<string, GameData.DiscipleGenerationRecord>();
+            // purge legacy disciple keys that do not map to resources
+            var toRemove = new List<string>();
+            foreach (var key in oracle.saveData.Disciples.Keys)
+                if (!oracle.saveData.Resources.ContainsKey(key))
+                    toRemove.Add(key);
+            foreach (var k in toRemove)
+                oracle.saveData.Disciples.Remove(k);
             EnsureLookup();
             amounts.Clear();
             unlocked.Clear();


### PR DESCRIPTION
## Summary
- Generate disciple resources dynamically based on earned resources and track rates with `DisciplePercent`
- Add persistent `DisciplePercent` field with quest rewards and console reset support
- Update UI and crop growth to work with single-resource generators and refresh after run completion

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689070ad0a3c832ea5f3aed79f781aa6