### PR TITLE
Expose echo duration bar for echoes

### DIFF
--- a/Assets/Scripts/Hero/EchoController.cs
+++ b/Assets/Scripts/Hero/EchoController.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using TimelessEchoes.Skills;
 using TimelessEchoes.Tasks;
 using UnityEngine;
+using UnityEngine.UI;
 
 namespace TimelessEchoes.Hero
 {
@@ -27,6 +28,8 @@ namespace TimelessEchoes.Hero
         private TaskController taskController;
         private float remaining;
         private float defaultAggroRange;
+        private GameObject durationBarParent;
+        private Image durationFill;
 
         /// <summary>
         ///     Returns true once <see cref="Init" /> has completed.
@@ -65,6 +68,8 @@ namespace TimelessEchoes.Hero
         {
             CombatEchoes.Remove(this);
             AllEchoes.Remove(this);
+            if (durationBarParent != null)
+                durationBarParent.SetActive(false);
             if (hero != null)
             {
                 hero.UnlimitedAggroRange = false;
@@ -93,6 +98,12 @@ namespace TimelessEchoes.Hero
                 hero.UnlimitedAggroRange = combatOnly;
                 if (combatOnly)
                     hero.CombatAggroRange = defaultAggroRange;
+                durationBarParent = hero.EchoDurationBar;
+                durationFill = hero.EchoDurationFill;
+                if (durationBarParent != null)
+                    durationBarParent.SetActive(true);
+                if (durationFill != null)
+                    durationFill.fillAmount = 1f;
             }
 
             Initialized = true;
@@ -114,6 +125,8 @@ namespace TimelessEchoes.Hero
                 Destroy(gameObject);
                 return;
             }
+            if (durationBarParent != null && durationBarParent.activeSelf && durationFill != null)
+                durationFill.fillAmount = remaining / lifetime;
 
             if (!disableSkills && taskController != null)
             {
@@ -150,6 +163,8 @@ namespace TimelessEchoes.Hero
         {
             CombatEchoes.Remove(this);
             AllEchoes.Remove(this);
+            if (durationBarParent != null)
+                durationBarParent.SetActive(false);
             if (hero != null)
             {
                 hero.UnlimitedAggroRange = false;

--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -14,6 +14,7 @@ using TimelessEchoes.Stats;
 using TimelessEchoes.Tasks;
 using TimelessEchoes.UI;
 using TimelessEchoes.Upgrades;
+using Blindsided.Utilities;
 using UnityEngine;
 using UnityEngine.Serialization;
 using static TimelessEchoes.TELogger;
@@ -60,6 +61,8 @@ namespace TimelessEchoes.Hero
         [SerializeField] private GameObject fishingIndicator;
         [SerializeField] private GameObject farmingIndicator;
         [SerializeField] private GameObject lootingIndicator;
+        [SerializeField] private GameObject echoDurationBar;
+        [SerializeField] private SlicedFilledImage echoDurationFill;
 
         public GameObject CombatIndicator => combatIndicator;
         public GameObject MiningIndicator => miningIndicator;
@@ -67,6 +70,8 @@ namespace TimelessEchoes.Hero
         public GameObject FishingIndicator => fishingIndicator;
         public GameObject FarmingIndicator => farmingIndicator;
         public GameObject LootingIndicator => lootingIndicator;
+        public GameObject EchoDurationBar => echoDurationBar;
+        public SlicedFilledImage EchoDurationFill => echoDurationFill;
         private bool diceUnlocked;
         [SerializeField] private BuffManager buffController;
         [SerializeField] private LayerMask enemyMask = ~0;


### PR DESCRIPTION
## Summary
- Expose echo duration bar and fill references on `HeroController`
- Cache and activate the bar in `EchoController`, updating its fill amount over time
- Hide the bar when echoes disable or are destroyed to avoid leftover UI

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_6894219a673c832e8e1145468aab155d