### PR TITLE
Adjust run drop UI capacity

### DIFF
--- a/Assets/Scripts/Blindsided/Components/CompactGridLayout.cs
+++ b/Assets/Scripts/Blindsided/Components/CompactGridLayout.cs
@@ -14,6 +14,15 @@ public class CompactGridLayout : LayoutGroup
     [SerializeField] private Vector2 spacing = Vector2.zero;
     [SerializeField] private int maxColumns = 7;
 
+    public Vector2 CellSize => cellSize;
+    public Vector2 Spacing => spacing;
+
+    public int MaxColumns
+    {
+        get => maxColumns;
+        set => maxColumns = Mathf.Max(1, value);
+    }
+
     /* ---------- Size calculations -------------------------------------------------- */
 
     public override void CalculateLayoutInputHorizontal()

--- a/Assets/Scripts/Upgrades/RunDropUI.cs
+++ b/Assets/Scripts/Upgrades/RunDropUI.cs
@@ -16,6 +16,7 @@ namespace TimelessEchoes.Upgrades
         [SerializeField] private Transform slotParent;
         [SerializeField] private GameObject displayObject;
         [SerializeField] [Min(1)] private int maxVisibleDrops = 5;
+        private CompactGridLayout layout;
 
         private readonly List<Resource> resources = new();
         private readonly List<ResourceUIReferences> slots = new();
@@ -36,7 +37,14 @@ namespace TimelessEchoes.Upgrades
                 slotParent = transform;
             if (displayObject == null)
                 displayObject = gameObject;
+            layout = slotParent != null ? slotParent.GetComponent<CompactGridLayout>() : GetComponent<CompactGridLayout>();
+            RecalculateCapacity();
             ClearDrops();
+        }
+
+        private void OnRectTransformDimensionsChange()
+        {
+            RecalculateCapacity();
         }
 
         private void OnEnable()
@@ -71,6 +79,24 @@ namespace TimelessEchoes.Upgrades
             amounts.Clear();
             if (displayObject != null)
                 displayObject.SetActive(false);
+        }
+
+        private void RecalculateCapacity()
+        {
+            if (layout == null) return;
+
+            var canvas = GetComponentInParent<Canvas>();
+            var scale = canvas ? canvas.scaleFactor : 1f;
+            var safeWidth = Screen.safeArea.width / scale;
+            const float hudWidth = 200f;
+            const float hudGap = 1f;
+
+            var slotWidth = layout.CellSize.x + layout.Spacing.x;  // e.g., 26 + 1
+            var available = safeWidth - hudWidth - hudGap;
+
+            maxVisibleDrops = Mathf.Max(1,
+                Mathf.FloorToInt((available + layout.Spacing.x) / slotWidth));
+            layout.MaxColumns = maxVisibleDrops;
         }
 
 


### PR DESCRIPTION
## Summary
- expose CompactGridLayout properties and add a clamped `MaxColumns` setter
- recalc RunDropUI capacity based on safe area and update grid columns

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6891b85fe664832e95929d29cd4491c8