### PR TITLE
Track map type for runs

### DIFF
--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -167,6 +167,7 @@ namespace Blindsided.SaveData
         public class RunRecord
         {
             public int RunNumber;
+            public string MapType;
             public float Duration;
             public float Distance;
             public int TasksCompleted;

--- a/Assets/Scripts/References/UI/RunStatUIReferences.cs
+++ b/Assets/Scripts/References/UI/RunStatUIReferences.cs
@@ -9,6 +9,7 @@ namespace TimelessEchoes.References.UI
     public class RunStatUIReferences : MonoBehaviour
     {
         public TMP_Text runIdText;
+        public TMP_Text mapTypeText;
         public TMP_Text distanceTasksResourcesText;
         public TMP_Text killsDamageDoneDamageTakenText;
         public TMP_Text statusText;

--- a/Assets/Scripts/Stats/GameplayStatTracker.cs
+++ b/Assets/Scripts/Stats/GameplayStatTracker.cs
@@ -441,6 +441,7 @@ namespace TimelessEchoes.Stats
             var record = new GameData.RunRecord
             {
                 RunNumber = nextRunNumber,
+                MapType = currentMapKey,
                 Duration = duration,
                 Distance = CurrentRunDistance,
                 TasksCompleted = currentRunTasks,
@@ -475,6 +476,7 @@ namespace TimelessEchoes.Stats
             var record = new GameData.RunRecord
             {
                 RunNumber = nextRunNumber,
+                MapType = currentMapKey,
                 Duration = duration,
                 Distance = CurrentRunDistance,
                 TasksCompleted = currentRunTasks,

--- a/Assets/Scripts/UI/RunStatsPanelUI.cs
+++ b/Assets/Scripts/UI/RunStatsPanelUI.cs
@@ -166,6 +166,12 @@ namespace TimelessEchoes.UI
             if (runStatUI.runIdText != null)
                 runStatUI.runIdText.text = $"Trek {record.RunNumber}";
 
+            if (runStatUI.mapTypeText != null)
+            {
+                var mapType = string.IsNullOrEmpty(record.MapType) ? "Unknown" : record.MapType;
+                runStatUI.mapTypeText.text = $"Map: {mapType}";
+            }
+
             if (runStatUI.distanceTasksResourcesText != null)
             {
                 var time = CalcUtils.FormatTime(record.Duration);


### PR DESCRIPTION
## Summary
- record map type in run records
- include map type when a run ends or is abandoned
- surface map type in run stats panel UI

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68951cac8364832e9ffe46ce93aab09f