### PR TITLE
feat: configure hero spawn height

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -398,6 +398,13 @@ namespace TimelessEchoes
                     if (runCalebUI != null)
                         hp.HealthBar = runCalebUI.healthBar;
                 }
+
+                if (CurrentGenerationConfig != null)
+                {
+                    var heroPos = hero.transform.position;
+                    heroPos.y = CurrentGenerationConfig.heroStartY;
+                    hero.transform.position = heroPos;
+                }
             }
 
             EnableMildred();

--- a/Assets/Scripts/MapGeneration/MapGenerationConfig.cs
+++ b/Assets/Scripts/MapGeneration/MapGenerationConfig.cs
@@ -21,6 +21,9 @@ namespace TimelessEchoes.MapGeneration
         // Whether clouds should be shown while this map is active.
         public bool allowClouds = true;
 
+        // Starting Y position for the hero when a run begins.
+        public float heroStartY = 0f;
+
         [Serializable]
         public class TilemapChunkSettings
         {


### PR DESCRIPTION
## Summary
- allow map configs to set hero starting Y position
- GameManager uses map config to position hero before run starts

## Testing
- `dotnet test` *(fails: MSB1003: project or solution file not found)*

------
https://chatgpt.com/codex/tasks/task_e_689130791d84832e920783414671ac5a