### PR TITLE
feat: add wandering animal behaviours

### DIFF
--- a/Assets/Prefabs/Decor/Animals/Mouse_Black.prefab
+++ b/Assets/Prefabs/Decor/Animals/Mouse_Black.prefab
@@ -121,6 +121,7 @@ GameObject:
   - component: {fileID: 4891254437283259235}
   - component: {fileID: 4549794364739409662}
   - component: {fileID: 2718269970555017869}
+  - component: {fileID: 3364930137357180203}
   m_Layer: 0
   m_Name: Mouse_Black
   m_TagString: Untagged
@@ -219,3 +220,24 @@ MonoBehaviour:
   slowWhenNotFacingTarget: 1
   preventMovingBackwards: 0
   constrainInsideGraph: 0
+--- !u!114 &3364930137357180203
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6951001417029320113}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 90693976edd14eb28d91af58f7a04e65, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  animator: {fileID: 6169638799197241066}
+  spriteRenderer: {fileID: 1874905378044195023}
+  wanderInterval: {x: 1, y: 3}
+  wanderDistance: 1
+  enableFlee: 0
+  fleeRadius: 2
+  fleeDistance: 3
+  hero: {fileID: 0}
+  eatInterval: {x: 5, y: 10}

--- a/Assets/Scripts/NPC/AnimalDecorationController.cs
+++ b/Assets/Scripts/NPC/AnimalDecorationController.cs
@@ -1,0 +1,118 @@
+using Pathfinding;
+using TimelessEchoes.Hero;
+using UnityEngine;
+
+namespace TimelessEchoes.NPC
+{
+    [RequireComponent(typeof(AIPath))]
+    public class AnimalDecorationController : MonoBehaviour
+    {
+        [SerializeField] private Animator animator;
+        [SerializeField] private SpriteRenderer spriteRenderer;
+        [SerializeField] private Vector2 wanderInterval = new Vector2(1f, 3f);
+        [SerializeField] private float wanderDistance = 1f;
+        [SerializeField] private bool enableFlee = false;
+        [SerializeField] private float fleeRadius = 2f;
+        [SerializeField] private float fleeDistance = 3f;
+        [SerializeField] private HeroController hero;
+
+        private AIPath ai;
+        private Vector3 spawnPos;
+        private float nextWanderTime;
+        private Vector2 lastMoveDir = Vector2.down;
+        private LayerMask blockingMask;
+        private bool isPaused;
+
+        protected virtual void Awake()
+        {
+            ai = GetComponent<AIPath>();
+            if (animator == null)
+                animator = GetComponentInChildren<Animator>();
+            if (spriteRenderer == null)
+                spriteRenderer = GetComponentInChildren<SpriteRenderer>();
+            if (hero == null)
+                hero = HeroController.Instance ?? FindFirstObjectByType<HeroController>();
+            spawnPos = transform.position;
+            blockingMask = LayerMask.GetMask("Blocking");
+        }
+
+        protected virtual void OnEnable()
+        {
+            nextWanderTime = Time.time;
+            Wander();
+        }
+
+        private void Update()
+        {
+            UpdateAnimation();
+            if (isPaused)
+                return;
+            if (enableFlee && hero != null && Vector2.Distance(transform.position, hero.transform.position) < fleeRadius)
+                Flee();
+            else
+                Wander();
+        }
+
+        private void UpdateAnimation()
+        {
+            Vector2 vel = ai != null ? ai.desiredVelocity : Vector2.zero;
+            var dir = vel;
+            dir.y = 0f;
+            if (dir.sqrMagnitude > 0.0001f)
+                lastMoveDir = dir;
+            if (animator != null)
+            {
+                animator.SetFloat("MoveX", lastMoveDir.x);
+                animator.SetFloat("MoveY", lastMoveDir.y);
+                animator.SetFloat("MoveMagnitude", vel.magnitude);
+            }
+            if (spriteRenderer != null)
+                spriteRenderer.flipX = lastMoveDir.x < 0f;
+        }
+
+        private void Wander()
+        {
+            if (Time.time < nextWanderTime)
+                return;
+            const int maxAttempts = 5;
+            Vector2 wander = transform.position;
+            for (int i = 0; i < maxAttempts; i++)
+            {
+                Vector2 candidate = (Vector2)spawnPos + Random.insideUnitCircle * wanderDistance;
+                if (Physics2D.OverlapCircle(candidate, 0.2f, blockingMask) == null)
+                {
+                    wander = candidate;
+                    break;
+                }
+            }
+            if (ai != null)
+                ai.destination = wander;
+            nextWanderTime = Time.time + Random.Range(wanderInterval.x, wanderInterval.y);
+        }
+
+        private void Flee()
+        {
+            Vector2 dir = (Vector2)(transform.position - hero.transform.position).normalized;
+            Vector2 target = (Vector2)transform.position + dir * fleeDistance;
+            if (ai != null)
+                ai.destination = target;
+        }
+
+        public void PauseMovement()
+        {
+            isPaused = true;
+            if (ai != null)
+                ai.canMove = false;
+        }
+
+        public void ResumeMovement()
+        {
+            isPaused = false;
+            if (ai != null)
+                ai.canMove = true;
+        }
+
+        protected Animator Animator => animator;
+    }
+}
+

--- a/Assets/Scripts/NPC/AnimalDecorationController.cs.meta
+++ b/Assets/Scripts/NPC/AnimalDecorationController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 568e3fd3a07d4242a09f6a0f27de8f33

--- a/Assets/Scripts/NPC/MouseDecorationController.cs
+++ b/Assets/Scripts/NPC/MouseDecorationController.cs
@@ -1,0 +1,42 @@
+using System.Collections;
+using UnityEngine;
+
+namespace TimelessEchoes.NPC
+{
+    public class MouseDecorationController : AnimalDecorationController
+    {
+        [SerializeField] private Vector2 eatInterval = new Vector2(5f, 10f);
+        private Coroutine routine;
+
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+            routine = StartCoroutine(EatRoutine());
+        }
+
+        protected override void OnDisable()
+        {
+            if (routine != null)
+                StopCoroutine(routine);
+            base.OnDisable();
+        }
+
+        private IEnumerator EatRoutine()
+        {
+            while (true)
+            {
+                float wait = Random.Range(eatInterval.x, eatInterval.y);
+                yield return new WaitForSeconds(wait);
+                PauseMovement();
+                if (Animator != null)
+                {
+                    Animator.Play("Eat");
+                    yield return null;
+                    yield return new WaitForSeconds(Animator.GetCurrentAnimatorStateInfo(0).length);
+                }
+                ResumeMovement();
+            }
+        }
+    }
+}
+

--- a/Assets/Scripts/NPC/MouseDecorationController.cs.meta
+++ b/Assets/Scripts/NPC/MouseDecorationController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 90693976edd14eb28d91af58f7a04e65


### PR DESCRIPTION
## Summary
- add `AnimalDecorationController` for wandering/fleeing decorative NPCs
- implement `MouseDecorationController` with periodic eating animation
- wire up mouse prefab with new controller

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689167e683e0832ea678f7bc6524be01