### PR TITLE
Display spawn distance in task stats entries

### DIFF
--- a/Assets/Prefabs/UI/Stats/TaskEntry.prefab
+++ b/Assets/Prefabs/UI/Stats/TaskEntry.prefab
@@ -129,6 +129,7 @@ MonoBehaviour:
   entryIDText: {fileID: 949700655226611025}
   entryNameText: {fileID: 9118106661275263825}
   entryCompletionsTimeOnTaskExperienceText: {fileID: 3455198727293779481}
+  entrySpawnDistanceText: {fileID: 8405256825568168057}
 --- !u!114 &6383340080225041462
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/References/StatPanel/TaskStatEntryUIReferences.cs
+++ b/Assets/Scripts/References/StatPanel/TaskStatEntryUIReferences.cs
@@ -10,5 +10,6 @@ namespace TimelessEchoes.References.StatPanel
         public TMP_Text entryIDText;
         public TMP_Text entryNameText;
         public TMP_Text entryCompletionsTimeOnTaskExperienceText;
+        public TMP_Text entrySpawnDistanceText;
     }
 }

--- a/Assets/Scripts/UI/TaskStatsPanelUI.cs
+++ b/Assets/Scripts/UI/TaskStatsPanelUI.cs
@@ -127,6 +127,14 @@ namespace TimelessEchoes.UI
                 ui.entryCompletionsTimeOnTaskExperienceText.text =
                     $"Completions: {comp}\nTime on Task: {timeStr}\nXP Gained: {xpStr}";
             }
+
+            if (ui.entrySpawnDistanceText != null)
+            {
+                var minStr = CalcUtils.FormatNumber(data.minX, true);
+                var maxStr = CalcUtils.FormatNumber(data.maxX, true);
+                ui.entrySpawnDistanceText.text =
+                    $"Minimum Spawn Distance: {minStr}\nMaximum Spawn Distance: {maxStr}";
+            }
         }
 
         private void SortEntries()


### PR DESCRIPTION
## Summary
- expose a new TMP_Text reference for spawn distance in task stat entries
- fill spawn distance info in `TaskStatsPanelUI` using formatted task bounds
- hook up the prefab reference for the new spawn distance text

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68955eaa2cbc832ebb4617029f83f394