### PR TITLE
Remove buff resource costs

### DIFF
--- a/Assets/Resources/Buffs/Combat Echo.asset
+++ b/Assets/Resources/Buffs/Combat Echo.asset
@@ -28,8 +28,3 @@ MonoBehaviour:
   lifestealPercent: 0
   instantTasks: 0
   distancePercent: 0
-  requirements:
-  - resource: {fileID: 11400000, guid: b448067cd3b40aa478fb72e658eee42b, type: 2}
-    amount: 1
-  - resource: {fileID: 11400000, guid: f96c4a57aabf68c42a298a2de063e3a8, type: 2}
-    amount: 1

--- a/Assets/Resources/Buffs/Combat Enhancer.asset
+++ b/Assets/Resources/Buffs/Combat Enhancer.asset
@@ -27,8 +27,3 @@ MonoBehaviour:
   lifestealPercent: 0
   instantTasks: 0
   distancePercent: 0
-  requirements:
-  - resource: {fileID: 11400000, guid: b448067cd3b40aa478fb72e658eee42b, type: 2}
-    amount: 25
-  - resource: {fileID: 11400000, guid: fd9d01ece4e2c454dae0765c61a02e16, type: 2}
-    amount: 10

--- a/Assets/Resources/Buffs/Echo.asset
+++ b/Assets/Resources/Buffs/Echo.asset
@@ -27,6 +27,3 @@ MonoBehaviour:
   lifestealPercent: 0
   instantTasks: 0
   distancePercent: 0
-  requirements:
-  - resource: {fileID: 11400000, guid: b448067cd3b40aa478fb72e658eee42b, type: 2}
-    amount: 1

--- a/Assets/Resources/Buffs/Lerp.asset
+++ b/Assets/Resources/Buffs/Lerp.asset
@@ -27,8 +27,3 @@ MonoBehaviour:
   lifestealPercent: 0
   instantTasks: 1
   distancePercent: 0.7
-  requirements:
-  - resource: {fileID: 11400000, guid: 1b77cb67ea1673647af1d3a57796d18f, type: 2}
-    amount: 500
-  - resource: {fileID: 11400000, guid: 457dbb132eac48d429163353adb4b532, type: 2}
-    amount: 10

--- a/Assets/Resources/Buffs/MoveSpeed.asset
+++ b/Assets/Resources/Buffs/MoveSpeed.asset
@@ -28,6 +28,3 @@ MonoBehaviour:
   taskSpeedPercent: 100
   lifestealPercent: 0
   instantTasks: 0
-  requirements:
-  - resource: {fileID: 11400000, guid: 1b77cb67ea1673647af1d3a57796d18f, type: 2}
-    amount: 5

--- a/Assets/Resources/Buffs/Vampiric.asset
+++ b/Assets/Resources/Buffs/Vampiric.asset
@@ -27,8 +27,3 @@ MonoBehaviour:
   lifestealPercent: 15
   instantTasks: 0
   distancePercent: 0
-  requirements:
-  - resource: {fileID: 11400000, guid: 691350e69adc08a4082225a8015d2955, type: 2}
-    amount: 13
-  - resource: {fileID: 11400000, guid: 1fd4ff0f627126a4a8ca50ea71793823, type: 2}
-    amount: 3

--- a/Assets/Scripts/Buffs/BuffRecipe.cs
+++ b/Assets/Scripts/Buffs/BuffRecipe.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Collections.Generic;
 using Blindsided.Utilities;
-using TimelessEchoes.Upgrades;
 using Sirenix.OdinInspector;
 using UnityEngine;
 
@@ -64,16 +62,6 @@ namespace TimelessEchoes.Buffs
         [Tooltip("Tasks complete instantly while active.")]
         public bool instantTasks;
 
-        [TitleGroup("Requirements")]
-        public List<ResourceRequirement> requirements = new();
-
         public string Title => string.IsNullOrEmpty(title) ? name : title;
-    }
-
-    [Serializable]
-    public class ResourceRequirement
-    {
-        public Resource resource;
-        public int amount;
     }
 }


### PR DESCRIPTION
## Summary
- remove resource requirements from buff recipes and related scriptable objects
- refactor buff activation logic into new `CanActivate` without resource manager dependencies
- simplify buff UI to drop cost display and rely on `CanActivate`

## Testing
- `dotnet test` *(fails: no project or solution file)*


------
https://chatgpt.com/codex/tasks/task_e_68907eb62554832e8976ad71aadb6969