### PR TITLE
Handle missing Windows taskbar interface safely

### DIFF
--- a/Assets/Scripts/Steamworks.NET/RichPresenceManager.cs
+++ b/Assets/Scripts/Steamworks.NET/RichPresenceManager.cs
@@ -85,7 +85,9 @@ namespace TimelessEchoes
         {
             if (taskbar != null)
                 return;
-            taskbar = (ITaskbarList3)new CTaskbarList();
+            taskbar = new CTaskbarList() as ITaskbarList3;
+            if (taskbar == null)
+                return;
             taskbar.HrInit();
             windowHandle = GetActiveWindow();
         }


### PR DESCRIPTION
## Summary
- Avoid InvalidCastException when initializing Windows taskbar integration by using a safe cast
- Skip taskbar progress features if the interface isn't available

## Testing
- `dotnet test` (fails: no project or solution file)

------
https://chatgpt.com/codex/tasks/task_e_6891c1a17124832e93afd38330c42c6d