### PR TITLE
feat: add abandon run console command

### DIFF
--- a/Assets/Scripts/Tools/ConsoleCommands.cs
+++ b/Assets/Scripts/Tools/ConsoleCommands.cs
@@ -174,5 +174,11 @@ namespace TimelessEchoes
             Blindsided.EventHandler.LoadData();
         }
 
+        [Command("abandon-run", "Abandon the current run and return to town")]
+        public static void AbandonRun()
+        {
+            GameManager.Instance?.AbandonRun();
+        }
+
     }
 }


### PR DESCRIPTION
## Summary
- add `abandon-run` debug console command
- support abandoning a run by skipping rewards and returning to town

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892a953afe0832e8be910561c3b1f95