### PR TITLE
Revamp Buff system with quest-based upgrades

### DIFF
--- a/Assets/Resources/Buffs/Combat Enhancer.asset
+++ b/Assets/Resources/Buffs/Combat Enhancer.asset
@@ -11,20 +11,20 @@ MonoBehaviour:
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0af36f21f516c014e84b0332b152cb1c, type: 3}
   m_Name: Combat Enhancer
-  m_EditorClassIdentifier: 
-  title: 
+  m_EditorClassIdentifier:
+  title:
   description: Buffs Damage, and Defense by 50%
   buffIcon: {fileID: 2601603839896418933, guid: 61614b6dea4e6254e853eb57bbf5ef3b, type: 3}
+  durationType: 0
   baseDuration: 60
-  distancePercent: 0
-  echoSpawnConfig:
-    echoCount: 0
+  baseEchoCount: 0
+  echoConfig:
     capableSkills: []
     echoType: 2
-  moveSpeedPercent: 0
-  damagePercent: 50
-  defensePercent: 50
-  attackSpeedPercent: 0
-  taskSpeedPercent: 0
-  lifestealPercent: 0
-  instantTasks: 0
+  requiredQuest: {fileID: 0}
+  baseEffects:
+  - type: 1
+    value: 50
+  - type: 2
+    value: 50
+  upgrades: []

--- a/Assets/Resources/Buffs/Echo Combat.asset
+++ b/Assets/Resources/Buffs/Echo Combat.asset
@@ -11,21 +11,16 @@ MonoBehaviour:
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0af36f21f516c014e84b0332b152cb1c, type: 3}
   m_Name: Echo Combat
-  m_EditorClassIdentifier: 
+  m_EditorClassIdentifier:
   title: Echo | Combat
-  description: A combat oriented Echo from your past will ignore tasks and attack
-    enemies for you.
+  description: A combat oriented Echo from your past will ignore tasks and attack enemies for you.
   buffIcon: {fileID: 7218046035808895280, guid: 16b9f4cabb88e55479fb4cb5a33be70d, type: 3}
+  durationType: 0
   baseDuration: 30
-  distancePercent: 0
-  echoSpawnConfig:
-    echoCount: 1
+  baseEchoCount: 1
+  echoConfig:
     capableSkills: []
     echoType: 0
-  moveSpeedPercent: 0
-  damagePercent: 0
-  defensePercent: 0
-  attackSpeedPercent: 0
-  taskSpeedPercent: 0
-  lifestealPercent: 0
-  instantTasks: 0
+  requiredQuest: {fileID: 0}
+  baseEffects: []
+  upgrades: []

--- a/Assets/Resources/Buffs/Echo Tasks.asset
+++ b/Assets/Resources/Buffs/Echo Tasks.asset
@@ -11,20 +11,16 @@ MonoBehaviour:
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0af36f21f516c014e84b0332b152cb1c, type: 3}
   m_Name: Echo Tasks
-  m_EditorClassIdentifier: 
+  m_EditorClassIdentifier:
   title: Echo | Tasks
   description: An Echo of your past will complete tasks alongside you.
   buffIcon: {fileID: 21300000, guid: 27afd0a9708dae942b5fcb9f60c65dff, type: 3}
+  durationType: 0
   baseDuration: 30
-  distancePercent: 0
-  echoSpawnConfig:
-    echoCount: 1
+  baseEchoCount: 1
+  echoConfig:
     capableSkills: []
     echoType: 2
-  moveSpeedPercent: 0
-  damagePercent: 0
-  defensePercent: 0
-  attackSpeedPercent: 0
-  taskSpeedPercent: 0
-  lifestealPercent: 0
-  instantTasks: 0
+  requiredQuest: {fileID: 0}
+  baseEffects: []
+  upgrades: []

--- a/Assets/Resources/Buffs/MoveSpeed.asset
+++ b/Assets/Resources/Buffs/MoveSpeed.asset
@@ -11,20 +11,18 @@ MonoBehaviour:
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0af36f21f516c014e84b0332b152cb1c, type: 3}
   m_Name: MoveSpeed
-  m_EditorClassIdentifier: 
-  title: 
+  m_EditorClassIdentifier:
+  title:
   description: Increases Movespeed by 40% for its duration.
   buffIcon: {fileID: -5882155960153656733, guid: 75e6aad650cc46242a07d1d673daedeb, type: 3}
+  durationType: 0
   baseDuration: 120
-  distancePercent: 0
-  echoSpawnConfig:
-    echoCount: 0
+  baseEchoCount: 0
+  echoConfig:
     capableSkills: []
     echoType: 2
-  moveSpeedPercent: 40
-  damagePercent: 0
-  defensePercent: 0
-  attackSpeedPercent: 0
-  taskSpeedPercent: 0
-  lifestealPercent: 0
-  instantTasks: 0
+  requiredQuest: {fileID: 0}
+  baseEffects:
+  - type: 0
+    value: 40
+  upgrades: []

--- a/Assets/Resources/Buffs/Slipstream.asset
+++ b/Assets/Resources/Buffs/Slipstream.asset
@@ -11,20 +11,18 @@ MonoBehaviour:
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0af36f21f516c014e84b0332b152cb1c, type: 3}
   m_Name: Slipstream
-  m_EditorClassIdentifier: 
+  m_EditorClassIdentifier:
   title: Slipstream
   description: Instantly complete all tasks up to 50% of your distance record.
   buffIcon: {fileID: 6903983040440877652, guid: 27d08327615764bc9a976be93fb999d3, type: 3}
-  baseDuration: 300
-  distancePercent: 0.5
-  echoSpawnConfig:
-    echoCount: 0
+  durationType: 1
+  baseDuration: 0.5
+  baseEchoCount: 0
+  echoConfig:
     capableSkills: []
     echoType: 1
-  moveSpeedPercent: 0
-  damagePercent: 0
-  defensePercent: 0
-  attackSpeedPercent: 0
-  taskSpeedPercent: 0
-  lifestealPercent: 0
-  instantTasks: 1
+  requiredQuest: {fileID: 0}
+  baseEffects:
+  - type: 6
+    value: 1
+  upgrades: []

--- a/Assets/Resources/Buffs/Task Speed.asset
+++ b/Assets/Resources/Buffs/Task Speed.asset
@@ -11,20 +11,18 @@ MonoBehaviour:
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0af36f21f516c014e84b0332b152cb1c, type: 3}
   m_Name: Task Speed
-  m_EditorClassIdentifier: 
-  title: 
+  m_EditorClassIdentifier:
+  title:
   description: Increases Movespeed by 40% for its duration.
   buffIcon: {fileID: -5882155960153656733, guid: 75e6aad650cc46242a07d1d673daedeb, type: 3}
+  durationType: 0
   baseDuration: 120
-  distancePercent: 0
-  echoSpawnConfig:
-    echoCount: 0
+  baseEchoCount: 0
+  echoConfig:
     capableSkills: []
     echoType: 2
-  moveSpeedPercent: 40
-  damagePercent: 0
-  defensePercent: 0
-  attackSpeedPercent: 0
-  taskSpeedPercent: 0
-  lifestealPercent: 0
-  instantTasks: 0
+  requiredQuest: {fileID: 0}
+  baseEffects:
+  - type: 0
+    value: 40
+  upgrades: []

--- a/Assets/Resources/Buffs/Vampiric.asset
+++ b/Assets/Resources/Buffs/Vampiric.asset
@@ -11,19 +11,18 @@ MonoBehaviour:
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0af36f21f516c014e84b0332b152cb1c, type: 3}
   m_Name: Vampiric
-  m_EditorClassIdentifier: 
+  m_EditorClassIdentifier:
   title: Vampiric
   description: Gain 15% Lifesteal
   buffIcon: {fileID: -2906203513720773286, guid: 27d08327615764bc9a976be93fb999d3, type: 3}
+  durationType: 0
   baseDuration: 30
-  echoSpawnConfig:
-    echoCount: 0
+  baseEchoCount: 0
+  echoConfig:
     capableSkills: []
     echoType: 1
-  moveSpeedPercent: 0
-  damagePercent: 0
-  defensePercent: 0
-  attackSpeedPercent: 0
-  lifestealPercent: 15
-  instantTasks: 0
-  distancePercent: 0
+  requiredQuest: {fileID: 0}
+  baseEffects:
+  - type: 5
+    value: 15
+  upgrades: []

--- a/Assets/Scripts/Buffs/BuffTypes.cs
+++ b/Assets/Scripts/Buffs/BuffTypes.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using TimelessEchoes.Quests;
+
+namespace TimelessEchoes.Buffs
+{
+    public enum BuffEffectType
+    {
+        MoveSpeedPercent,
+        DamagePercent,
+        DefensePercent,
+        AttackSpeedPercent,
+        TaskSpeedPercent,
+        LifestealPercent,
+        InstantTasks
+    }
+
+    public enum BuffDurationType
+    {
+        Time,
+        DistancePercent
+    }
+
+    [Serializable]
+    public struct BuffEffect
+    {
+        public BuffEffectType type;
+        public float value;
+    }
+
+    [Serializable]
+    public class BuffUpgrade
+    {
+        public QuestData quest;
+        public List<BuffEffect> additionalEffects = new();
+        public float durationDelta;
+        public int echoCountDelta;
+    }
+}

--- a/Assets/Scripts/Hero/EchoManager.cs
+++ b/Assets/Scripts/Hero/EchoManager.cs
@@ -78,9 +78,9 @@ namespace TimelessEchoes.Hero
         /// <param name="baseDuration">Base lifetime for the spawned Echoes.</param>
         /// <param name="fallbackSkills">Used when the config does not specify any skills.</param>
         /// <param name="applyLifetimeUpgrade">When true, applies the Echo Lifetime upgrade value.</param>
-        /// <param name="countOverride">Optional spawn count override.</param>
+        /// <param name="count">Number of echoes to spawn.</param>
         public static List<HeroController> SpawnEchoes(EchoSpawnConfig config, float baseDuration,
-            IEnumerable<Skill> fallbackSkills = null, bool applyLifetimeUpgrade = false, int countOverride = 0)
+            IEnumerable<Skill> fallbackSkills = null, bool applyLifetimeUpgrade = false, int count = 1)
         {
             var duration = baseDuration;
             if (applyLifetimeUpgrade)
@@ -92,21 +92,17 @@ namespace TimelessEchoes.Hero
                     duration += upgradeController.GetTotalValue(echoUpgrade);
             }
 
-            var count = 1;
             var skills = fallbackSkills;
             var type = EchoType.All;
 
             if (config != null)
             {
-                count = countOverride > 0 ? countOverride : Mathf.Max(1, config.echoCount);
                 if (config.capableSkills != null && config.capableSkills.Count > 0)
                     skills = config.capableSkills;
                 type = config.echoType;
             }
-            else if (countOverride > 0)
-            {
-                count = countOverride;
-            }
+            if (count <= 0)
+                count = 1;
 
             var spawned = new List<HeroController>();
             for (var i = 0; i < count; i++)

--- a/Assets/Scripts/Hero/EchoSpawnConfig.cs
+++ b/Assets/Scripts/Hero/EchoSpawnConfig.cs
@@ -8,8 +8,6 @@ namespace TimelessEchoes
     [Serializable]
     public class EchoSpawnConfig
     {
-        [Min(1)]
-        public int echoCount = 1;
         [Tooltip("Skills this Echo can perform. Leave empty to allow all skills.")]
         public List<Skill> capableSkills = new();
 

--- a/Assets/Scripts/Quests/QuestData.cs
+++ b/Assets/Scripts/Quests/QuestData.cs
@@ -28,6 +28,8 @@ namespace TimelessEchoes.Quests
         public int unlockAutoBuffSlots;
         public float maxDistanceIncrease;
         public float disciplePercentReward;
+        public bool unlocksBuff;
+        public bool upgradesBuff;
 
         [Serializable]
         public class Requirement

--- a/Assets/Scripts/Quests/QuestManager.cs
+++ b/Assets/Scripts/Quests/QuestManager.cs
@@ -343,6 +343,12 @@ namespace TimelessEchoes.Quests
             return active.ContainsKey(questId);
         }
 
+        public bool IsQuestCompleted(QuestData quest)
+        {
+            if (quest == null || oracle == null) return false;
+            return oracle.saveData.Quests.TryGetValue(quest.questId, out var rec) && rec.Completed;
+        }
+
         /// <summary>
         ///     Returns quest data for the given id or null if not found.
         /// </summary>


### PR DESCRIPTION
## Summary
- Introduce BuffEffectType & BuffDurationType enums with BuffEffect and BuffUpgrade structs
- Overhaul BuffRecipe and BuffManager for aggregated effects, quest gating, and dynamic echo spawning
- Refresh BuffUIManager and buff assets to use new dynamic data and hide locked buffs

## Testing
- `mcs --version` *(fails: command not found)*
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689296ed27cc832e9a77a5eca21b4723