### PR TITLE
Use pooled projectiles

### DIFF
--- a/Assets/Scripts/Enemies/Enemy.cs
+++ b/Assets/Scripts/Enemies/Enemy.cs
@@ -16,6 +16,7 @@ using System.Linq;
 using static TimelessEchoes.TELogger;
 using Random = UnityEngine.Random;
 using static Blindsided.Oracle;
+using Blindsided.Utilities.Pooling;
 
 namespace TimelessEchoes.Enemies
 {
@@ -308,7 +309,9 @@ namespace TimelessEchoes.Enemies
         {
             if (stats.projectilePrefab == null || setter.target == null) return;
             var origin = projectileOrigin ? projectileOrigin : transform;
-            var projObj = Instantiate(stats.projectilePrefab, origin.position, Quaternion.identity);
+            var projObj = PoolManager.Get(stats.projectilePrefab);
+            projObj.transform.position = origin.position;
+            projObj.transform.rotation = Quaternion.identity;
             var proj = projObj.GetComponent<Projectile>();
             if (proj != null)
                 proj.Init(setter.target, stats.GetDamageForLevel(level));

--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -15,6 +15,7 @@ using TimelessEchoes.Tasks;
 using TimelessEchoes.UI;
 using TimelessEchoes.Upgrades;
 using Blindsided.Utilities;
+using Blindsided.Utilities.Pooling;
 using UnityEngine;
 using UnityEngine.Serialization;
 using static TimelessEchoes.TELogger;
@@ -886,7 +887,9 @@ namespace TimelessEchoes.Hero
                 AutoBuffAnimator.Play("Attack");
 
             var origin = projectileOrigin ? projectileOrigin : transform;
-            var projObj = Instantiate(stats.projectilePrefab, origin.position, Quaternion.identity);
+            var projObj = PoolManager.Get(stats.projectilePrefab);
+            projObj.transform.position = origin.position;
+            projObj.transform.rotation = Quaternion.identity;
             var proj = projObj.GetComponent<Projectile>();
             if (proj != null)
             {

--- a/Assets/Scripts/Projectile.cs
+++ b/Assets/Scripts/Projectile.cs
@@ -54,20 +54,21 @@ namespace TimelessEchoes
             this.fromHero = fromHero;
             this.combatSkill = combatSkill;
             effectPrefab = hitEffect ?? hitEffectPrefab;
+            transform.rotation = Quaternion.identity;
         }
 
         private void Update()
         {
             if (target == null)
             {
-                Destroy(gameObject);
+                PoolManager.Release(gameObject);
                 return;
             }
 
             IHasHealth health = target.GetComponent<IHasHealth>();
             if (health != null && health.CurrentHealth <= 0f)
             {
-                Destroy(gameObject);
+                PoolManager.Release(gameObject);
                 return;
             }
 
@@ -99,7 +100,7 @@ namespace TimelessEchoes
                             var sfx2 = GetComponent<ProjectileHitSfx>();
                             sfx2?.PlayHit();
                             SpawnEffect();
-                            Destroy(gameObject);
+                            PoolManager.Release(gameObject);
                             return;
                         }
                         var hp = target.GetComponent<IHasHealth>();
@@ -131,7 +132,7 @@ namespace TimelessEchoes
                 var sfx = GetComponent<ProjectileHitSfx>();
                 sfx?.PlayHit();
                 SpawnEffect();
-                Destroy(gameObject);
+                PoolManager.Release(gameObject);
                 return;
             }
 


### PR DESCRIPTION
## Summary
- Spawn enemy and hero projectiles from PoolManager
- Return projectiles to their pools instead of destroying them
- Reset projectile state on initialization to work with pooling

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896a37102f4832e96f084e6003f9dfe