### PR TITLE
Fix Windows taskbar handle for progress and death flash

### DIFF
--- a/Assets/Scripts/Steamworks.NET/RichPresenceManager.cs
+++ b/Assets/Scripts/Steamworks.NET/RichPresenceManager.cs
@@ -83,13 +83,15 @@ namespace TimelessEchoes
 
         private static void InitTaskbar()
         {
-            if (taskbar != null)
-                return;
-            taskbar = new CTaskbarList() as ITaskbarList3;
             if (taskbar == null)
-                return;
-            taskbar.HrInit();
-            windowHandle = GetActiveWindow();
+            {
+                taskbar = new CTaskbarList() as ITaskbarList3;
+                if (taskbar == null)
+                    return;
+                taskbar.HrInit();
+            }
+            if (windowHandle == IntPtr.Zero)
+                windowHandle = GetActiveWindow();
         }
 
         private static void ResetTaskbarProgress()


### PR DESCRIPTION
## Summary
- Ensure Windows taskbar initialization reacquires the active window handle so distance progress and death flashes work

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(package not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891c3895e0c832eb6b2193e275dc3a8