### PR TITLE
Enable desktop hotkeys for buff activation

### DIFF
--- a/Assets/Scripts/Buffs/BuffUIManager.cs
+++ b/Assets/Scripts/Buffs/BuffUIManager.cs
@@ -270,6 +270,19 @@ namespace TimelessEchoes.Buffs
 
             RefreshSlots();
 
+            if (!Application.isMobilePlatform && buffManager != null)
+            {
+                for (var i = 0; i < 5; i++)
+                {
+                    if (Input.GetKeyDown(KeyCode.Alpha1 + i))
+                    {
+                        var recipe = buffManager.GetAssigned(i);
+                        if (recipe != null && buffManager.CanActivate(recipe))
+                            buffManager.ActivateSlot(i);
+                    }
+                }
+            }
+
             foreach (var pair in recipeEntries)
             {
                 var panel = pair.Value;


### PR DESCRIPTION
## Summary
- Allow desktop players to trigger assigned buff slots with number keys 1-5

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689579e25c3c832e8888a9174c1c9ebe