### PR TITLE
Show decimals for short buff timers

### DIFF
--- a/Assets/Scripts/Buffs/BuffUIManager.cs
+++ b/Assets/Scripts/Buffs/BuffUIManager.cs
@@ -198,7 +198,7 @@ namespace TimelessEchoes.Buffs
                         else
                         {
                             ui.durationText.text = remain > 0f
-                                ? FormatTime(remain, shortForm: true)
+                                ? FormatTime(remain, showDecimal: remain < 10f, shortForm: true)
                                 : string.Empty;
                             if (ui.radialFillImage != null)
                                 ui.radialFillImage.fillAmount = remain > 0f && recipe != null


### PR DESCRIPTION
## Summary
- Display buff timer decimals when remaining time is under 10s

## Testing
- `mcs Assets/Scripts/Buffs/BuffUIManager.cs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68956bec4fc0832eb54bb68a1bdeb1b6