### PR TITLE
Add random horizontal flipping for decor

### DIFF
--- a/Assets/Scripts/MapGeneration/DecorConfig.cs
+++ b/Assets/Scripts/MapGeneration/DecorConfig.cs
@@ -44,6 +44,9 @@ namespace TimelessEchoes.MapGeneration
         [HideLabel]
         public GameObject prefab;
 
+        [ToggleLeft]
+        public bool randomFlipX;
+
         // When any value inside the config is changed, call the UpdateName method.
         [OnValueChanged("UpdateName", true)] [HorizontalGroup("Entry")] [InlineProperty] [HideLabel]
         public DecorConfig config = new();

--- a/Assets/Scripts/MapGeneration/TilemapChunkGenerator.cs
+++ b/Assets/Scripts/MapGeneration/TilemapChunkGenerator.cs
@@ -301,11 +301,27 @@ namespace TimelessEchoes.MapGeneration
                         if (d.prefab != null)
                         {
                             var center = terrainMap.GetCellCenterWorld(cell);
-                            Instantiate(d.prefab, center, Quaternion.identity, decorParent);
+                            var instance = Instantiate(d.prefab, center, Quaternion.identity, decorParent);
+                            if (d.randomFlipX && RandomRangeFloat(0f, 1f) < 0.5f)
+                            {
+                                var renderer = instance.GetComponentInChildren<SpriteRenderer>();
+                                if (renderer != null)
+                                    renderer.flipX = true;
+                            }
                         }
 
                         if (decorMap != null && d.tile != null)
+                        {
                             decorMap.SetTile(cell, d.tile);
+                            if (d.randomFlipX)
+                            {
+                                decorMap.SetTileFlags(cell, TileFlags.None);
+                                var matrix = RandomRangeFloat(0f, 1f) < 0.5f
+                                    ? Matrix4x4.Scale(new Vector3(-1, 1, 1))
+                                    : Matrix4x4.identity;
+                                decorMap.SetTransformMatrix(cell, matrix);
+                            }
+                        }
 
                         break;
                     }
@@ -417,7 +433,11 @@ namespace TimelessEchoes.MapGeneration
             {
                 var pos = new Vector3Int(offset.x + x, offset.y + y, 0);
                 terrainMap.SetTile(pos, null);
-                decorMap?.SetTile(pos, null);
+                if (decorMap != null)
+                {
+                    decorMap.SetTile(pos, null);
+                    decorMap.SetTransformMatrix(pos, Matrix4x4.identity);
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- allow decor entries to request random horizontal flipping through a new `randomFlipX` toggle
- when placing decor prefabs, randomly flip the SpriteRenderer on a 50/50 chance
- support tile-based flipping with transform matrices and reset transforms when clearing

## Testing
- `dotnet test` *(fails: project or solution file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68917e6f7510832e83aea8bf705ef44c