### PR TITLE
Hide spawn distances for unknown stats entries

### DIFF
--- a/Assets/Scripts/UI/ItemStatsPanelUI.cs
+++ b/Assets/Scripts/UI/ItemStatsPanelUI.cs
@@ -177,9 +177,18 @@ namespace TimelessEchoes.UI
                     oracle.saveData.Resources != null &&
                     oracle.saveData.Resources.TryGetValue(res.name, out var record))
                     best = record.BestPerMinute;
-                var minDist = minDistanceLookup.TryGetValue(res, out var d) ? d : 0f;
-                ui.bestPerMinuteText.text =
-                    $"Min Distance: {CalcUtils.FormatNumber(minDist)}\nAE Power: {CalcUtils.FormatNumber(best)}";
+
+                if (earned)
+                {
+                    var minDist = minDistanceLookup.TryGetValue(res, out var d) ? d : 0f;
+                    ui.bestPerMinuteText.text =
+                        $"Min Distance: {CalcUtils.FormatNumber(minDist)}\nAE Power: {CalcUtils.FormatNumber(best)}";
+                }
+                else
+                {
+                    ui.bestPerMinuteText.text =
+                        $"Min Distance: ???\nAE Power: {CalcUtils.FormatNumber(best)}";
+                }
             }
         }
 

--- a/Assets/Scripts/UI/TaskStatsPanelUI.cs
+++ b/Assets/Scripts/UI/TaskStatsPanelUI.cs
@@ -130,10 +130,18 @@ namespace TimelessEchoes.UI
 
             if (ui.entrySpawnDistanceText != null)
             {
-                var minStr = CalcUtils.FormatNumber(data.minX, true);
-                var maxStr = CalcUtils.FormatNumber(data.maxX, true);
-                ui.entrySpawnDistanceText.text =
-                    $"Minimum Spawn Distance: {minStr}\nMaximum Spawn Distance: {maxStr}";
+                if (completed > 0)
+                {
+                    var minStr = CalcUtils.FormatNumber(data.minX, true);
+                    var maxStr = CalcUtils.FormatNumber(data.maxX, true);
+                    ui.entrySpawnDistanceText.text =
+                        $"Minimum Spawn Distance: {minStr}\nMaximum Spawn Distance: {maxStr}";
+                }
+                else
+                {
+                    ui.entrySpawnDistanceText.text =
+                        "Minimum Spawn Distance: ???\nMaximum Spawn Distance: ???";
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- Replace task spawn distance values with placeholders when tasks haven't been completed
- Display unknown marker for item min distance when the item hasn't been collected

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68956aa53474832e90c6fc68ef9a906a