### PR TITLE
feat: show run info in window title

### DIFF
--- a/Assets/Scripts/Steamworks.NET/RichPresenceManager.cs
+++ b/Assets/Scripts/Steamworks.NET/RichPresenceManager.cs
@@ -2,6 +2,10 @@
 #define DISABLESTEAMWORKS
 #endif
 using UnityEngine;
+#if UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN
+using System;
+using System.Runtime.InteropServices;
+#endif
 #if !DISABLESTEAMWORKS
 using Steamworks;
 #endif
@@ -15,6 +19,14 @@ namespace TimelessEchoes
     /// </summary>
     public class RichPresenceManager : MonoBehaviour
     {
+#if UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        private static extern IntPtr GetActiveWindow();
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        private static extern bool SetWindowText(IntPtr hWnd, string text);
+#endif
+
 #if !DISABLESTEAMWORKS
         private static RichPresenceManager instance;
 
@@ -58,6 +70,7 @@ namespace TimelessEchoes
                 return;
             SteamFriends.SetRichPresence("status", "In Town");
             SteamFriends.SetRichPresence("steam_display", "#Status_InTown");
+            SetWindowTitle("In Town");
         }
 
         /// <summary>
@@ -69,6 +82,7 @@ namespace TimelessEchoes
                 return;
             SteamFriends.SetRichPresence("status", "Exploring");
             SteamFriends.SetRichPresence("steam_display", "#Status_InRun");
+            SetWindowTitle("Exploring");
         }
 
         /// <summary>
@@ -82,12 +96,22 @@ namespace TimelessEchoes
             SteamFriends.SetRichPresence("status", $"Distance: {d}");
             SteamFriends.SetRichPresence("distance", d.ToString());
             SteamFriends.SetRichPresence("steam_display", "#Status_Distance");
+            SetWindowTitle($"Distance: {d}");
         }
 
         private void OnDestroy()
         {
             if (instance == this)
                 instance = null;
+        }
+
+        private void SetWindowTitle(string status)
+        {
+#if UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN
+            var handle = GetActiveWindow();
+            if (handle != IntPtr.Zero)
+                SetWindowText(handle, $"{Application.productName} - {status}");
+#endif
         }
 #endif
     }


### PR DESCRIPTION
## Summary
- expand `RichPresenceManager` to display run status in the Windows title bar

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891b8a0b7e4832e9144e912871e179f