### PR TITLE
Initialize localization for quest editor

### DIFF
--- a/Assets/Editor/QuestFlowWindow.cs
+++ b/Assets/Editor/QuestFlowWindow.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using TimelessEchoes.Quests;
 using UnityEditor;
 using UnityEngine;
+using UnityEngine.Localization.Settings;
 
 /// <summary>
 ///     An editor window to visualize the quest flow graph automatically from QuestData assets.
@@ -26,7 +27,17 @@ public class QuestFlowWindow : EditorWindow
 
             // Determine title
             if (questData.questName != null && !questData.questName.IsEmpty)
+            {
+                if (!LocalizationSettings.InitializationOperation.IsDone)
+                    LocalizationSettings.InitializationOperation.WaitForCompletion();
+
+                if (LocalizationSettings.SelectedLocale == null)
+                    LocalizationSettings.SelectedLocale = LocalizationSettings.AvailableLocales.Locales
+                        .FirstOrDefault();
+
                 title = questData.questName.GetLocalizedString();
+            }
+
             if (string.IsNullOrEmpty(title)) title = questData.name;
 
             // --- FEATURE: Determine node color based on localization status ---


### PR DESCRIPTION
## Summary
- Ensure localization system is initialized in QuestFlowWindow editor tool before fetching localized quest names
- Default to first available locale when none is selected to prevent null SelectedLocale errors

## Testing
- `npm test` *(fails: Could not read package.json)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68918eb84c2c832ea1ebd43226a1dbfb