### PR TITLE
Allow decor entries to reference prefabs

### DIFF
--- a/Assets/Scripts/MapGeneration/DecorConfig.cs
+++ b/Assets/Scripts/MapGeneration/DecorConfig.cs
@@ -30,8 +30,14 @@ namespace TimelessEchoes.MapGeneration
         [HorizontalGroup("Entry", 55)]
         [PreviewField(50, ObjectFieldAlignment.Left)]
         [HideLabel]
-        [Required]
         public TileBase tile;
+
+        // When the prefab is changed, call the UpdateName method.
+        [OnValueChanged("UpdateName")]
+        [HorizontalGroup("Entry", 55)]
+        [PreviewField(50, ObjectFieldAlignment.Left)]
+        [HideLabel]
+        public GameObject prefab;
 
         // When any value inside the config is changed, call the UpdateName method.
         [OnValueChanged("UpdateName", true)] [HorizontalGroup("Entry")] [InlineProperty] [HideLabel]
@@ -42,14 +48,17 @@ namespace TimelessEchoes.MapGeneration
         /// </summary>
         public void UpdateName()
         {
-            var tileName = tile != null ? tile.name : "No Tile";
-
-            Name = tileName;
+            if (tile != null)
+                Name = tile.name;
+            else if (prefab != null)
+                Name = prefab.name;
+            else
+                Name = "None";
         }
 
         public float GetWeight(float worldX)
         {
-            if (tile == null) return 0f;
+            if (tile == null && prefab == null) return 0f;
             if (worldX < config.minX || worldX > config.maxX) return 0f;
             return Mathf.Max(0f, config.weight);
         }


### PR DESCRIPTION
## Summary
- allow decor entries to link to either a tile or prefab
- display prefab preview and name in inspector labels
- ignore entries with neither tile nor prefab

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68913de78174832ea628ff1f48ff9de1