### PR TITLE
feat: extend distance buffs with flat bonuses

### DIFF
--- a/Assets/Scripts/Buffs/BuffManager.cs
+++ b/Assets/Scripts/Buffs/BuffManager.cs
@@ -176,7 +176,8 @@ namespace TimelessEchoes.Buffs
                 }
                 else if (recipe.durationType == BuffDurationType.ExtraDistancePercent)
                 {
-                    var expireDist = tracker.MaxRunDistance * (1f + recipe.GetDuration());
+                    var baseMax = tracker.MaxRunDistance;
+                    var expireDist = baseMax + recipe.GetExtraDistance(baseMax);
                     if (tracker.CurrentRunDistance >= expireDist)
                         return false;
                 }
@@ -202,7 +203,10 @@ namespace TimelessEchoes.Buffs
                 if (recipe.durationType == BuffDurationType.DistancePercent)
                     expireDist = tracker.LongestRun * recipe.GetDuration();
                 else if (recipe.durationType == BuffDurationType.ExtraDistancePercent)
-                    expireDist = tracker.MaxRunDistance * (1f + recipe.GetDuration());
+                {
+                    var baseMax = tracker.MaxRunDistance;
+                    expireDist = baseMax + recipe.GetExtraDistance(baseMax);
+                }
             }
 
             var buff = new ActiveBuff
@@ -325,6 +329,19 @@ namespace TimelessEchoes.Buffs
                         if (eff.type == BuffEffectType.MaxDistancePercent)
                             percent += eff.value;
                 return 1f + percent / 100f;
+            }
+        }
+
+        public float MaxDistanceFlatBonus
+        {
+            get
+            {
+                var flat = 0f;
+                foreach (var b in activeBuffs)
+                    foreach (var eff in b.effects)
+                        if (eff.type == BuffEffectType.MaxDistanceIncrease)
+                            flat += eff.value;
+                return flat;
             }
         }
 

--- a/Assets/Scripts/Buffs/BuffTypes.cs
+++ b/Assets/Scripts/Buffs/BuffTypes.cs
@@ -13,6 +13,7 @@ namespace TimelessEchoes.Buffs
         TaskSpeedPercent,
         LifestealPercent,
         MaxDistancePercent,
+        MaxDistanceIncrease,
         InstantTasks
     }
 

--- a/Assets/Scripts/Buffs/BuffUIManager.cs
+++ b/Assets/Scripts/Buffs/BuffUIManager.cs
@@ -93,7 +93,8 @@ namespace TimelessEchoes.Buffs
                     }
                     else if (recipe.durationType == BuffDurationType.ExtraDistancePercent)
                     {
-                        expireDist = tracker.MaxRunDistance * (1f + recipe.GetDuration());
+                        expireDist = tracker.MaxRunDistance +
+                                     recipe.GetExtraDistance(tracker.MaxRunDistance);
                         distanceOk = tracker.CurrentRunDistance < expireDist;
                     }
                 }
@@ -138,10 +139,12 @@ namespace TimelessEchoes.Buffs
                                 ui.durationText.text = string.Empty;
                         }
                         else if (recipe != null && tracker != null && recipe.durationType == BuffDurationType.ExtraDistancePercent &&
-                                 recipe.GetAggregatedEffects().Exists(e => e.type == BuffEffectType.MaxDistancePercent))
+                                 recipe.GetAggregatedEffects().Exists(e => e.type == BuffEffectType.MaxDistancePercent ||
+                                                                            e.type == BuffEffectType.MaxDistanceIncrease))
                         {
                             var baseMax = tracker.MaxRunDistance;
-                            var buffedMax = baseMax * (buffManager != null ? buffManager.MaxDistanceMultiplier : 1f);
+                            var buffedMax = baseMax * (buffManager != null ? buffManager.MaxDistanceMultiplier : 1f) +
+                                            (buffManager != null ? buffManager.MaxDistanceFlatBonus : 0f);
                             var totalPercent = baseMax > 0f ? tracker.CurrentRunDistance / baseMax : 0f;
                             var bonusPercent = buffedMax > baseMax
                                 ? (tracker.CurrentRunDistance - baseMax) / (buffedMax - baseMax)

--- a/Assets/Scripts/Enemies/ReaperManager.cs
+++ b/Assets/Scripts/Enemies/ReaperManager.cs
@@ -118,7 +118,8 @@ namespace TimelessEchoes.Enemies
             if (heroCtrl != null && heroCtrl.ReaperSpawnedByDistance && tracker != null)
             {
                 var buff = BuffManager.Instance ?? FindFirstObjectByType<BuffManager>();
-                var buffedMax = tracker.MaxRunDistance * (buff != null ? buff.MaxDistanceMultiplier : 1f);
+                var buffedMax = tracker.MaxRunDistance * (buff != null ? buff.MaxDistanceMultiplier : 1f) +
+                                (buff != null ? buff.MaxDistanceFlatBonus : 0f);
                 var increase = buffedMax * 0.01f;
                 tracker.IncreaseMaxRunDistance(increase);
             }

--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -269,7 +269,9 @@ namespace TimelessEchoes.Hero
                 RichPresenceManager.Instance?.UpdateDistance(tracker.CurrentRunDistance);
 #endif
                 if (!IsEcho && !ReaperSpawnedByDistance &&
-                    transform.position.x >= tracker.MaxRunDistance * (buffController != null ? buffController.MaxDistanceMultiplier : 1f))
+                    transform.position.x >= tracker.MaxRunDistance *
+                        (buffController != null ? buffController.MaxDistanceMultiplier : 1f) +
+                        (buffController != null ? buffController.MaxDistanceFlatBonus : 0f))
                 {
                     var gm = GameManager.Instance;
                     var hp = health != null ? health : GetComponent<HeroHealth>();

--- a/Assets/Scripts/UI/MapUI.cs
+++ b/Assets/Scripts/UI/MapUI.cs
@@ -32,7 +32,8 @@ namespace TimelessEchoes.UI
                 var tracker = GameplayStatTracker.Instance;
                 var buff = BuffManager.Instance;
                 var max = tracker != null
-                    ? tracker.MaxRunDistance * (buff != null ? buff.MaxDistanceMultiplier : 1f)
+                    ? tracker.MaxRunDistance * (buff != null ? buff.MaxDistanceMultiplier : 1f) +
+                      (buff != null ? buff.MaxDistanceFlatBonus : 0f)
                     : 1f;
                 distanceSlider.value = Mathf.Clamp01(distance / max);
             }


### PR DESCRIPTION
## Summary
- add `MaxDistanceIncrease` effect type and extra-distance effect lists
- calculate extra run distance from percent and flat bonuses
- apply combined distance buffs across manager, UI, and gameplay

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: package has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_68953a257648832e8ce39b946ce6373e