### PR TITLE
feat: hide decor buffers when border only

### DIFF
--- a/Assets/Scripts/MapGeneration/DecorConfig.cs
+++ b/Assets/Scripts/MapGeneration/DecorConfig.cs
@@ -12,9 +12,9 @@ namespace TimelessEchoes.MapGeneration
         [MinValue(0f)] public float weight = 1f;
         public float minX;
         public float maxX = float.PositiveInfinity;
-        [MinValue(0)] public int topBuffer = 1;
-        [MinValue(0)] public int bottomBuffer;
-        [MinValue(0)] public int sideBuffer = 1;
+        [MinValue(0)] [HideIf(nameof(borderOnly))] public int topBuffer = 1;
+        [MinValue(0)] [HideIf(nameof(borderOnly))] public int bottomBuffer;
+        [MinValue(0)] [HideIf(nameof(borderOnly))] public int sideBuffer = 1;
         public bool borderOnly;
         public int topBorderOffset;
         public int bottomBorderOffset;


### PR DESCRIPTION
## Summary
- hide decor buffer fields when border-only is enabled using Odin's `HideIf`

## Testing
- `mcs -target:library -r:Assets/Plugins/Sirenix/Assemblies/Sirenix.OdinInspector.Attributes.dll -out:/tmp/DecorConfig.dll /tmp/UnityStubs.cs /tmp/DecorConfig_temp.cs` *(fails: UnityEngine assembly missing)*

------
https://chatgpt.com/codex/tasks/task_e_68918e366404832ea5f7a33c871e953a