### PR TITLE
Add decor border placement

### DIFF
--- a/Assets/Scripts/MapGeneration/DecorConfig.cs
+++ b/Assets/Scripts/MapGeneration/DecorConfig.cs
@@ -15,6 +15,11 @@ namespace TimelessEchoes.MapGeneration
         [MinValue(0)] public int topBuffer = 1;
         [MinValue(0)] public int bottomBuffer;
         [MinValue(0)] public int sideBuffer = 1;
+        public bool borderOnly;
+        [MinValue(0)] public int topBorderOffset;
+        [MinValue(0)] public int bottomBorderOffset;
+        [MinValue(0)] public int leftBorderOffset;
+        [MinValue(0)] public int rightBorderOffset;
 
     }
 


### PR DESCRIPTION
## Summary
- expand decor config with border-only offsets
- support decor placement at terrain borders

## Testing
- `dotnet build` *(fails: MSB1003: specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689178f58154832eb5775e4e05efbd3b