### PR TITLE
Refactor buff system with effect lists and quest integration

### DIFF
--- a/Assets/Resources/Buffs/Combat Enhancer.asset
+++ b/Assets/Resources/Buffs/Combat Enhancer.asset
@@ -15,16 +15,16 @@ MonoBehaviour:
   title: 
   description: Buffs Damage, and Defense by 50%
   buffIcon: {fileID: 2601603839896418933, guid: 61614b6dea4e6254e853eb57bbf5ef3b, type: 3}
-  baseDuration: 60
-  distancePercent: 0
+  durationType: 0
+  durationMagnitude: 60
   echoSpawnConfig:
     echoCount: 0
     capableSkills: []
     echoType: 2
-  moveSpeedPercent: 0
-  damagePercent: 50
-  defensePercent: 50
-  attackSpeedPercent: 0
-  taskSpeedPercent: 0
-  lifestealPercent: 0
-  instantTasks: 0
+  requiredQuest: {fileID: 0}
+  baseEffects:
+  - type: 1
+    magnitude: 50
+  - type: 2
+    magnitude: 50
+  upgrades: []

--- a/Assets/Resources/Buffs/Echo Combat.asset
+++ b/Assets/Resources/Buffs/Echo Combat.asset
@@ -16,16 +16,12 @@ MonoBehaviour:
   description: A combat oriented Echo from your past will ignore tasks and attack
     enemies for you.
   buffIcon: {fileID: 7218046035808895280, guid: 16b9f4cabb88e55479fb4cb5a33be70d, type: 3}
-  baseDuration: 30
-  distancePercent: 0
+  durationType: 0
+  durationMagnitude: 30
   echoSpawnConfig:
     echoCount: 1
     capableSkills: []
     echoType: 0
-  moveSpeedPercent: 0
-  damagePercent: 0
-  defensePercent: 0
-  attackSpeedPercent: 0
-  taskSpeedPercent: 0
-  lifestealPercent: 0
-  instantTasks: 0
+  requiredQuest: {fileID: 0}
+  baseEffects: []
+  upgrades: []

--- a/Assets/Resources/Buffs/Echo Tasks.asset
+++ b/Assets/Resources/Buffs/Echo Tasks.asset
@@ -15,16 +15,12 @@ MonoBehaviour:
   title: Echo | Tasks
   description: An Echo of your past will complete tasks alongside you.
   buffIcon: {fileID: 21300000, guid: 27afd0a9708dae942b5fcb9f60c65dff, type: 3}
-  baseDuration: 30
-  distancePercent: 0
+  durationType: 0
+  durationMagnitude: 30
   echoSpawnConfig:
     echoCount: 1
     capableSkills: []
     echoType: 2
-  moveSpeedPercent: 0
-  damagePercent: 0
-  defensePercent: 0
-  attackSpeedPercent: 0
-  taskSpeedPercent: 0
-  lifestealPercent: 0
-  instantTasks: 0
+  requiredQuest: {fileID: 0}
+  baseEffects: []
+  upgrades: []

--- a/Assets/Resources/Buffs/MoveSpeed.asset
+++ b/Assets/Resources/Buffs/MoveSpeed.asset
@@ -15,16 +15,14 @@ MonoBehaviour:
   title: 
   description: Increases Movespeed by 40% for its duration.
   buffIcon: {fileID: -5882155960153656733, guid: 75e6aad650cc46242a07d1d673daedeb, type: 3}
-  baseDuration: 120
-  distancePercent: 0
+  durationType: 0
+  durationMagnitude: 120
   echoSpawnConfig:
     echoCount: 0
     capableSkills: []
     echoType: 2
-  moveSpeedPercent: 40
-  damagePercent: 0
-  defensePercent: 0
-  attackSpeedPercent: 0
-  taskSpeedPercent: 0
-  lifestealPercent: 0
-  instantTasks: 0
+  requiredQuest: {fileID: 0}
+  baseEffects:
+  - type: 0
+    magnitude: 40
+  upgrades: []

--- a/Assets/Resources/Buffs/Slipstream.asset
+++ b/Assets/Resources/Buffs/Slipstream.asset
@@ -15,16 +15,14 @@ MonoBehaviour:
   title: Slipstream
   description: Instantly complete all tasks up to 50% of your distance record.
   buffIcon: {fileID: 6903983040440877652, guid: 27d08327615764bc9a976be93fb999d3, type: 3}
-  baseDuration: 300
-  distancePercent: 0.5
+  durationType: 1
+  durationMagnitude: 0.5
   echoSpawnConfig:
     echoCount: 0
     capableSkills: []
     echoType: 1
-  moveSpeedPercent: 0
-  damagePercent: 0
-  defensePercent: 0
-  attackSpeedPercent: 0
-  taskSpeedPercent: 0
-  lifestealPercent: 0
-  instantTasks: 1
+  requiredQuest: {fileID: 0}
+  baseEffects:
+  - type: 6
+    magnitude: 1
+  upgrades: []

--- a/Assets/Resources/Buffs/Task Speed.asset
+++ b/Assets/Resources/Buffs/Task Speed.asset
@@ -15,16 +15,14 @@ MonoBehaviour:
   title: 
   description: Increases Movespeed by 40% for its duration.
   buffIcon: {fileID: -5882155960153656733, guid: 75e6aad650cc46242a07d1d673daedeb, type: 3}
-  baseDuration: 120
-  distancePercent: 0
+  durationType: 0
+  durationMagnitude: 120
   echoSpawnConfig:
     echoCount: 0
     capableSkills: []
     echoType: 2
-  moveSpeedPercent: 40
-  damagePercent: 0
-  defensePercent: 0
-  attackSpeedPercent: 0
-  taskSpeedPercent: 0
-  lifestealPercent: 0
-  instantTasks: 0
+  requiredQuest: {fileID: 0}
+  baseEffects:
+  - type: 4
+    magnitude: 40
+  upgrades: []

--- a/Assets/Resources/Buffs/Vampiric.asset
+++ b/Assets/Resources/Buffs/Vampiric.asset
@@ -15,15 +15,14 @@ MonoBehaviour:
   title: Vampiric
   description: Gain 15% Lifesteal
   buffIcon: {fileID: -2906203513720773286, guid: 27d08327615764bc9a976be93fb999d3, type: 3}
-  baseDuration: 30
+  durationType: 0
+  durationMagnitude: 30
   echoSpawnConfig:
     echoCount: 0
     capableSkills: []
     echoType: 1
-  moveSpeedPercent: 0
-  damagePercent: 0
-  defensePercent: 0
-  attackSpeedPercent: 0
-  lifestealPercent: 15
-  instantTasks: 0
-  distancePercent: 0
+  requiredQuest: {fileID: 0}
+  baseEffects:
+  - type: 5
+    magnitude: 15
+  upgrades: []

--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -35,6 +35,8 @@ namespace Blindsided.SaveData
         [TabGroup("Buffs")] public int UnlockedAutoBuffSlots = 0;
         [HideReferenceObjectPicker]
         [TabGroup("Buffs")] public List<bool> AutoBuffSlots = new() { false, false, false, false, false };
+        [HideReferenceObjectPicker]
+        [TabGroup("Buffs")] public Dictionary<string, int> BuffLevels = new();
 
         [HideReferenceObjectPicker]
         [TabGroup("Tasks")] public HashSet<string> CompletedNpcTasks = new();

--- a/Assets/Scripts/Buffs/BuffEnums.cs
+++ b/Assets/Scripts/Buffs/BuffEnums.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace TimelessEchoes.Buffs
+{
+    /// <summary>
+    /// Types of buff effects supported by the game.
+    /// </summary>
+    public enum BuffEffectType
+    {
+        MoveSpeed,
+        Damage,
+        Defense,
+        AttackSpeed,
+        TaskSpeed,
+        Lifesteal,
+        InstantTasks,
+        EchoCount,
+        Duration
+    }
+
+    /// <summary>
+    /// How a buff's duration is measured.
+    /// </summary>
+    public enum BuffDurationType
+    {
+        Time,
+        Distance
+    }
+}

--- a/Assets/Scripts/Buffs/BuffRecipe.cs
+++ b/Assets/Scripts/Buffs/BuffRecipe.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using Blindsided.Utilities;
 using Sirenix.OdinInspector;
+using TimelessEchoes.Quests;
 using UnityEngine;
 
 namespace TimelessEchoes.Buffs
@@ -21,47 +23,153 @@ namespace TimelessEchoes.Buffs
         public Sprite buffIcon;
 
         [TitleGroup("General")]
-        [MinValue(0f)]
-        public float baseDuration = 30f;
+        public BuffDurationType durationType = BuffDurationType.Time;
 
         [TitleGroup("General")]
-        [Tooltip("Percent of longest run distance this buff remains active. 0 = no distance limit")]
-        [Range(0f,1f)]
-        public float distancePercent;
+        [MinValue(0f)]
+        public float durationMagnitude = 30f;
 
         [TitleGroup("General")]
         [SerializeField]
         public TimelessEchoes.EchoSpawnConfig echoSpawnConfig;
 
-        [TitleGroup("Effects")]
-        [Range(-100f, 100f)]
-        public float moveSpeedPercent;
+        [TitleGroup("General")]
+        [Tooltip("Quest required to unlock this buff.")]
+        public QuestData requiredQuest;
 
         [TitleGroup("Effects")]
-        [Range(-100f, 100f)]
-        public float damagePercent;
+        public List<BuffEffect> baseEffects = new();
 
-        [TitleGroup("Effects")]
-        [Range(-100f, 100f)]
-        public float defensePercent;
-
-        [TitleGroup("Effects")]
-        [Range(-100f, 100f)]
-        public float attackSpeedPercent;
-
-        [TitleGroup("Effects")]
-        [Range(-100f, 100f)]
-        public float taskSpeedPercent;
-
-        [TitleGroup("Effects")]
-        [Tooltip("Percent of damage returned as health while active.")]
-        [Range(0f, 100f)]
-        public float lifestealPercent;
-
-        [TitleGroup("Effects")]
-        [Tooltip("Tasks complete instantly while active.")]
-        public bool instantTasks;
+        [TitleGroup("Upgrades")]
+        public List<BuffUpgrade> upgrades = new();
 
         public string Title => string.IsNullOrEmpty(title) ? name : title;
+
+        /// <summary>
+        ///     Returns the current level based on completed upgrade quests.
+        /// </summary>
+        public int GetLevel()
+        {
+            var lvl = 1;
+            if (upgrades == null) return lvl;
+            foreach (var up in upgrades)
+            {
+                if (up?.quest == null) continue;
+                if (QuestManager.Instance != null && QuestManager.Instance.IsQuestCompleted(up.quest))
+                    lvl++;
+            }
+            return lvl;
+        }
+
+        /// <summary>
+        ///     Returns true if the required quest to unlock this buff has been completed.
+        /// </summary>
+        public bool IsUnlocked()
+        {
+            if (requiredQuest == null) return true;
+            return QuestManager.Instance != null && QuestManager.Instance.IsQuestCompleted(requiredQuest);
+        }
+
+        /// <summary>
+        ///     Combine base effects with effects from completed upgrades.
+        /// </summary>
+        public IEnumerable<BuffEffect> GetActiveEffects()
+        {
+            var effects = new List<BuffEffect>();
+            if (baseEffects != null)
+                effects.AddRange(baseEffects);
+            if (upgrades != null)
+            {
+                foreach (var up in upgrades)
+                {
+                    if (up?.quest == null || up.effects == null) continue;
+                    if (QuestManager.Instance != null && QuestManager.Instance.IsQuestCompleted(up.quest))
+                        effects.AddRange(up.effects);
+                }
+            }
+            return effects;
+        }
+
+        /// <summary>
+        ///     Builds a display name including current level.
+        /// </summary>
+        public string GetDisplayName()
+        {
+            return $"{Title} Lvl {GetLevel()}";
+        }
+
+        /// <summary>
+        ///     Generates human readable description lines for the aggregated effects.
+        /// </summary>
+        public List<string> GetDescriptionLines()
+        {
+            var totals = new Dictionary<BuffEffectType, float>();
+            foreach (var eff in GetActiveEffects())
+            {
+                if (totals.ContainsKey(eff.type))
+                    totals[eff.type] += eff.magnitude;
+                else
+                    totals[eff.type] = eff.magnitude;
+            }
+
+            if (echoSpawnConfig != null && echoSpawnConfig.echoCount > 0)
+            {
+                if (totals.ContainsKey(BuffEffectType.EchoCount))
+                    totals[BuffEffectType.EchoCount] += echoSpawnConfig.echoCount;
+                else
+                    totals[BuffEffectType.EchoCount] = echoSpawnConfig.echoCount;
+            }
+
+            var lines = new List<string>();
+            foreach (var kv in totals)
+            {
+                switch (kv.Key)
+                {
+                    case BuffEffectType.MoveSpeed:
+                        lines.Add($"Move Speed {kv.Value:+0;-0;0}%");
+                        break;
+                    case BuffEffectType.Damage:
+                        lines.Add($"Damage {kv.Value:+0;-0;0}%");
+                        break;
+                    case BuffEffectType.Defense:
+                        lines.Add($"Defense {kv.Value:+0;-0;0}%");
+                        break;
+                    case BuffEffectType.AttackSpeed:
+                        lines.Add($"Attack Speed {kv.Value:+0;-0;0}%");
+                        break;
+                    case BuffEffectType.TaskSpeed:
+                        lines.Add($"Task Speed {kv.Value:+0;-0;0}%");
+                        break;
+                    case BuffEffectType.Lifesteal:
+                        lines.Add($"Lifesteal {kv.Value:+0;-0;0}%");
+                        break;
+                    case BuffEffectType.InstantTasks:
+                        lines.Add("Tasks complete instantly");
+                        break;
+                    case BuffEffectType.EchoCount:
+                        lines.Add($"Echo Count {kv.Value:+0;-0;0}");
+                        break;
+                    case BuffEffectType.Duration:
+                        lines.Add($"Duration {kv.Value:+0;-0;0}s");
+                        break;
+                }
+            }
+
+            return lines;
+        }
+
+        [Serializable]
+        public struct BuffEffect
+        {
+            public BuffEffectType type;
+            [Range(-100f, 100f)] public float magnitude;
+        }
+
+        [Serializable]
+        public class BuffUpgrade
+        {
+            public QuestData quest;
+            public List<BuffEffect> effects = new();
+        }
     }
 }

--- a/Assets/Scripts/Quests/QuestData.cs
+++ b/Assets/Scripts/Quests/QuestData.cs
@@ -4,6 +4,7 @@ using Blindsided.Utilities;
 using Sirenix.OdinInspector;
 using TimelessEchoes.Enemies;
 using TimelessEchoes.Upgrades;
+using TimelessEchoes.Buffs;
 using UnityEngine;
 using UnityEngine.Localization;
 
@@ -28,6 +29,8 @@ namespace TimelessEchoes.Quests
         public int unlockAutoBuffSlots;
         public float maxDistanceIncrease;
         public float disciplePercentReward;
+        public BuffRecipe unlockBuff;
+        public BuffRecipe upgradeBuff;
 
         [Serializable]
         public class Requirement

--- a/Assets/Scripts/Quests/QuestManager.cs
+++ b/Assets/Scripts/Quests/QuestManager.cs
@@ -1,6 +1,7 @@
 #if !(UNITY_STANDALONE_WIN || UNITY_STANDALONE_LINUX || UNITY_STANDALONE_OSX || STEAMWORKS_WIN || STEAMWORKS_LIN_OSX)
 #define DISABLESTEAMWORKS
 #endif
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using Blindsided.SaveData;
@@ -290,6 +291,19 @@ namespace TimelessEchoes.Quests
                 oracle.saveData.DisciplePercent += inst.data.disciplePercentReward;
                 DiscipleGenerationManager.Instance?.RefreshRates();
             }
+            oracle.saveData.BuffLevels ??= new Dictionary<string, int>();
+            if (inst.data.unlockBuff != null)
+            {
+                var bid = inst.data.unlockBuff.name;
+                oracle.saveData.BuffLevels[bid] = Math.Max(oracle.saveData.BuffLevels.ContainsKey(bid) ? oracle.saveData.BuffLevels[bid] : 0, 1);
+            }
+            if (inst.data.upgradeBuff != null)
+            {
+                var bid = inst.data.upgradeBuff.name;
+                var level = 1;
+                oracle.saveData.BuffLevels.TryGetValue(bid, out level);
+                oracle.saveData.BuffLevels[bid] = level + 1;
+            }
             if (!string.IsNullOrEmpty(inst.data.npcId))
                 CompletedNpcTasks.Add(inst.data.npcId);
             if (inst.ui != null)
@@ -305,6 +319,26 @@ namespace TimelessEchoes.Quests
                 PinnedQuestUIManager.Instance?.RefreshPins();
             else
                 PinnedQuestUIManager.Instance?.UpdateProgress();
+            BuffUIManager.Instance?.BuildRecipeEntries();
+        }
+
+        /// <summary>
+        ///     Returns true if the given quest has been completed.
+        /// </summary>
+        public bool IsQuestCompleted(QuestData quest)
+        {
+            if (quest == null || oracle == null) return false;
+            if (oracle.saveData.Quests.TryGetValue(quest.questId, out var rec))
+                return rec.Completed;
+            return false;
+        }
+
+        public bool IsQuestCompleted(string questId)
+        {
+            if (string.IsNullOrEmpty(questId) || oracle == null) return false;
+            if (oracle.saveData.Quests.TryGetValue(questId, out var rec))
+                return rec.Completed;
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- add shared enums for buff effects and duration types
- refactor BuffRecipe and BuffManager to aggregate effects and support quest-driven upgrades
- track buff levels in save data, expose unlock/upgrade hooks to quests, and update buff UI accordingly
- migrate existing buff assets to list-based format
- enable echo configuration via spawn config and allow quests to extend buff durations

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68928cc1b608832eb91fd297de6855ba