### PR TITLE
Adjust safe-area aspect ratio calculation

### DIFF
--- a/Assets/Scripts/Blindsided/Utilities/ScreenSafeArea.cs
+++ b/Assets/Scripts/Blindsided/Utilities/ScreenSafeArea.cs
@@ -207,19 +207,23 @@ namespace Blindsided.Utilities
                 var screenWidthInCanvasUnits = Screen.width / scaleFactor;
                 var screenHeightInCanvasUnits = Screen.height / scaleFactor;
 
+                var outerHeight = screenHeightInCanvasUnits; // full height
                 var currentWidth = screenWidthInCanvasUnits - left - right;
-                var currentHeight = screenHeightInCanvasUnits - top - bottom;
-                var currentAspect = currentWidth / currentHeight;
+                var targetWidth = outerHeight * maxAllowedAspect - (left + right);
 
-                if (currentAspect > maxAllowedAspect)
+                if (currentWidth > targetWidth)
                 {
-                    // The area is too wide, so we need to add horizontal padding.
-                    var targetWidth = currentHeight * maxAllowedAspect;
                     var delta = currentWidth - targetWidth;
-
-                    // Distribute the change equally to the left and right padding variables.
                     left += delta * 0.5f;
                     right += delta * 0.5f;
+                }
+                else if (currentWidth < targetWidth)
+                {
+                    var targetHeight = (screenWidthInCanvasUnits - left - right) / maxAllowedAspect;
+                    var delta = screenHeightInCanvasUnits - targetHeight;
+                    var halfDelta = delta * 0.5f;
+                    top = Mathf.Max(minPaddingTop, top + halfDelta);
+                    bottom = Mathf.Max(minPaddingBottom, bottom + halfDelta);
                 }
             }
 


### PR DESCRIPTION
## Summary
- Refine safe-area width calculation to use full screen height before applying padding
- Add complementary vertical padding adjustment to avoid excessively narrow interfaces

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896a4ac6ffc832ea00d871c4085d4cc