### PR TITLE
Guard Steam locale selector on non-Steam platforms

### DIFF
--- a/Assets/Scripts/Steamworks.NET/SteamLanguageLocaleSelector.cs
+++ b/Assets/Scripts/Steamworks.NET/SteamLanguageLocaleSelector.cs
@@ -1,3 +1,8 @@
+// Disable Steamworks usage on unsupported platforms.
+#if !(UNITY_STANDALONE_WIN || UNITY_STANDALONE_LINUX || UNITY_STANDALONE_OSX || STEAMWORKS_WIN || STEAMWORKS_LIN_OSX)
+#define DISABLESTEAMWORKS
+#endif
+
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Localization;


### PR DESCRIPTION
## Summary
- prevent Steam locale selector from referencing Steamworks on unsupported builds

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68919887d3dc832ea7c7deabe76f1dbc