### PR TITLE
Hide empty bonus in run resource tracker UI

### DIFF
--- a/Assets/Scripts/UI/RunStatsPanelUI.cs
+++ b/Assets/Scripts/UI/RunStatsPanelUI.cs
@@ -172,9 +172,12 @@ namespace TimelessEchoes.UI
                 var dist = CalcUtils.FormatNumber(record.Distance, true);
                 var tasks = CalcUtils.FormatNumber(record.TasksCompleted, true);
                 var resources = CalcUtils.FormatNumber(record.ResourcesCollected, true);
-                var bonus = CalcUtils.FormatNumber(record.BonusResourcesCollected, true);
+                var bonusCollected = Mathf.FloorToInt((float)record.BonusResourcesCollected);
+                var bonus = CalcUtils.FormatNumber(bonusCollected, true);
                 runStatUI.distanceTasksResourcesText.text =
-                    $"Duration: {time}\nDistance: {dist}\nTasks: {tasks}\nResources: {resources} (+{bonus})";
+                    $"Duration: {time}\nDistance: {dist}\nTasks: {tasks}\nResources: {resources}";
+                if (bonusCollected >= 1)
+                    runStatUI.distanceTasksResourcesText.text += $" (+{bonus})";
             }
 
 


### PR DESCRIPTION
## Summary
- only display resource gain bonus in run stats panel when truncated amount is at least one

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689180f86928832eb9b07519527535cb