### PR TITLE
Maintain ordered quest pin list

### DIFF
--- a/Assets/Scripts/Blindsided/Oracle.cs
+++ b/Assets/Scripts/Blindsided/Oracle.cs
@@ -255,7 +255,7 @@ namespace Blindsided
             saveData.SkillData ??= new Dictionary<string, GameData.SkillProgress>();
             saveData.EnemyKills ??= new Dictionary<string, double>();
             saveData.CompletedNpcTasks ??= new HashSet<string>();
-            saveData.PinnedQuests ??= new HashSet<string>();
+            saveData.PinnedQuests ??= new List<string>();
             saveData.BuffSlots ??= new List<string>(new string[5]);
             if (saveData.BuffSlots.Count < 5)
                 while (saveData.BuffSlots.Count < 5)

--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -37,7 +37,7 @@ namespace Blindsided.SaveData
 
         [HideReferenceObjectPicker] public Dictionary<string, QuestRecord> Quests = new();
 
-        [HideReferenceObjectPicker] public HashSet<string> PinnedQuests = new();
+        [HideReferenceObjectPicker] public List<string> PinnedQuests = new();
 
         [HideReferenceObjectPicker] public Dictionary<int, TaskRecord> TaskRecords = new();
 

--- a/Assets/Scripts/Quests/PinnedQuestUIManager.cs
+++ b/Assets/Scripts/Quests/PinnedQuestUIManager.cs
@@ -76,11 +76,8 @@ namespace TimelessEchoes.Quests
                 Destroy(child.gameObject);
             entries.Clear();
 
-            var count = 0;
             foreach (var id in oracle.saveData.PinnedQuests)
             {
-                if (count >= MaxPins)
-                    break;
                 if (string.IsNullOrEmpty(id))
                     continue;
                 var qm = QuestManager.Instance ?? FindFirstObjectByType<QuestManager>();
@@ -98,7 +95,6 @@ namespace TimelessEchoes.Quests
                     continue;
                 var ui = Instantiate(entryPrefab, entryParent);
                 entries[id] = ui;
-                count++;
             }
 
             if (rootObject != null)

--- a/Assets/Scripts/Quests/QuestManager.cs
+++ b/Assets/Scripts/Quests/QuestManager.cs
@@ -366,11 +366,17 @@ namespace TimelessEchoes.Quests
             var data = GetQuestData(questId);
             if (IsInstantQuest(data))
                 return;
-            var set = oracle.saveData.PinnedQuests;
-            if (set.Contains(questId))
-                set.Remove(questId);
-            else if (set.Count < PinnedQuestUIManager.MaxPins)
-                set.Add(questId);
+            var pins = oracle.saveData.PinnedQuests;
+            if (pins.Contains(questId))
+            {
+                pins.Remove(questId);
+            }
+            else
+            {
+                pins.Insert(0, questId);
+                if (pins.Count > PinnedQuestUIManager.MaxPins)
+                    pins.RemoveAt(pins.Count - 1);
+            }
             PinnedQuestUIManager.Instance?.RefreshPins();
         }
 
@@ -428,10 +434,12 @@ namespace TimelessEchoes.Quests
             active[quest.questId] = inst;
             if (isNewQuest && (AutoPinActiveQuests || quest.autoPin) && !IsInstantQuest(quest))
             {
-                var set = oracle.saveData.PinnedQuests;
-                if (!set.Contains(quest.questId))
+                var pins = oracle.saveData.PinnedQuests;
+                if (!pins.Contains(quest.questId))
                 {
-                    set.Add(quest.questId);
+                    pins.Insert(0, quest.questId);
+                    if (pins.Count > PinnedQuestUIManager.MaxPins)
+                        pins.RemoveAt(pins.Count - 1);
                     PinnedQuestUIManager.Instance?.RefreshPins();
                 }
             }


### PR DESCRIPTION
## Summary
- Switch GameData.PinnedQuests to `List<string>` and ensure null initialization in `Oracle`
- Handle pinned quest list as ordered queue in `QuestManager`
- Iterate pins in order within `PinnedQuestUIManager`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68913f87d344832ea9cf3585d84255aa