### PR TITLE
Allow disabling task edges with negative offsets

### DIFF
--- a/Assets/Scripts/MapGeneration/DecorConfig.cs
+++ b/Assets/Scripts/MapGeneration/DecorConfig.cs
@@ -16,10 +16,10 @@ namespace TimelessEchoes.MapGeneration
         [MinValue(0)] public int bottomBuffer;
         [MinValue(0)] public int sideBuffer = 1;
         public bool borderOnly;
-        [MinValue(0)] public int topBorderOffset;
-        [MinValue(0)] public int bottomBorderOffset;
-        [MinValue(0)] public int leftBorderOffset;
-        [MinValue(0)] public int rightBorderOffset;
+        public int topBorderOffset;
+        public int bottomBorderOffset;
+        public int leftBorderOffset;
+        public int rightBorderOffset;
 
     }
 

--- a/Assets/Scripts/MapGeneration/TerrainSettings.cs
+++ b/Assets/Scripts/MapGeneration/TerrainSettings.cs
@@ -19,10 +19,10 @@ namespace TimelessEchoes.MapGeneration
             [Range(0f,1f)] public float taskDensity = 0.1f;
 
             public bool borderOnly;
-            [MinValue(0)] public int topBorderOffset;
-            [MinValue(0)] public int bottomBorderOffset;
-            [MinValue(0)] public int leftBorderOffset;
-            [MinValue(0)] public int rightBorderOffset;
+            public int topBorderOffset;
+            public int bottomBorderOffset;
+            public int leftBorderOffset;
+            public int rightBorderOffset;
             // When false, spawned tasks are not registered with the TaskController.
             [ToggleLeft]
             public bool addToTaskList = true;

--- a/Assets/Scripts/MapGeneration/TilemapChunkGenerator.cs
+++ b/Assets/Scripts/MapGeneration/TilemapChunkGenerator.cs
@@ -335,10 +335,19 @@ namespace TimelessEchoes.MapGeneration
             var leftDist = CountSame(cell + Vector3Int.left, Vector3Int.left, tile);
             var rightDist = CountSame(cell + Vector3Int.right, Vector3Int.right, tile);
 
-            var topOffset = config.topBorderOffset + extraOffset;
-            var bottomOffset = config.bottomBorderOffset + extraOffset;
-            var leftOffset = config.leftBorderOffset + extraOffset;
-            var rightOffset = config.rightBorderOffset + extraOffset;
+            var topRaw = config.topBorderOffset;
+            if (topRaw < 0 && upDist == 0) return false;
+            var bottomRaw = config.bottomBorderOffset;
+            if (bottomRaw < 0 && downDist == 0) return false;
+            var leftRaw = config.leftBorderOffset;
+            if (leftRaw < 0 && leftDist == 0) return false;
+            var rightRaw = config.rightBorderOffset;
+            if (rightRaw < 0 && rightDist == 0) return false;
+
+            var topOffset = Mathf.Max(0, topRaw) + extraOffset;
+            var bottomOffset = Mathf.Max(0, bottomRaw) + extraOffset;
+            var leftOffset = Mathf.Max(0, leftRaw) + extraOffset;
+            var rightOffset = Mathf.Max(0, rightRaw) + extraOffset;
 
             if (upDist < topOffset) return false;
             if (downDist < bottomOffset) return false;

--- a/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
+++ b/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
@@ -606,10 +606,19 @@ namespace TimelessEchoes.Tasks
             var leftDist = CountSame(cell + Vector3Int.left, Vector3Int.left, tile);
             var rightDist = CountSame(cell + Vector3Int.right, Vector3Int.right, tile);
 
-            var topOffset = settings.taskSettings.topBorderOffset + extraOffset;
-            var bottomOffset = settings.taskSettings.bottomBorderOffset + extraOffset;
-            var leftOffset = settings.taskSettings.leftBorderOffset + extraOffset;
-            var rightOffset = settings.taskSettings.rightBorderOffset + extraOffset;
+            var topRaw = settings.taskSettings.topBorderOffset;
+            if (topRaw < 0 && upDist == 0) return false;
+            var bottomRaw = settings.taskSettings.bottomBorderOffset;
+            if (bottomRaw < 0 && downDist == 0) return false;
+            var leftRaw = settings.taskSettings.leftBorderOffset;
+            if (leftRaw < 0 && leftDist == 0) return false;
+            var rightRaw = settings.taskSettings.rightBorderOffset;
+            if (rightRaw < 0 && rightDist == 0) return false;
+
+            var topOffset = Mathf.Max(0, topRaw) + extraOffset;
+            var bottomOffset = Mathf.Max(0, bottomRaw) + extraOffset;
+            var leftOffset = Mathf.Max(0, leftRaw) + extraOffset;
+            var rightOffset = Mathf.Max(0, rightRaw) + extraOffset;
 
             if (upDist < topOffset) return false;
             if (downDist < bottomOffset) return false;

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ appear. When `borderOnly` is enabled, tasks spawn only along the terrain's
 computed borders. The directional offsets (`topBorderOffset`, `bottomBorderOffset`,
 `leftBorderOffset` and `rightBorderOffset`) shift this border check in each
 direction. If `borderOnly` is disabled these offsets specify how many tiles away
-from the edges tasks must spawn. Task spawn counts now rely solely on each
+from the edges tasks must spawn. Setting an offset to a negative value disables
+spawning from that edge entirely. Task spawn counts now rely solely on each
 terrain's `taskSettings.taskDensity` value; the generator's overall density
 setting has been removed.
 


### PR DESCRIPTION
## Summary
- allow negative border offsets in terrain and decor configs
- skip spawning on edges where a negative offset is set
- document that negative offsets disable their respective edge

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*


------
https://chatgpt.com/codex/tasks/task_e_68917aee83a4832e8643e0f2973d2f32