### PR TITLE
Maintain hero's current combat target

### DIFF
--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -557,17 +557,6 @@ namespace TimelessEchoes.Hero
         {
             if (stats == null) return;
 
-            if (currentEnemy != null)
-            {
-                var hp = currentEnemy.GetComponent<Health>();
-                if (hp == null || hp.CurrentHealth <= 0f)
-                {
-                    currentEnemyHealth?.SetHealthBarVisible(false);
-                    currentEnemy = null;
-                    currentEnemyHealth = null;
-                }
-            }
-
             enemyRemovalBuffer.Clear();
             foreach (var enemy in engagedEnemies)
             {
@@ -579,8 +568,20 @@ namespace TimelessEchoes.Hero
             foreach (var enemy in enemyRemovalBuffer)
                 UnregisterEngagedEnemy(enemy);
 
-            Transform nearest = null;
-            if (allowAttacks)
+            if (currentEnemy != null)
+            {
+                var hp = currentEnemy.GetComponent<Health>();
+                var enemyComp = currentEnemy.GetComponent<Enemy>();
+                if (hp == null || hp.CurrentHealth <= 0f || enemyComp == null || !engagedEnemies.Contains(enemyComp))
+                {
+                    currentEnemyHealth?.SetHealthBarVisible(false);
+                    currentEnemy = null;
+                    currentEnemyHealth = null;
+                }
+            }
+
+            Transform nearest = currentEnemy;
+            if (allowAttacks && nearest == null)
             {
                 if (engagedEnemies.Count > 0)
                 {


### PR DESCRIPTION
## Summary
- Keep hero locked on its current enemy while it's alive and engaged
- Pick a new enemy only when the current target is gone or disengaged

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6892b90818d4832ea1485d5db2aa2d07