### PR TITLE
Use saved FPS value for target frame rate

### DIFF
--- a/Assets/Scripts/Blindsided/Oracle.cs
+++ b/Assets/Scripts/Blindsided/Oracle.cs
@@ -78,8 +78,10 @@ namespace Blindsided
 
         private void Start()
         {
-            Application.targetFrameRate = (int)Screen.currentResolution.refreshRateRatio.value;
             Load();
+            if (StaticReferences.TargetFps <= 0)
+                StaticReferences.TargetFps = (int)Screen.currentResolution.refreshRateRatio.value;
+            Application.targetFrameRate = StaticReferences.TargetFps;
             StartCoroutine(LoadMainScene());
             InvokeRepeating(nameof(SaveToFile), 10, 10);
         }


### PR DESCRIPTION
## Summary
- load saved preferences before setting frame rate in `Oracle`
- fall back to monitor refresh rate only if no FPS preference exists

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_6896a16ea370832ea5a16d120ae36f25