### PR TITLE
feat: remove overlapping decor around tasks

### DIFF
--- a/Assets/Scripts/MapGeneration/SegmentedMapGenerator.cs
+++ b/Assets/Scripts/MapGeneration/SegmentedMapGenerator.cs
@@ -110,7 +110,15 @@ namespace TimelessEchoes.MapGeneration
             var minX = Mathf.Max(taskGenerator.MinX, offset.x);
             var maxX = offset.x + segmentSize.x;
             if (maxX > minX)
+            {
                 taskGenerator.GenerateSegment(minX, maxX, tasksRoot.transform);
+
+                foreach (var task in taskGenerator.Controller.TaskObjects)
+                {
+                    if (task != null && task.transform.IsChildOf(tasksRoot.transform))
+                        chunkGenerator.ClearDecorAtPosition(task.transform.position);
+                }
+            }
 
             segments.Enqueue(new Segment { startX = offset.x, tasks = tasksRoot, decor = decorRoot });
             nextSegmentX += segmentSize.x;

--- a/Assets/Scripts/MapGeneration/TilemapChunkGenerator.cs
+++ b/Assets/Scripts/MapGeneration/TilemapChunkGenerator.cs
@@ -59,6 +59,7 @@ namespace TimelessEchoes.MapGeneration
         private Random rng;
         private int prevSandDepth = -1;
         private int prevGrassDepth = -1;
+        private Transform currentDecorParent;
         public Tilemap TerrainMap => terrainMap;
         private BetterRuleTile BottomTile => bottomTerrain != null ? bottomTerrain.tile : null;
         private BetterRuleTile MiddleTile => middleTerrain != null ? middleTerrain.tile : null;
@@ -106,7 +107,28 @@ namespace TimelessEchoes.MapGeneration
         {
             rng = randomizeSeed ? new Random() : new Random(seed);
 
+            currentDecorParent = decorParent;
             GenerateInternal(offset, segmentSize, decorParent);
+        }
+
+        public void ClearDecorAtPosition(Vector3 pos)
+        {
+            if (decorMap != null)
+            {
+                var cell = decorMap.WorldToCell(pos);
+                decorMap.SetTile(cell, null);
+                decorMap.SetTransformMatrix(cell, Matrix4x4.identity);
+            }
+
+            if (currentDecorParent == null)
+                return;
+
+            for (var i = currentDecorParent.childCount - 1; i >= 0; i--)
+            {
+                var child = currentDecorParent.GetChild(i);
+                if (Vector3.Distance(child.position, pos) < 0.1f)
+                    Destroy(child.gameObject);
+            }
         }
 
         private void GenerateInternal(Vector2Int offset, Vector2Int segmentSize, Transform decorParent)


### PR DESCRIPTION
## Summary
- add TilemapChunkGenerator.ClearDecorAtPosition to purge decor tiles and prefabs
- clear decor at new task positions within CreateSegment

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689312a34df8832e91e683e40c05322e