### PR TITLE
Fix core tile detection to consider axis neighbors

### DIFF
--- a/Assets/Scripts/MapGeneration/TilemapChunkGenerator.cs
+++ b/Assets/Scripts/MapGeneration/TilemapChunkGenerator.cs
@@ -373,7 +373,8 @@ namespace TimelessEchoes.MapGeneration
             for (var dx = -leftOffset; dx <= rightOffset; dx++)
             for (var dy = -bottomOffset; dy <= topOffset; dy++)
             {
-                if (dx == 0 || dy == 0) continue;
+                // Skip only the cell itself so axis neighbours are evaluated
+                if (dx == 0 && dy == 0) continue;
                 var checkPos = cell + new Vector3Int(dx, dy, 0);
                 if (terrainMap.GetTile(checkPos) != tile)
                     return false;


### PR DESCRIPTION
## Summary
- Evaluate axis neighbors in `IsInCore` so corners touching different tiles are not treated as core

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6891895e9684832e8a9cb2b3918bb93f