### PR TITLE
Show icons for pinned quest resources

### DIFF
--- a/Assets/Scripts/Quests/PinnedQuestUIManager.cs
+++ b/Assets/Scripts/Quests/PinnedQuestUIManager.cs
@@ -95,6 +95,9 @@ namespace TimelessEchoes.Quests
                     continue;
                 var ui = Instantiate(entryPrefab, entryParent);
                 entries[id] = ui;
+
+                if (ui.progressText != null)
+                    ui.progressText.spriteAsset = ResourceIconLookup.SpriteAsset;
             }
 
             if (rootObject != null)
@@ -205,12 +208,16 @@ namespace TimelessEchoes.Quests
 
                     if (req.type == QuestData.RequirementType.Resource)
                     {
-                        var name = req.resource ? req.resource.name : "";
+                        var iconTag = req.resource ? ResourceIconLookup.GetIconTag(req.resource.resourceID) : string.Empty;
+                        var fallbackName = req.resource ? req.resource.name : string.Empty;
+                        var label = string.IsNullOrEmpty(iconTag) ? fallbackName : iconTag;
+                        var separator = string.IsNullOrEmpty(iconTag) ? ": " : " ";
+
                         if (target <= 0)
-                            sb.AppendLine($"<size=90%>{name}: {CalcUtils.FormatNumber(current, true)}</size>");
+                            sb.AppendLine($"<size=90%>{label}{separator}{CalcUtils.FormatNumber(current, true)}</size>");
                         else
                             sb.AppendLine(
-                                $"<size=90%>{name}: {CalcUtils.FormatNumber(current, true)} / {CalcUtils.FormatNumber(target, true)}</size>");
+                                $"<size=90%>{label}{separator}{CalcUtils.FormatNumber(current, true)} / {CalcUtils.FormatNumber(target, true)}</size>");
                     }
                     else if (req.type == QuestData.RequirementType.Kill && !string.IsNullOrEmpty(req.killName))
                     {


### PR DESCRIPTION
## Summary
- Show resource sprite icons in pinned quest progress lines
- Assign quest pin progress text to use shared sprite asset for TextMeshPro

## Testing
- `dotnet test` *(fails: MSB1003, no project file)*

------
https://chatgpt.com/codex/tasks/task_e_689178b2da14832eafa69934af541ceb