### PR TITLE
Improve buff UI countdown and update efficiency

### DIFF
--- a/Assets/Scripts/References/UI/BuffSlotUIReferences.cs
+++ b/Assets/Scripts/References/UI/BuffSlotUIReferences.cs
@@ -15,6 +15,12 @@ namespace References.UI
         public Image autoCastImage;
         public MPImageBasic radialFillImage;
 
+        private void Awake()
+        {
+            if (radialFillImage != null)
+                radialFillImage.StrokeWidth = 1f;
+        }
+
         public event Action<BuffSlotUIReferences> PointerEnter;
         public event Action<BuffSlotUIReferences> PointerExit;
 


### PR DESCRIPTION
## Summary
- Show remaining extra distance for buffs and drive radial fills from full to empty
- Initialize buff slot radial stroke width to prevent resets
- Skip buff UI updates when the window is hidden

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68954676f1f4832e84c9b0031e732db7