### PR TITLE
Close milestones window on hero death

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -94,6 +94,8 @@ namespace TimelessEchoes
         public Transform MeetingParent => meetingParent;
         public GameObject CurrentMap => currentMap;
 
+        public event System.Action HeroDied;
+
         [TitleGroup("Map Generation")]
         [SerializeField] private List<MapGenerationButton> generationButtons = new();
 
@@ -454,6 +456,7 @@ namespace TimelessEchoes
         {
             DestroyAllEchoes();
             heroDead = true;
+            HeroDied?.Invoke();
             if (returnToTavernButton != null)
                 returnToTavernButton.interactable = false;
             if (returnOnDeathButton != null)

--- a/Assets/Scripts/Skills/MilestoneBonusUI.cs
+++ b/Assets/Scripts/Skills/MilestoneBonusUI.cs
@@ -2,6 +2,7 @@ using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 using References.UI;
+using TimelessEchoes;
 
 namespace TimelessEchoes.Skills
 {
@@ -37,6 +38,20 @@ namespace TimelessEchoes.Skills
                 controller = FindFirstObjectByType<SkillController>();
             if (window == null)
                 window = gameObject;
+        }
+
+        private void OnEnable()
+        {
+            var gm = GameManager.Instance;
+            if (gm != null)
+                gm.HeroDied += CloseWindow;
+        }
+
+        private void OnDisable()
+        {
+            var gm = GameManager.Instance;
+            if (gm != null)
+                gm.HeroDied -= CloseWindow;
         }
 
         public void PopulateMilestones(Skill skill)


### PR DESCRIPTION
## Summary
- Add `HeroDied` event to `GameManager` and fire it when the hero dies
- Subscribe `MilestoneBonusUI` to `GameManager.HeroDied` so the milestones window closes on hero death

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_6892b5f7dd80832ebaf65ce6e9b35540