### PR TITLE
Pass buff remaining time to echoes and hide infinite timers

### DIFF
--- a/Assets/Scripts/Buffs/BuffManager.cs
+++ b/Assets/Scripts/Buffs/BuffManager.cs
@@ -204,7 +204,7 @@ namespace TimelessEchoes.Buffs
             var echoCount = recipe.GetEchoCount();
             if (recipe.echoConfig != null && echoCount > 0)
             {
-                var spawned = EchoManager.SpawnEchoes(recipe.echoConfig, float.PositiveInfinity,
+                var spawned = EchoManager.SpawnEchoes(recipe.echoConfig, buff.remaining,
                     null, false, echoCount);
                 foreach (var c in spawned)
                     if (c != null)

--- a/Assets/Scripts/Hero/EchoController.cs
+++ b/Assets/Scripts/Hero/EchoController.cs
@@ -101,8 +101,8 @@ namespace TimelessEchoes.Hero
                 durationBarParent = hero.EchoDurationBar;
                 durationFill = hero.EchoDurationFill;
                 if (durationBarParent != null)
-                    durationBarParent.SetActive(true);
-                if (durationFill != null)
+                    durationBarParent.SetActive(!float.IsPositiveInfinity(duration));
+                if (durationFill != null && !float.IsPositiveInfinity(duration))
                     durationFill.fillAmount = 1f;
             }
 
@@ -125,7 +125,8 @@ namespace TimelessEchoes.Hero
                 Destroy(gameObject);
                 return;
             }
-            if (durationBarParent != null && durationBarParent.activeSelf && durationFill != null)
+            if (durationBarParent != null && durationBarParent.activeSelf && durationFill != null &&
+                !float.IsPositiveInfinity(lifetime))
                 durationFill.fillAmount = remaining / lifetime;
 
             if (!disableSkills && taskController != null)


### PR DESCRIPTION
## Summary
- Spawn echoes for buffs using each buff's actual remaining time
- Hide duration bar for echoes with infinite lifetime and guard against NaN fill values

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68942c627878832e90a2aa0ef91ef85c