### PR TITLE
Group buff effect descriptions and format duration

### DIFF
--- a/Assets/Scripts/Buffs/BuffRecipe.cs
+++ b/Assets/Scripts/Buffs/BuffRecipe.cs
@@ -131,17 +131,28 @@ namespace TimelessEchoes.Buffs
             var lines = new List<string>();
             if (!string.IsNullOrEmpty(description))
                 lines.Add(description);
+
+            var effectStrings = new List<string>();
             foreach (var eff in GetAggregatedEffects())
             {
-                lines.Add(DescribeEffect(eff));
+                var text = DescribeEffect(eff);
+                if (!string.IsNullOrEmpty(text))
+                    effectStrings.Add(text);
             }
+
+            for (var i = 0; i < effectStrings.Count; i += 3)
+            {
+                var count = Math.Min(3, effectStrings.Count - i);
+                lines.Add(string.Join(", ", effectStrings.GetRange(i, count)));
+            }
+
             var echoCount = GetEchoCount();
             if (echoCount > 0)
                 lines.Add($"Echoes: {echoCount}");
             if (durationType == BuffDurationType.DistancePercent)
                 lines.Add($"Distance: {Mathf.CeilToInt(GetDuration() * 100f)}%");
             else
-                lines.Add($"Duration: {Mathf.CeilToInt(GetDuration())}");
+                lines.Add($"Duration: {CalcUtils.FormatTime(GetDuration(), shortForm: true)}");
             return lines;
         }
 


### PR DESCRIPTION
## Summary
- Group multiple buff effects into comma-separated lines (max 3 per line)
- Display buff duration using CalcUtils' short time format

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6892a0aac4c8832e99a3623e436a749d