### PR TITLE
Add max distance buff and UI tracking

### DIFF
--- a/Assets/Scripts/Buffs/BuffRecipe.cs
+++ b/Assets/Scripts/Buffs/BuffRecipe.cs
@@ -151,6 +151,8 @@ namespace TimelessEchoes.Buffs
                 lines.Add($"Echoes: {echoCount}");
             if (durationType == BuffDurationType.DistancePercent)
                 lines.Add($"Distance: {Mathf.CeilToInt(GetDuration() * 100f)}%");
+            else if (durationType == BuffDurationType.ExtraDistancePercent)
+                lines.Add($"Extra Distance: {Mathf.CeilToInt(GetDuration() * 100f)}%");
             else
                 lines.Add($"Duration: {CalcUtils.FormatTime(GetDuration(), shortForm: true)}");
             return lines;
@@ -166,6 +168,7 @@ namespace TimelessEchoes.Buffs
                 BuffEffectType.AttackSpeedPercent => $"Attack Speed +{eff.value}%",
                 BuffEffectType.TaskSpeedPercent => $"Task Speed +{eff.value}%",
                 BuffEffectType.LifestealPercent => $"Lifesteal {eff.value}%",
+                BuffEffectType.MaxDistancePercent => $"Max Reap Distance +{eff.value}%",
                 BuffEffectType.InstantTasks => "Tasks complete instantly",
                 _ => string.Empty
             };

--- a/Assets/Scripts/Buffs/BuffTypes.cs
+++ b/Assets/Scripts/Buffs/BuffTypes.cs
@@ -12,13 +12,15 @@ namespace TimelessEchoes.Buffs
         AttackSpeedPercent,
         TaskSpeedPercent,
         LifestealPercent,
+        MaxDistancePercent,
         InstantTasks
     }
 
     public enum BuffDurationType
     {
         Time,
-        DistancePercent
+        DistancePercent,
+        ExtraDistancePercent
     }
 
     [Serializable]

--- a/Assets/Scripts/Enemies/ReaperManager.cs
+++ b/Assets/Scripts/Enemies/ReaperManager.cs
@@ -117,7 +117,9 @@ namespace TimelessEchoes.Enemies
             // increase that maximum by 1% for future runs.
             if (heroCtrl != null && heroCtrl.ReaperSpawnedByDistance && tracker != null)
             {
-                var increase = tracker.MaxRunDistance * 0.01f;
+                var buff = BuffManager.Instance ?? FindFirstObjectByType<BuffManager>();
+                var buffedMax = tracker.MaxRunDistance * (buff != null ? buff.MaxDistanceMultiplier : 1f);
+                var increase = buffedMax * 0.01f;
                 tracker.IncreaseMaxRunDistance(increase);
             }
 

--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -268,7 +268,8 @@ namespace TimelessEchoes.Hero
 #if !DISABLESTEAMWORKS
                 RichPresenceManager.Instance?.UpdateDistance(tracker.CurrentRunDistance);
 #endif
-                if (!IsEcho && !ReaperSpawnedByDistance && transform.position.x >= tracker.MaxRunDistance)
+                if (!IsEcho && !ReaperSpawnedByDistance &&
+                    transform.position.x >= tracker.MaxRunDistance * (buffController != null ? buffController.MaxDistanceMultiplier : 1f))
                 {
                     var gm = GameManager.Instance;
                     var hp = health != null ? health : GetComponent<HeroHealth>();

--- a/Assets/Scripts/References/UI/BuffSlotUIReferences.cs
+++ b/Assets/Scripts/References/UI/BuffSlotUIReferences.cs
@@ -3,6 +3,7 @@ using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.EventSystems;
+using MPUIKIT;
 
 namespace References.UI
 {
@@ -12,6 +13,7 @@ namespace References.UI
         public Image iconImage;
         public TMP_Text durationText;
         public Image autoCastImage;
+        public MPImageBasic radialFillImage;
 
         public event Action<BuffSlotUIReferences> PointerEnter;
         public event Action<BuffSlotUIReferences> PointerExit;

--- a/Assets/Scripts/UI/MapUI.cs
+++ b/Assets/Scripts/UI/MapUI.cs
@@ -1,3 +1,4 @@
+using TimelessEchoes.Buffs;
 using TimelessEchoes.Stats;
 using TMPro;
 using UnityEngine;
@@ -29,7 +30,10 @@ namespace TimelessEchoes.UI
             if (distanceSlider != null)
             {
                 var tracker = GameplayStatTracker.Instance;
-                var max = tracker != null ? tracker.MaxRunDistance : 1f;
+                var buff = BuffManager.Instance;
+                var max = tracker != null
+                    ? tracker.MaxRunDistance * (buff != null ? buff.MaxDistanceMultiplier : 1f)
+                    : 1f;
                 distanceSlider.value = Mathf.Clamp01(distance / max);
             }
         }


### PR DESCRIPTION
## Summary
- Support max distance buffs via new `MaxDistancePercent` effect and `ExtraDistancePercent` duration, with descriptions and multiplier aggregation
- Apply buffed max distance to gameplay, UI slider, and reap-based max distance increases
- Expose radial fill images and display bonus-distance progress for buffs extending max distance

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689530197bf8832eb2ce04f720cfcab9