### PR TITLE
feat: add mobile gesture to open quantum console

### DIFF
--- a/Assets/Scripts/Tools/QuantumConsoleMobileActivator.cs
+++ b/Assets/Scripts/Tools/QuantumConsoleMobileActivator.cs
@@ -1,0 +1,74 @@
+using QFSW.QC;
+using UnityEngine;
+
+namespace TimelessEchoes
+{
+    /// <summary>
+    /// Automatically instantiates at startup and opens the Quantum Console on mobile
+    /// when three fingers are held on the screen for a set duration.
+    /// No manual scene setup is required.
+    /// </summary>
+    public class QuantumConsoleMobileActivator : MonoBehaviour
+    {
+        [SerializeField] private float holdDuration = 2f;
+        private float _touchTimer;
+        private QuantumConsole _console;
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        private static void Bootstrap()
+        {
+            var go = new GameObject(nameof(QuantumConsoleMobileActivator));
+            DontDestroyOnLoad(go);
+            go.AddComponent<QuantumConsoleMobileActivator>();
+        }
+
+        private void Awake()
+        {
+            _console = FindFirstObjectByType<QuantumConsole>(FindObjectsInactive.Include);
+        }
+
+        private void Update()
+        {
+            if (!Application.isMobilePlatform)
+            {
+                return;
+            }
+
+            if (_console == null)
+            {
+                _console = FindFirstObjectByType<QuantumConsole>(FindObjectsInactive.Include);
+                if (_console == null)
+                {
+                    return;
+                }
+            }
+
+            if (Input.touchCount >= 3)
+            {
+                bool allHeld = true;
+                for (int i = 0; i < Input.touchCount; i++)
+                {
+                    var phase = Input.touches[i].phase;
+                    if (phase == TouchPhase.Ended || phase == TouchPhase.Canceled)
+                    {
+                        allHeld = false;
+                        break;
+                    }
+                }
+
+                if (allHeld)
+                {
+                    _touchTimer += Time.unscaledDeltaTime;
+                    if (_touchTimer >= holdDuration)
+                    {
+                        _console.Toggle();
+                        _touchTimer = 0f;
+                    }
+                    return;
+                }
+            }
+
+            _touchTimer = 0f;
+        }
+    }
+}

--- a/Assets/Scripts/Tools/QuantumConsoleMobileActivator.cs.meta
+++ b/Assets/Scripts/Tools/QuantumConsoleMobileActivator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 101c4601ade0424ab87eaf3503964ee8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- trigger Quantum Console with a three-finger hold on mobile
- clarify that the activator is auto-instantiated so no manual setup is needed

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_6892b3791528832e87b9a73facd8f286