### PR TITLE
Reverse reap distance radial fill

### DIFF
--- a/Assets/Scripts/Buffs/BuffUIManager.cs
+++ b/Assets/Scripts/Buffs/BuffUIManager.cs
@@ -162,7 +162,6 @@ namespace TimelessEchoes.Buffs
                                 var baseMax = tracker.MaxRunDistance;
                                 var totalExtra = expireDist - baseMax;
                                 var remainExtra = expireDist - tracker.CurrentRunDistance;
-                                var usedExtra = Mathf.Max(0f, tracker.CurrentRunDistance - baseMax);
                                 if (tracker.CurrentRunDistance < baseMax)
                                 {
                                     ui.durationText.text = "Active";
@@ -173,8 +172,9 @@ namespace TimelessEchoes.Buffs
                                 {
                                     ui.durationText.text = FormatNumber(remainExtra, true);
                                     if (ui.radialFillImage != null)
+                                        // Use remaining distance so the radial fill drains instead of grows.
                                         ui.radialFillImage.fillAmount = totalExtra > 0f
-                                            ? Mathf.Clamp01(usedExtra / totalExtra)
+                                            ? Mathf.Clamp01(remainExtra / totalExtra)
                                             : 0f;
                                 }
                                 else


### PR DESCRIPTION
## Summary
- Reverse the extra distance buff radial fill so it drains as remaining distance decreases

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68954ed7507c832ea7028f35725353e9