### PR TITLE
Show progress for distance-based buffs

### DIFF
--- a/Assets/Scripts/Buffs/BuffManager.cs
+++ b/Assets/Scripts/Buffs/BuffManager.cs
@@ -185,7 +185,7 @@ namespace TimelessEchoes.Buffs
             var buff = new ActiveBuff
             {
                 recipe = recipe,
-                remaining = recipe.baseDuration,
+                remaining = recipe.distancePercent > 0f ? float.PositiveInfinity : recipe.baseDuration,
                 expireAtDistance = expireDist
             };
             activeBuffs.Add(buff);


### PR DESCRIPTION
## Summary
- Handle distance-based buffs with infinite time and distance expiry
- Show percentage progress for distance-based buffs in the buff UI
- Display distance-based info in buff purchase panels

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68927c3861b8832e99d3cdc5da330772