### PR TITLE
feat: refine border cell checks

### DIFF
--- a/Assets/Scripts/MapGeneration/TilemapChunkGenerator.cs
+++ b/Assets/Scripts/MapGeneration/TilemapChunkGenerator.cs
@@ -388,7 +388,34 @@ namespace TimelessEchoes.MapGeneration
         {
             var inCore = IsInCore(cell, tile, config, 0);
             var inInnerCore = IsInCore(cell, tile, config, 1);
-            return inCore && !inInnerCore;
+            if (!inCore || inInnerCore) return false;
+
+            var upDist = CountSame(cell + Vector3Int.up, Vector3Int.up, tile);
+            var downDist = CountSame(cell + Vector3Int.down, Vector3Int.down, tile);
+            var leftDist = CountSame(cell + Vector3Int.left, Vector3Int.left, tile);
+            var rightDist = CountSame(cell + Vector3Int.right, Vector3Int.right, tile);
+
+            if (config.topBorderOffset < 0 && upDist == 0) return false;
+            if (config.bottomBorderOffset < 0 && downDist == 0) return false;
+            if (config.leftBorderOffset < 0 && leftDist == 0) return false;
+            if (config.rightBorderOffset < 0 && rightDist == 0) return false;
+
+            var touchesTop = config.topBorderOffset >= 0 &&
+                             upDist == Mathf.Max(0, config.topBorderOffset);
+            var touchesBottom = config.bottomBorderOffset >= 0 &&
+                                downDist == Mathf.Max(0, config.bottomBorderOffset);
+            var touchesLeft = config.leftBorderOffset >= 0 &&
+                              leftDist == Mathf.Max(0, config.leftBorderOffset);
+            var touchesRight = config.rightBorderOffset >= 0 &&
+                               rightDist == Mathf.Max(0, config.rightBorderOffset);
+
+            var sideCount = 0;
+            if (touchesTop) sideCount++;
+            if (touchesBottom) sideCount++;
+            if (touchesLeft) sideCount++;
+            if (touchesRight) sideCount++;
+
+            return sideCount == 1;
         }
 
         // Updated to use HasFlag for the [Flags] enum

--- a/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
+++ b/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
@@ -592,9 +592,42 @@ namespace TimelessEchoes.Tasks
 
             if (!settings.taskSettings.borderOnly) return IsInCore(cell, settings, tile, 0);
 
+            return IsBorderCell(cell, settings, tile);
+        }
+
+        private bool IsBorderCell(Vector3Int cell, TerrainSettings settings, TileBase tile)
+        {
             var inCore = IsInCore(cell, settings, tile, 0);
             var inInnerCore = IsInCore(cell, settings, tile, 1);
-            return inCore && !inInnerCore;
+            if (!inCore || inInnerCore) return false;
+
+            var upDist = CountSame(cell + Vector3Int.up, Vector3Int.up, tile);
+            var downDist = CountSame(cell + Vector3Int.down, Vector3Int.down, tile);
+            var leftDist = CountSame(cell + Vector3Int.left, Vector3Int.left, tile);
+            var rightDist = CountSame(cell + Vector3Int.right, Vector3Int.right, tile);
+
+            var ts = settings.taskSettings;
+            if (ts.topBorderOffset < 0 && upDist == 0) return false;
+            if (ts.bottomBorderOffset < 0 && downDist == 0) return false;
+            if (ts.leftBorderOffset < 0 && leftDist == 0) return false;
+            if (ts.rightBorderOffset < 0 && rightDist == 0) return false;
+
+            var touchesTop = ts.topBorderOffset >= 0 &&
+                             upDist == Mathf.Max(0, ts.topBorderOffset);
+            var touchesBottom = ts.bottomBorderOffset >= 0 &&
+                                downDist == Mathf.Max(0, ts.bottomBorderOffset);
+            var touchesLeft = ts.leftBorderOffset >= 0 &&
+                              leftDist == Mathf.Max(0, ts.leftBorderOffset);
+            var touchesRight = ts.rightBorderOffset >= 0 &&
+                               rightDist == Mathf.Max(0, ts.rightBorderOffset);
+
+            var sideCount = 0;
+            if (touchesTop) sideCount++;
+            if (touchesBottom) sideCount++;
+            if (touchesLeft) sideCount++;
+            if (touchesRight) sideCount++;
+
+            return sideCount == 1;
         }
 
         private bool IsInCore(Vector3Int cell, TerrainSettings settings, TileBase tile, int extraOffset)


### PR DESCRIPTION
## Summary
- narrow border placement by detecting side adjacency and rejecting corners
- ensure procedural tasks follow updated border rules

## Testing
- `dotnet test` *(fails: MSB1003 no project)*

------
https://chatgpt.com/codex/tasks/task_e_6891930bf278832eb44991244bd6e2fe