### PR TITLE
fix border negative offsets

### DIFF
--- a/Assets/Scripts/MapGeneration/TilemapChunkGenerator.cs
+++ b/Assets/Scripts/MapGeneration/TilemapChunkGenerator.cs
@@ -352,13 +352,13 @@ namespace TimelessEchoes.MapGeneration
             var rightDist = CountSame(cell + Vector3Int.right, Vector3Int.right, tile);
 
             var topRaw = config.topBorderOffset;
-            if (topRaw < 0 && upDist == 0) return false;
+            if (topRaw < 0 && upDist > 0) return false;
             var bottomRaw = config.bottomBorderOffset;
-            if (bottomRaw < 0 && downDist == 0) return false;
+            if (bottomRaw < 0 && downDist > 0) return false;
             var leftRaw = config.leftBorderOffset;
-            if (leftRaw < 0 && leftDist == 0) return false;
+            if (leftRaw < 0 && leftDist > 0) return false;
             var rightRaw = config.rightBorderOffset;
-            if (rightRaw < 0 && rightDist == 0) return false;
+            if (rightRaw < 0 && rightDist > 0) return false;
 
             var topOffset = Mathf.Max(0, topRaw) + extraOffset;
             var bottomOffset = Mathf.Max(0, bottomRaw) + extraOffset;


### PR DESCRIPTION
## Summary
- prevent placement along disabled sides by rejecting cells with neighbors when border offset is negative

## Testing
- `dotnet test` (fails: MSB1003, no project or solution file)


------
https://chatgpt.com/codex/tasks/task_e_68918692ceb8832ea834d9dc3092d444