### PR TITLE
Clarify border offset behavior

### DIFF
--- a/Assets/Scripts/MapGeneration/DecorConfig.cs
+++ b/Assets/Scripts/MapGeneration/DecorConfig.cs
@@ -16,6 +16,10 @@ namespace TimelessEchoes.MapGeneration
         [MinValue(0)] public int bottomBuffer;
         [MinValue(0)] public int sideBuffer = 1;
         public bool borderOnly;
+        /// <summary>
+        /// Offsets from each edge used for core checks.
+        /// Negative values reject cells touching the corresponding edge.
+        /// </summary>
         public int topBorderOffset;
         public int bottomBorderOffset;
         public int leftBorderOffset;

--- a/Assets/Scripts/MapGeneration/TerrainSettings.cs
+++ b/Assets/Scripts/MapGeneration/TerrainSettings.cs
@@ -19,6 +19,11 @@ namespace TimelessEchoes.MapGeneration
             [Range(0f,1f)] public float taskDensity = 0.1f;
 
             public bool borderOnly;
+
+            /// <summary>
+            /// Offsets from each edge for task placement.
+            /// Negative values reject cells touching that edge.
+            /// </summary>
             public int topBorderOffset;
             public int bottomBorderOffset;
             public int leftBorderOffset;

--- a/Assets/Scripts/MapGeneration/TilemapChunkGenerator.cs
+++ b/Assets/Scripts/MapGeneration/TilemapChunkGenerator.cs
@@ -352,13 +352,15 @@ namespace TimelessEchoes.MapGeneration
             var rightDist = CountSame(cell + Vector3Int.right, Vector3Int.right, tile);
 
             var topRaw = config.topBorderOffset;
-            if (topRaw < 0 && upDist > 0) return false;
             var bottomRaw = config.bottomBorderOffset;
-            if (bottomRaw < 0 && downDist > 0) return false;
             var leftRaw = config.leftBorderOffset;
-            if (leftRaw < 0 && leftDist > 0) return false;
             var rightRaw = config.rightBorderOffset;
-            if (rightRaw < 0 && rightDist > 0) return false;
+
+            // Negative offsets forbid cells that touch the corresponding edge
+            if (topRaw < 0 && upDist == 0) return false;
+            if (bottomRaw < 0 && downDist == 0) return false;
+            if (leftRaw < 0 && leftDist == 0) return false;
+            if (rightRaw < 0 && rightDist == 0) return false;
 
             var topOffset = Mathf.Max(0, topRaw) + extraOffset;
             var bottomOffset = Mathf.Max(0, bottomRaw) + extraOffset;


### PR DESCRIPTION
## Summary
- Reject edge cells when border offsets are negative
- Document negative border offset behavior for decor and task settings

## Testing
- `dotnet test` *(fails: project or solution file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68918e2ea51c832eaee65decdade45fd