### PR TITLE
Refine extra distance buff behavior

### DIFF
--- a/Assets/Scripts/Buffs/BuffRecipe.cs
+++ b/Assets/Scripts/Buffs/BuffRecipe.cs
@@ -45,9 +45,11 @@ namespace TimelessEchoes.Buffs
         public QuestData requiredQuest;
 
         [TitleGroup("Effects")]
+        [HideIf("@durationType == BuffDurationType.ExtraDistancePercent")]
         public List<BuffEffect> baseEffects = new();
 
         [TitleGroup("Upgrades")]
+        [HideIf("@durationType == BuffDurationType.ExtraDistancePercent")]
         public List<BuffUpgrade> upgrades = new();
 
         [TitleGroup("Extra Distance")]
@@ -68,7 +70,8 @@ namespace TimelessEchoes.Buffs
             var level = 0;
             var qm = QuestManager.Instance ?? UnityEngine.Object.FindFirstObjectByType<QuestManager>();
             if (qm == null) return 0;
-            foreach (var up in upgrades)
+            var upgradeList = durationType == BuffDurationType.ExtraDistancePercent ? extraDistanceUpgrades : upgrades;
+            foreach (var up in upgradeList)
             {
                 if (up?.quest != null && qm.IsQuestCompleted(up.quest))
                     level++;
@@ -79,27 +82,20 @@ namespace TimelessEchoes.Buffs
         public List<BuffEffect> GetAggregatedEffects()
         {
             var dict = new Dictionary<BuffEffectType, float>();
-            foreach (var eff in baseEffects)
+            var effList = durationType == BuffDurationType.ExtraDistancePercent ? extraDistanceEffects : baseEffects;
+            foreach (var eff in effList)
             {
                 if (dict.ContainsKey(eff.type))
                     dict[eff.type] += eff.value;
                 else
                     dict[eff.type] = eff.value;
             }
-            if (durationType == BuffDurationType.ExtraDistancePercent)
-            {
-                foreach (var eff in extraDistanceEffects)
-                {
-                    if (dict.ContainsKey(eff.type))
-                        dict[eff.type] += eff.value;
-                    else
-                        dict[eff.type] = eff.value;
-                }
-            }
+
             var qm = QuestManager.Instance ?? UnityEngine.Object.FindFirstObjectByType<QuestManager>();
             if (qm != null)
             {
-                foreach (var up in upgrades)
+                var upgradeList = durationType == BuffDurationType.ExtraDistancePercent ? extraDistanceUpgrades : upgrades;
+                foreach (var up in upgradeList)
                 {
                     if (up?.quest == null || !qm.IsQuestCompleted(up.quest))
                         continue;
@@ -109,21 +105,6 @@ namespace TimelessEchoes.Buffs
                             dict[eff.type] += eff.value;
                         else
                             dict[eff.type] = eff.value;
-                    }
-                }
-                if (durationType == BuffDurationType.ExtraDistancePercent)
-                {
-                    foreach (var up in extraDistanceUpgrades)
-                    {
-                        if (up?.quest == null || !qm.IsQuestCompleted(up.quest))
-                            continue;
-                        foreach (var eff in up.additionalEffects)
-                        {
-                            if (dict.ContainsKey(eff.type))
-                                dict[eff.type] += eff.value;
-                            else
-                                dict[eff.type] = eff.value;
-                        }
                     }
                 }
             }

--- a/Assets/Scripts/Buffs/BuffUIManager.cs
+++ b/Assets/Scripts/Buffs/BuffUIManager.cs
@@ -152,7 +152,7 @@ namespace TimelessEchoes.Buffs
                             if (tracker.CurrentRunDistance > baseMax)
                                 ui.durationText.text = $"{Mathf.FloorToInt(totalPercent * 100f)}%";
                             else
-                                ui.durationText.text = string.Empty;
+                                ui.durationText.text = "Active";
                             if (ui.radialFillImage != null)
                                 ui.radialFillImage.fillAmount = Mathf.Clamp01(bonusPercent);
                         }


### PR DESCRIPTION
## Summary
- Hide base effects and upgrades when duration type is set to ExtraDistancePercent
- Ensure extra distance buffs use only their special effects and upgrades
- Display "Active" for extra distance buffs before the extra distance threshold is reached

## Testing
- `dotnet build` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*


------
https://chatgpt.com/codex/tasks/task_e_68953f749fe0832e84348c7881145dd5