### PR TITLE
Hide empty bonus in run resource tracker UI

### DIFF
--- a/Assets/Scripts/UI/RunStatsPanelUI.cs
+++ b/Assets/Scripts/UI/RunStatsPanelUI.cs
@@ -174,7 +174,9 @@ namespace TimelessEchoes.UI
                 var resources = CalcUtils.FormatNumber(record.ResourcesCollected, true);
                 var bonus = CalcUtils.FormatNumber(record.BonusResourcesCollected, true);
                 runStatUI.distanceTasksResourcesText.text =
-                    $"Duration: {time}\nDistance: {dist}\nTasks: {tasks}\nResources: {resources} (+{bonus})";
+                    $"Duration: {time}\nDistance: {dist}\nTasks: {tasks}\nResources: {resources}";
+                if (record.BonusResourcesCollected > 0)
+                    runStatUI.distanceTasksResourcesText.text += $" (+{bonus})";
             }
 
 


### PR DESCRIPTION
## Summary
- only show resource gain bonus in run stats panel when greater than zero

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689180f86928832eb9b07519527535cb