### PR TITLE
Use CalcUtils time formatting for disciple UI

### DIFF
--- a/Assets/Scripts/NpcGeneration/DiscipleGeneratorProgressUI.cs
+++ b/Assets/Scripts/NpcGeneration/DiscipleGeneratorProgressUI.cs
@@ -112,8 +112,9 @@ namespace TimelessEchoes.NpcGeneration
             {
                 if (generator.Interval > 0)
                 {
-                    var time = generator.Interval.ToString("0.##");
-                    collectionRateText.text = CalcUtils.FormatNumber(generator.CycleAmount, true) + " / " + time + "s";
+                    var time = CalcUtils.FormatTime(generator.Interval, showDecimal: true, shortForm: true);
+                    collectionRateText.text =
+                        $"{CalcUtils.FormatNumber(generator.CycleAmount, true)} / {time}";
                 }
                 else
                 {


### PR DESCRIPTION
## Summary
- Use `CalcUtils.FormatTime` short form to show disciple generator interval

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892d3349bec832ea736046d1cb986da