### PR TITLE
Hide decimals for long disciple generation times

### DIFF
--- a/Assets/Scripts/NpcGeneration/DiscipleGeneratorProgressUI.cs
+++ b/Assets/Scripts/NpcGeneration/DiscipleGeneratorProgressUI.cs
@@ -112,7 +112,8 @@ namespace TimelessEchoes.NpcGeneration
             {
                 if (generator.Interval > 0)
                 {
-                    var time = CalcUtils.FormatTime(generator.Interval, showDecimal: true, shortForm: true);
+                    var showDecimal = generator.Interval < 60f;
+                    var time = CalcUtils.FormatTime(generator.Interval, showDecimal: showDecimal, shortForm: true);
                     collectionRateText.text =
                         $"{CalcUtils.FormatNumber(generator.CycleAmount, true)} / {time}";
                 }


### PR DESCRIPTION
## Summary
- show collection time without seconds decimals when a disciple's interval is a minute or more

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892d501fcf4832eb3855e349784366c