### PR TITLE
Default auto-pinning quests to on

### DIFF
--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -99,7 +99,7 @@ namespace Blindsided.SaveData
             ///     Automatically pin new quests when they become active.
             /// </summary>
             [System.Obsolete("Use PlayerPrefs via StaticReferences instead.")]
-            public bool AutoPinActiveQuests = false;
+            public bool AutoPinActiveQuests = true;
 
             /// <summary>
             ///     Whether the pinned quest panel is visible.

--- a/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
+++ b/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
@@ -210,7 +210,7 @@ namespace Blindsided.SaveData
 
         public static bool AutoPinActiveQuests
         {
-            get => PlayerPrefs.GetInt(AutoPinActiveQuestsKey, 0) == 1;
+            get => PlayerPrefs.GetInt(AutoPinActiveQuestsKey, 1) == 1;
             set
             {
                 PlayerPrefs.SetInt(AutoPinActiveQuestsKey, value ? 1 : 0);


### PR DESCRIPTION
## Summary
- default quest auto-pin preference to enabled in saved settings
- update obsolete game data default for auto-pin to true

## Testing
- `dotnet test` *(fails: specify project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_6896c9375cb8832e99a57aa14debb41d