### PR TITLE
Sort noticeboard quests by readiness

### DIFF
--- a/Assets/Scripts/Quests/QuestManager.cs
+++ b/Assets/Scripts/Quests/QuestManager.cs
@@ -3,6 +3,7 @@
 #endif
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using Blindsided.SaveData;
 using TimelessEchoes.Buffs;
 using TimelessEchoes.Enemies;
@@ -461,6 +462,10 @@ namespace TimelessEchoes.Quests
                 return;
             uiManager.Clear();
             foreach (var inst in active.Values)
+                UpdateProgress(inst);
+
+            var ordered = active.Values.OrderByDescending(q => q.ReadyForTurnIn);
+            foreach (var inst in ordered)
             {
                 inst.ui = uiManager.CreateEntry(inst.data, () => CompleteQuest(inst));
                 UpdateProgress(inst);


### PR DESCRIPTION
## Summary
- Compute progress for active quests before creating noticeboard entries
- Order active quests by ReadyForTurnIn so ready quests appear first

## Testing
- `dotnet test` *(fails: MSB1003 no project)*

------
https://chatgpt.com/codex/tasks/task_e_6893f8490674832e961c31aab93b01d3