### PR TITLE
Fix MouseDecorationController OnDisable

### DIFF
--- a/Assets/Scripts/NPC/MouseDecorationController.cs
+++ b/Assets/Scripts/NPC/MouseDecorationController.cs
@@ -14,11 +14,13 @@ namespace TimelessEchoes.NPC
             routine = StartCoroutine(EatRoutine());
         }
 
-        protected override void OnDisable()
+        protected void OnDisable()
         {
             if (routine != null)
+            {
                 StopCoroutine(routine);
-            base.OnDisable();
+                routine = null;
+            }
         }
 
         private IEnumerator EatRoutine()


### PR DESCRIPTION
## Summary
- remove override from MouseDecorationController.OnDisable and clear coroutine reference

## Testing
- `mcs Assets/Scripts/NPC/MouseDecorationController.cs Assets/Scripts/NPC/AnimalDecorationController.cs` *(fails: UnityEngine reference missing)*

------
https://chatgpt.com/codex/tasks/task_e_68916edb0ec8832e9aa475d6b6c0e942