### PR TITLE
docs: regenerate task summaries

### DIFF
--- a/Documentation/TASKS_SUMMARY.md
+++ b/Documentation/TASKS_SUMMARY.md
@@ -1,489 +1,606 @@
 # Task Configuration Summary
-
-## Woodcutting
-### Small Fruit Tree
-- **Task ID:** 0
-- **XP:** 1
-- **Duration:** 1s
-- **Spawn Range X:** 0 to Infinity
-  - **Drops:**
-    - Range 1-2 chance 0.5 (resource Stick)
-    - Range 5-15 chance 0.15 (resource Feather)
-### Medium Fruit Tree
-- **Task ID:** 1
-- **XP:** 3
-- **Duration:** 2s
-- **Spawn Range X:** 0 to Infinity
-  - **Drops:**
-    - Range 2-5 chance 1 (resource Stick)
-    - Range 5-15 chance 0.15 (resource Feather)
-### Large Fruit Tree
-- **Task ID:** 2
-- **XP:** 7
-- **Duration:** 3s
-- **Spawn Range X:** 0 to Infinity
-  - **Drops:**
-    - Range 8-16 chance 1 (resource Stick)
-    - Range 5-15 chance 0.15 (resource Feather)
-### Small Oak Tree
-- **Task ID:** 3
-- **XP:** 2
-- **Duration:** 1.5s
-- **Spawn Range X:** 100 to Infinity
-  - **Drops:**
-    - Range 2-3 chance 0.72 (resource Stick)
-    - Range 5-15 chance 0.15 (resource Feather)
-### Medium Oak Tree
-- **Task ID:** 4
-- **XP:** 5
-- **Duration:** 3s
-- **Spawn Range X:** 100 to Infinity
-  - **Drops:**
-    - Range 5-20 chance 1 (resource Stick)
-    - Range 5-15 chance 0.15 (resource Feather)
-### Large Oak Tree
-- **Task ID:** 5
-- **XP:** 10
-- **Duration:** 6s
-- **Spawn Range X:** 100 to Infinity
-  - **Drops:**
-    - Range 8-36 chance 1 (resource Stick)
-    - Range 5-15 chance 0.15 (resource Feather)
-### Small Birch Tree
-- **Task ID:** 6
-- **XP:** 3
-- **Duration:** 2.5s
-- **Spawn Range X:** 500 to Infinity
-  - **Drops:**
-    - Range 4-16 chance 1 (resource Stick)
-    - Range 5-15 chance 0.15 (resource Feather)
-### Medium Birch Tree
-- **Task ID:** 7
-- **XP:** 8
-- **Duration:** 3s
-- **Spawn Range X:** 500 to Infinity
-  - **Drops:**
-    - Range 42-86 chance 1 (resource Stick)
-    - Range 5-15 chance 0.15 (resource Feather)
-### Large Birch Tree
-- **Task ID:** 8
-- **XP:** 25
-- **Duration:** 7s
-- **Spawn Range X:** 500 to Infinity
-  - **Drops:**
-    - Range 112-420 chance 1 (resource Stick)
-    - Range 5-15 chance 0.15 (resource Feather)
-### Small Spruce Tree
-- **Task ID:** 9
-- **XP:** 6
-- **Duration:** 3s
-- **Spawn Range X:** 2500 to Infinity
-  - **Drops:**
-    - Range 4-16 chance 1 (resource Stick)
-    - Range 5-15 chance 0.15 (resource Feather)
-### Medium Spruce Tree
-- **Task ID:** 10
-- **XP:** 15
-- **Duration:** 4s
-- **Spawn Range X:** 2500 to Infinity
-  - **Drops:**
-    - Range 4-16 chance 1 (resource Stick)
-    - Range 5-15 chance 0.15 (resource Feather)
-### Large Spruce Tree
-- **Task ID:** 11
-- **XP:** 50
-- **Duration:** 10s
-- **Spawn Range X:** 2500 to Infinity
-  - **Drops:**
-    - Range 4-16 chance 1 (resource Stick)
-    - Range 5-15 chance 0.15 (resource Feather)
-
-## Mining
-### Eznorb Ore
-- **Task ID:** 12
-- **XP:** 3
-- **Duration:** 2s
-- **Spawn Range X:** 40 to Infinity
-  - **Drops:**
-    - Range 4-12 chance 1 (resource Stone)
-    - Range 2-5 chance 0.5 (resource Eznorb Chunks)
-    - Range 1-4 chance 0.2 (resource Eznorb Crystal)
-### Nori Ore
-- **Task ID:** 13
-- **XP:** 5
-- **Duration:** 3s
-- **Spawn Range X:** 100 to Infinity
-  - **Drops:**
-    - Range 4-12 chance 1 (resource Stone)
-    - Range 2-5 chance 0.5 (resource Nori Chunks)
-    - Range 1-4 chance 0.2 (resource Nori Crystal)
-### Dlog Ore
-- **Task ID:** 14
-- **XP:** 7
-- **Duration:** 4s
-- **Spawn Range X:** 150 to Infinity
-  - **Drops:**
-    - Range 4-12 chance 1 (resource Stone)
-    - Range 2-5 chance 0.5 (resource Dlog Chunks)
-    - Range 1-4 chance 0.2 (resource Dlog Crystal)
-### Erif Ore
-- **Task ID:** 15
-- **XP:** 10
-- **Duration:** 5s
-- **Spawn Range X:** 200 to Infinity
-  - **Drops:**
-    - Range 4-12 chance 1 (resource Stone)
-    - Range 2-5 chance 0.5 (resource Erif Chunks)
-    - Range 1-4 chance 0.2 (resource Erif Crystal)
-### Lirium Ore
-- **Task ID:** 16
-- **XP:** 15
-- **Duration:** 7s
-- **Spawn Range X:** 300 to Infinity
-  - **Drops:**
-    - Range 4-12 chance 1 (resource Stone)
-    - Range 2-5 chance 0.5 (resource Lirium Chunks)
-    - Range 1-4 chance 0.2 (resource Lirium Crystal)
-### Copium Ore
-- **Task ID:** 17
-- **XP:** 20
-- **Duration:** 10s
-- **Spawn Range X:** 500 to Infinity
-  - **Drops:**
-    - Range 4-12 chance 1 (resource Stone)
-    - Range 2-5 chance 0.5 (resource Copium Chunks)
-    - Range 1-4 chance 0.2 (resource Copium Crystal)
-### Idle Ore
-- **Task ID:** 18
-- **XP:** 25
-- **Duration:** 15s
-- **Spawn Range X:** 1000 to Infinity
-  - **Drops:**
-    - Range 4-12 chance 1 (resource Stone)
-    - Range 2-5 chance 0.5 (resource Idle Chunks)
-    - Range 1-4 chance 0.2 (resource Idle Crystal)
-### Vastium Ore
-- **Task ID:** 19
-- **XP:** 50
-- **Duration:** 25s
-- **Spawn Range X:** 2500 to Infinity
-  - **Drops:**
-    - Range 4-12 chance 1 (resource Stone)
-    - Range 2-5 chance 0.5 (resource Vastium Chunks)
-    - Range 1-4 chance 0.2 (resource Vastium Crystal)
-
 ## Farming
-### Radish
-- **Task ID:** 28
-- **XP:** 5
-- **Duration:** 2s
-- **Spawn Range X:** 0 to Infinity
-  - **Drops:**
-    - Range 1-5 chance 1 (resource Radish)
-### Corn
-- **Task ID:** 29
-- **XP:** 5
-- **Duration:** 3s
-- **Spawn Range X:** 50 to Infinity
-  - **Drops:**
-    - Range 1-5 chance 1 (resource Corn)
-### Wheat
-- **Task ID:** 30
-- **XP:** 8
-- **Duration:** 4s
-- **Spawn Range X:** 75 to Infinity
-  - **Drops:**
-    - Range 1-5 chance 1 (resource Wheat)
-### Wartermelone
-- **Task ID:** 31
-- **XP:** 12
-- **Duration:** 6s
-- **Spawn Range X:** 100 to Infinity
-  - **Drops:**
-    - Range 1-5 chance 1 (resource Wartermelone)
-### Carrot
-- **Task ID:** 32
-- **XP:** 5
-- **Duration:** 2s
-- **Spawn Range X:** 125 to Infinity
-  - **Drops:**
-    - Range 1-5 chance 1 (resource Carrot)
-### Spud
-- **Task ID:** 33
-- **XP:** 5
-- **Duration:** 2s
-- **Spawn Range X:** 150 to Infinity
-  - **Drops:**
-    - Range 1-5 chance 1 (resource Spud)
-### Tomato
-- **Task ID:** 34
-- **XP:** 5
-- **Duration:** 2s
-- **Spawn Range X:** 175 to Infinity
-  - **Drops:**
-    - Range 1-5 chance 1 (resource Tomato)
-### Lettuce
-- **Task ID:** 35
-- **XP:** 5
-- **Duration:** 2s
-- **Spawn Range X:** 200 to Infinity
-  - **Drops:**
-    - Range 1-5 chance 1 (resource Lettuce)
-### Cucumber
-- **Task ID:** 36
-- **XP:** 5
-- **Duration:** 2s
-- **Spawn Range X:** 225 to Infinity
-  - **Drops:**
-    - Range 1-5 chance 1 (resource Cucumber)
-### Onion
-- **Task ID:** 37
-- **XP:** 5
-- **Duration:** 2s
-- **Spawn Range X:** 250 to Infinity
-  - **Drops:**
-    - Range 1-5 chance 1 (resource Onion)
-### Leek
-- **Task ID:** 38
-- **XP:** 5
-- **Duration:** 2s
-- **Spawn Range X:** 275 to Infinity
-  - **Drops:**
-    - Range 1-5 chance 1 (resource Leek)
-### Parsnip
-- **Task ID:** 39
-- **XP:** 5
-- **Duration:** 2s
-- **Spawn Range X:** 300 to Infinity
-  - **Drops:**
-    - Range 1-5 chance 1 (resource Parsnip)
-### Pepper
-- **Task ID:** 40
-- **XP:** 5
-- **Duration:** 2s
-- **Spawn Range X:** 325 to Infinity
-  - **Drops:**
-    - Range 1-5 chance 1 (resource Pepper)
-### Chillie
-- **Task ID:** 41
-- **XP:** 5
-- **Duration:** 2s
-- **Spawn Range X:** 350 to Infinity
-  - **Drops:**
-    - Range 1-5 chance 1 (resource Chillie)
-### Pumking
-- **Task ID:** 42
-- **XP:** 5
-- **Duration:** 2s
-- **Spawn Range X:** 375 to Infinity
-  - **Drops:**
-    - Range 1-5 chance 1 (resource Pumking)
-### Strawberry
-- **Task ID:** 43
-- **XP:** 5
-- **Duration:** 2s
-- **Spawn Range X:** 400 to Infinity
-  - **Drops:**
-    - Range 1-5 chance 1 (resource Strawberry)
-### Funion
-- **Task ID:** 44
-- **XP:** 5
-- **Duration:** 2s
-- **Spawn Range X:** 425 to Infinity
-  - **Drops:**
-    - Range 1-5 chance 1 (resource Funion)
-### Turnip
-- **Task ID:** 45
-- **XP:** 5
-- **Duration:** 2s
-- **Spawn Range X:** 450 to Infinity
-  - **Drops:**
-    - Range 1-5 chance 1 (resource Turnip)
+Radish | ID: 28
+XP: 5
+Duration: 2s
+Weight: 1
+Spawn Terrains: Grass, Grass_Farmlands, Grass_Woods, Grass_River
+Resource Drops:
+  - Radish: range 1-5, chance 1, minX 0, maxX Infinity, requiredQuest none
+Min Spawn X: 0
+Max Spawn X: 200
+
+Corn | ID: 29
+XP: 5
+Duration: 3s
+Weight: 1
+Spawn Terrains: Grass, Grass_Farmlands, Grass_Woods, Grass_River
+Resource Drops:
+  - Corn: range 1-5, chance 1, minX 50, maxX Infinity, requiredQuest none
+Min Spawn X: 50
+Max Spawn X: 400
+
+Wheat | ID: 30
+XP: 8
+Duration: 4s
+Weight: 1
+Spawn Terrains: Grass, Grass_Farmlands, Grass_Woods, Grass_River
+Resource Drops:
+  - Wheat: range 1-5, chance 1, minX 75, maxX Infinity, requiredQuest none
+Min Spawn X: 75
+Max Spawn X: 600
+
+Wartermelone | ID: 31
+XP: 12
+Duration: 6s
+Weight: 1
+Spawn Terrains: Grass, Grass_Farmlands, Grass_Woods, Grass_River
+Resource Drops:
+  - Watermelone: range 1-5, chance 1, minX 100, maxX Infinity, requiredQuest none
+Min Spawn X: 100
+Max Spawn X: 800
+
+Carrot | ID: 32
+XP: 5
+Duration: 2s
+Weight: 1
+Spawn Terrains: Grass, Grass_Farmlands, Grass_Woods, Grass_River
+Resource Drops:
+  - Carrot: range 1-5, chance 1, minX 125, maxX Infinity, requiredQuest none
+Min Spawn X: 125
+Max Spawn X: 1000
+
+Spud | ID: 33
+XP: 5
+Duration: 2s
+Weight: 1
+Spawn Terrains: Grass, Grass_Farmlands, Grass_Woods, Grass_River
+Resource Drops:
+  - Spud: range 1-5, chance 1, minX 150, maxX Infinity, requiredQuest none
+Min Spawn X: 150
+Max Spawn X: 1200
+
+Tomato | ID: 34
+XP: 5
+Duration: 2s
+Weight: 1
+Spawn Terrains: Grass, Grass_Farmlands, Grass_Woods, Grass_River
+Resource Drops:
+  - Tomato: range 1-5, chance 1, minX 175, maxX Infinity, requiredQuest none
+Min Spawn X: 175
+Max Spawn X: 1400
+
+Lettuce | ID: 35
+XP: 5
+Duration: 2s
+Weight: 1
+Spawn Terrains: Grass, Grass_Farmlands, Grass_Woods, Grass_River
+Resource Drops:
+  - Lettuce: range 1-5, chance 1, minX 200, maxX Infinity, requiredQuest none
+Min Spawn X: 200
+Max Spawn X: 1600
+
+Cucumber | ID: 36
+XP: 5
+Duration: 2s
+Weight: 1
+Spawn Terrains: Grass, Grass_Farmlands, Grass_Woods, Grass_River
+Resource Drops:
+  - Cucumber: range 1-5, chance 1, minX 225, maxX Infinity, requiredQuest none
+Min Spawn X: 225
+Max Spawn X: 1800
+
+Onion | ID: 37
+XP: 5
+Duration: 2s
+Weight: 1
+Spawn Terrains: Grass, Grass_Farmlands, Grass_Woods, Grass_River
+Resource Drops:
+  - Onion: range 1-5, chance 1, minX 250, maxX Infinity, requiredQuest none
+Min Spawn X: 250
+Max Spawn X: 2000
+
+Leek | ID: 38
+XP: 5
+Duration: 2s
+Weight: 1
+Spawn Terrains: Grass, Grass_Farmlands, Grass_Woods, Grass_River
+Resource Drops:
+  - Leek: range 1-5, chance 1, minX 275, maxX Infinity, requiredQuest none
+Min Spawn X: 275
+Max Spawn X: 2200
+
+Parsnip | ID: 39
+XP: 5
+Duration: 2s
+Weight: 1
+Spawn Terrains: Grass, Grass_Farmlands, Grass_Woods, Grass_River
+Resource Drops:
+  - Parsnip: range 1-5, chance 1, minX 300, maxX Infinity, requiredQuest none
+Min Spawn X: 300
+Max Spawn X: 2400
+
+Pepper | ID: 40
+XP: 5
+Duration: 2s
+Weight: 1
+Spawn Terrains: Grass, Grass_Farmlands, Grass_Woods, Grass_River
+Resource Drops:
+  - Pepper: range 1-5, chance 1, minX 325, maxX Infinity, requiredQuest none
+Min Spawn X: 325
+Max Spawn X: 2600
+
+Chillie | ID: 41
+XP: 5
+Duration: 2s
+Weight: 1
+Spawn Terrains: Grass, Grass_Farmlands, Grass_Woods, Grass_River
+Resource Drops:
+  - Chillie: range 1-5, chance 1, minX 350, maxX Infinity, requiredQuest none
+Min Spawn X: 350
+Max Spawn X: 2800
+
+Pumking | ID: 42
+XP: 5
+Duration: 2s
+Weight: 1
+Spawn Terrains: Grass, Grass_Farmlands, Grass_Woods, Grass_River
+Resource Drops:
+  - Pumking: range 1-5, chance 1, minX 375, maxX Infinity, requiredQuest none
+Min Spawn X: 375
+Max Spawn X: 3000
+
+Strawberry | ID: 43
+XP: 5
+Duration: 2s
+Weight: 1
+Spawn Terrains: Grass, Grass_Farmlands, Grass_Woods, Grass_River
+Resource Drops:
+  - Strawberry: range 1-5, chance 1, minX 400, maxX Infinity, requiredQuest none
+Min Spawn X: 400
+Max Spawn X: 3200
+
+Funion | ID: 44
+XP: 5
+Duration: 2s
+Weight: 1
+Spawn Terrains: Grass, Grass_Farmlands, Grass_Woods, Grass_River
+Resource Drops:
+  - Funion: range 1-5, chance 1, minX 425, maxX Infinity, requiredQuest none
+Min Spawn X: 425
+Max Spawn X: 3400
+
+Turnip | ID: 45
+XP: 5
+Duration: 2s
+Weight: 1
+Spawn Terrains: Grass, Grass_Farmlands, Grass_Woods, Grass_River
+Resource Drops:
+  - Turnip: range 1-5, chance 1, minX 450, maxX Infinity, requiredQuest none
+Min Spawn X: 450
+Max Spawn X: 3600
 
 ## Fishing
-### Flippy Floppy
-- **Task ID:** 20
-- **XP:** 2
-- **Duration:** 2s
-- **Spawn Range X:** 0 to 250
-  - **Drops:**
-    - Range 1-2 chance 1 (resource Flippy Floppy)
-### Muddy Muck Muncher
-- **Task ID:** 21
-- **XP:** 3
-- **Duration:** 3s
-- **Spawn Range X:** 75 to 500
-  - **Drops:**
-    - Range 1-3 chance 1 (resource Muddy Muck Muncher)
-### Sir Splashford III
-- **Task ID:** 22
-- **XP:** 5
-- **Duration:** 4s
-- **Spawn Range X:** 200 to 1000
-  - **Drops:**
-    - Range 1-2 chance 1 (resource Sir Splashford III)
-### Wigglelittle
-- **Task ID:** 23
-- **XP:** 7
-- **Duration:** 5s
-- **Spawn Range X:** 300 to 2500
-  - **Drops:**
-    - Range 1-4 chance 1 (resource Wigglelittle)
-### Snapjaw Jr.
-- **Task ID:** 24
-- **XP:** 10
-- **Duration:** 7s
-- **Spawn Range X:** 400 to 10000
-  - **Drops:**
-    - Range 1-2 chance 1 (resource Snapjaw Jr.)
-### Flipzoid
-- **Task ID:** 25
-- **XP:** 15
-- **Duration:** 10s
-- **Spawn Range X:** 500 to Infinity
-  - **Drops:**
-    - Range 1-3 chance 1 (resource Flipzoid)
-### Niblet the Bold
-- **Task ID:** 26
-- **XP:** 25
-- **Duration:** 15s
-- **Spawn Range X:** 1000 to Infinity
-  - **Drops:**
-    - Range 1-2 chance 1 (resource Niblet the Bold)
-### Bloopicus Maximus
-- **Task ID:** 27
-- **XP:** 50
-- **Duration:** 25s
-- **Spawn Range X:** 2500 to Infinity
-  - **Drops:**
-    - Range 1-2 chance 1 (resource Bloopicus Maximus)
+Flippy Floppy | ID: 20
+XP: 2
+Duration: 2s
+Weight: 1
+Spawn Terrains: Water, Water_Dirt, Water_Stone
+Resource Drops:
+  - Flippy Floppy: range 1-2, chance 1, minX 0, maxX 250, requiredQuest none
+Min Spawn X: 0
+Max Spawn X: 400
+
+Muddy Muck Muncher | ID: 21
+XP: 3
+Duration: 3s
+Weight: 1
+Spawn Terrains: Water, Water_Dirt, Water_Stone
+Resource Drops:
+  - Muddy Muck Muncher: range 1-3, chance 1, minX 75, maxX 500, requiredQuest none
+Min Spawn X: 75
+Max Spawn X: 800
+
+Sir Splashford III | ID: 22
+XP: 5
+Duration: 4s
+Weight: 1
+Spawn Terrains: Water, Water_Dirt, Water_Stone
+Resource Drops:
+  - Sir Splashford III: range 1-2, chance 1, minX 200, maxX 1000, requiredQuest none
+Min Spawn X: 200
+Max Spawn X: 1200
+
+Wigglelittle | ID: 23
+XP: 7
+Duration: 5s
+Weight: 1
+Spawn Terrains: Water, Water_Dirt, Water_Stone
+Resource Drops:
+  - Wigglelittle: range 1-4, chance 1, minX 300, maxX 2500, requiredQuest none
+Min Spawn X: 300
+Max Spawn X: 1600
+
+Snapjaw Jr. | ID: 24
+XP: 10
+Duration: 7s
+Weight: 1
+Spawn Terrains: Water, Water_Dirt, Water_Stone
+Resource Drops:
+  - Snapjaw Jr.: range 1-2, chance 1, minX 400, maxX 10000, requiredQuest none
+Min Spawn X: 400
+Max Spawn X: 2000
+
+Flipzoid | ID: 25
+XP: 15
+Duration: 10s
+Weight: 1
+Spawn Terrains: Water, Water_Dirt, Water_Stone
+Resource Drops:
+  - Flipzoid: range 1-3, chance 1, minX 500, maxX Infinity, requiredQuest none
+Min Spawn X: 500
+Max Spawn X: 2400
+
+Niblet the Bold | ID: 26
+XP: 25
+Duration: 15s
+Weight: 1
+Spawn Terrains: Water, Water_Dirt, Water_Stone
+Resource Drops:
+  - Niblet the Bold: range 1-2, chance 1, minX 1000, maxX Infinity, requiredQuest none
+Min Spawn X: 1000
+Max Spawn X: 2800
+
+Bloopicus Maximus | ID: 27
+XP: 50
+Duration: 25s
+Weight: 1
+Spawn Terrains: Water, Water_Dirt, Water_Stone
+Resource Drops:
+  - Bloopicus Maximus: range 1-2, chance 1, minX 2500, maxX Infinity, requiredQuest none
+Min Spawn X: 2500
+Max Spawn X: 3200
 
 ## Looting
-### Wooden Chest
-- **Task ID:** 46
-- **XP:** 2
-- **Duration:** 0.5s
-- **Spawn Range X:** 0 to Infinity
-  - **Drops:**
-    - Range 4-7 chance 1 (resource Bone)
-    - Range 1-1 chance 1 (resource Leather)
-    - Range 1-5 chance 0.8 (resource Eznorb Ingot)
-    - Range 1-5 chance 0.7 (resource Nori Ingot)
-    - Range 1-5 chance 0.6 (resource Dlog Ingot)
-    - Range 1-5 chance 0.5 (resource Erif Ingot)
-    - Range 1-5 chance 0.4 (resource Lirium Ingot)
-    - Range 1-5 chance 0.3 (resource Copium Ingot)
-    - Range 1-5 chance 0.2 (resource Idle Ingot)
-    - Range 1-5 chance 0.1 (resource Vastium Ingot)
-### Metal Chest
-- **Task ID:** 47
-- **XP:** 5
-- **Duration:** 0.5s
-- **Spawn Range X:** 0 to Infinity
-  - **Drops:**
-    - Range 8-12 chance 1 (resource Bone)
-    - Range 1-5 chance 1 (resource Leather)
-    - Range 2-7 chance 0.8 (resource Eznorb Ingot)
-    - Range 2-7 chance 0.7 (resource Nori Ingot)
-    - Range 2-7 chance 0.6 (resource Dlog Ingot)
-    - Range 2-7 chance 0.5 (resource Erif Ingot)
-    - Range 2-7 chance 0.4 (resource Lirium Ingot)
-    - Range 2-7 chance 0.3 (resource Copium Ingot)
-    - Range 2-7 chance 0.2 (resource Idle Ingot)
-    - Range 2-7 chance 0.1 (resource Vastium Ingot)
-### Golden Chest
-- **Task ID:** 48
-- **XP:** 7
-- **Duration:** 0.5s
-- **Spawn Range X:** 0 to Infinity
-  - **Drops:**
-    - Range 10-18 chance 1 (resource Bone)
-    - Range 2-7 chance 1 (resource Leather)
-    - Range 4-10 chance 0.8 (resource Eznorb Ingot)
-    - Range 4-10 chance 0.7 (resource Nori Ingot)
-    - Range 4-10 chance 0.6 (resource Dlog Ingot)
-    - Range 4-10 chance 0.5 (resource Erif Ingot)
-    - Range 4-10 chance 0.4 (resource Lirium Ingot)
-    - Range 4-10 chance 0.3 (resource Copium Ingot)
-    - Range 4-10 chance 0.2 (resource Idle Ingot)
-    - Range 4-10 chance 0.1 (resource Vastium Ingot)
-### Crystal Chest
-- **Task ID:** 49
-- **XP:** 10
-- **Duration:** 0.5s
-- **Spawn Range X:** 0 to Infinity
-  - **Drops:**
-    - Range 12-22 chance 1 (resource Bone)
-    - Range 4-12 chance 1 (resource Leather)
-    - Range 5-14 chance 0.8 (resource Eznorb Ingot)
-    - Range 5-14 chance 0.7 (resource Nori Ingot)
-    - Range 5-14 chance 0.6 (resource Dlog Ingot)
-    - Range 5-14 chance 0.5 (resource Erif Ingot)
-    - Range 5-14 chance 0.4 (resource Lirium Ingot)
-    - Range 5-14 chance 0.3 (resource Copium Ingot)
-    - Range 5-14 chance 0.2 (resource Idle Ingot)
-    - Range 5-14 chance 0.1 (resource Vastium Ingot)
-### Lirium Chest
-- **Task ID:** 50
-- **XP:** 15
-- **Duration:** 0.5s
-- **Spawn Range X:** 0 to Infinity
-  - **Drops:**
-    - Range 12-33 chance 1 (resource Bone)
-    - Range 4-18 chance 1 (resource Leather)
-    - Range 7-14 chance 0.8 (resource Eznorb Ingot)
-    - Range 7-14 chance 0.7 (resource Nori Ingot)
-    - Range 7-14 chance 0.6 (resource Dlog Ingot)
-    - Range 7-14 chance 0.5 (resource Erif Ingot)
-    - Range 7-14 chance 0.4 (resource Lirium Ingot)
-    - Range 7-14 chance 0.3 (resource Copium Ingot)
-    - Range 7-14 chance 0.2 (resource Idle Ingot)
-    - Range 7-14 chance 0.1 (resource Vastium Ingot)
-### Copium Chest
-- **Task ID:** 51
-- **XP:** 20
-- **Duration:** 0.5s
-- **Spawn Range X:** 0 to Infinity
-  - **Drops:**
-    - Range 22-33 chance 1 (resource Bone)
-    - Range 7-18 chance 1 (resource Leather)
-    - Range 10-14 chance 0.8 (resource Eznorb Ingot)
-    - Range 10-14 chance 0.7 (resource Nori Ingot)
-    - Range 10-14 chance 0.6 (resource Dlog Ingot)
-    - Range 10-14 chance 0.5 (resource Erif Ingot)
-    - Range 10-14 chance 0.4 (resource Lirium Ingot)
-    - Range 10-14 chance 0.3 (resource Copium Ingot)
-    - Range 10-14 chance 0.2 (resource Idle Ingot)
-    - Range 10-14 chance 0.1 (resource Vastium Ingot)
-### Idle Chest
-- **Task ID:** 52
-- **XP:** 25
-- **Duration:** 0.5s
-- **Spawn Range X:** 0 to Infinity
-  - **Drops:**
-    - Range 33-44 chance 1 (resource Bone)
-    - Range 10-22 chance 1 (resource Leather)
-    - Range 10-17 chance 0.8 (resource Eznorb Ingot)
-    - Range 10-17 chance 0.7 (resource Nori Ingot)
-    - Range 10-17 chance 0.6 (resource Dlog Ingot)
-    - Range 10-17 chance 0.5 (resource Erif Ingot)
-    - Range 10-17 chance 0.4 (resource Lirium Ingot)
-    - Range 10-17 chance 0.3 (resource Copium Ingot)
-    - Range 10-17 chance 0.2 (resource Idle Ingot)
-    - Range 10-17 chance 0.1 (resource Vastium Ingot)
-### Vastium Chest
-- **Task ID:** 53
-- **XP:** 50
-- **Duration:** 0.5s
-- **Spawn Range X:** 0 to Infinity
-  - **Drops:**
-    - Range 33-55 chance 1 (resource Bone)
-    - Range 10-33 chance 1 (resource Leather)
-    - Range 10-22 chance 0.8 (resource Eznorb Ingot)
-    - Range 10-22 chance 0.7 (resource Nori Ingot)
-    - Range 10-22 chance 0.6 (resource Dlog Ingot)
-    - Range 10-22 chance 0.5 (resource Erif Ingot)
-    - Range 10-22 chance 0.4 (resource Lirium Ingot)
-    - Range 10-22 chance 0.3 (resource Copium Ingot)
-    - Range 10-22 chance 0.2 (resource Idle Ingot)
-    - Range 10-22 chance 0.1 (resource Vastium Ingot)
+Wooden Chest | ID: 46
+XP: 2
+Duration: 0.5s
+Weight: 10
+Spawn Terrains: Grass, Sand, Grass_Farmlands, Grass_Woods, Grass_River, Mines_Ground
+Resource Drops:
+  - Bone: range 1-1, chance 0.1, minX 0, maxX Infinity, requiredQuest none
+  - Leather: range 1-2, chance 1, minX 0, maxX Infinity, requiredQuest none
+  - Eznorb Ingot: range 1-5, chance 0.8, minX 40, maxX Infinity, requiredQuest none
+  - Nori Ingot: range 1-5, chance 0.7, minX 100, maxX Infinity, requiredQuest none
+  - Dlog Ingot: range 1-5, chance 0.6, minX 150, maxX Infinity, requiredQuest none
+  - Erif Ingot: range 1-5, chance 0.5, minX 200, maxX Infinity, requiredQuest none
+  - Lirium Ingot: range 1-5, chance 0.4, minX 300, maxX Infinity, requiredQuest none
+  - Copium Ingot: range 1-5, chance 0.3, minX 500, maxX Infinity, requiredQuest none
+  - Idle Ingot: range 1-5, chance 0.2, minX 1000, maxX Infinity, requiredQuest none
+  - Vastium Ingot: range 1-5, chance 0.1, minX 2500, maxX Infinity, requiredQuest none
+Min Spawn X: 0
+Max Spawn X: 500
+
+Metal Chest | ID: 47
+XP: 5
+Duration: 0.5s
+Weight: 5
+Spawn Terrains: Grass, Sand, Grass_Farmlands, Grass_Woods, Grass_River, Mines_Ground
+Resource Drops:
+  - Bone: range 1-2, chance 0.1, minX 0, maxX Infinity, requiredQuest none
+  - Leather: range 1-5, chance 1, minX 0, maxX Infinity, requiredQuest none
+  - Eznorb Ingot: range 2-7, chance 0.8, minX 40, maxX Infinity, requiredQuest none
+  - Nori Ingot: range 2-7, chance 0.7, minX 100, maxX Infinity, requiredQuest none
+  - Dlog Ingot: range 2-7, chance 0.6, minX 150, maxX Infinity, requiredQuest none
+  - Erif Ingot: range 2-7, chance 0.5, minX 200, maxX Infinity, requiredQuest none
+  - Lirium Ingot: range 2-7, chance 0.4, minX 300, maxX Infinity, requiredQuest none
+  - Copium Ingot: range 2-7, chance 0.3, minX 500, maxX Infinity, requiredQuest none
+  - Idle Ingot: range 2-7, chance 0.2, minX 1000, maxX Infinity, requiredQuest none
+  - Vastium Ingot: range 2-7, chance 0.1, minX 2500, maxX Infinity, requiredQuest none
+Min Spawn X: 250
+Max Spawn X: 1250
+
+Golden Chest | ID: 48
+XP: 7
+Duration: 0.5s
+Weight: 1
+Spawn Terrains: Grass, Sand, Grass_Farmlands, Grass_Woods, Grass_River, Mines_Ground
+Resource Drops:
+  - Bone: range 1-2, chance 0.1, minX 0, maxX Infinity, requiredQuest none
+  - Leather: range 2-7, chance 1, minX 0, maxX Infinity, requiredQuest none
+  - Eznorb Ingot: range 4-10, chance 0.8, minX 40, maxX Infinity, requiredQuest none
+  - Nori Ingot: range 4-10, chance 0.7, minX 100, maxX Infinity, requiredQuest none
+  - Dlog Ingot: range 4-10, chance 0.6, minX 150, maxX Infinity, requiredQuest none
+  - Erif Ingot: range 4-10, chance 0.5, minX 200, maxX Infinity, requiredQuest none
+  - Lirium Ingot: range 4-10, chance 0.4, minX 300, maxX Infinity, requiredQuest none
+  - Copium Ingot: range 4-10, chance 0.3, minX 500, maxX Infinity, requiredQuest none
+  - Idle Ingot: range 4-10, chance 0.2, minX 1000, maxX Infinity, requiredQuest none
+  - Vastium Ingot: range 4-10, chance 0.1, minX 2500, maxX Infinity, requiredQuest none
+Min Spawn X: 500
+Max Spawn X: 1500
+
+Crystal Chest | ID: 49
+XP: 10
+Duration: 0.5s
+Weight: 0.5
+Spawn Terrains: Grass, Sand, Grass_Farmlands, Grass_Woods, Grass_River, Mines_Ground
+Resource Drops:
+  - Bone: range 2-4, chance 0.1, minX 0, maxX Infinity, requiredQuest none
+  - Leather: range 4-12, chance 1, minX 0, maxX Infinity, requiredQuest none
+  - Eznorb Ingot: range 5-14, chance 0.8, minX 40, maxX Infinity, requiredQuest none
+  - Nori Ingot: range 5-14, chance 0.7, minX 100, maxX Infinity, requiredQuest none
+  - Dlog Ingot: range 5-14, chance 0.6, minX 150, maxX Infinity, requiredQuest none
+  - Erif Ingot: range 5-14, chance 0.5, minX 200, maxX Infinity, requiredQuest none
+  - Lirium Ingot: range 5-14, chance 0.4, minX 300, maxX Infinity, requiredQuest none
+  - Copium Ingot: range 5-14, chance 0.3, minX 500, maxX Infinity, requiredQuest none
+  - Idle Ingot: range 5-14, chance 0.2, minX 1000, maxX Infinity, requiredQuest none
+  - Vastium Ingot: range 5-14, chance 0.1, minX 2500, maxX Infinity, requiredQuest none
+Min Spawn X: 1000
+Max Spawn X: 2500
+
+Lirium Chest | ID: 50
+XP: 15
+Duration: 0.5s
+Weight: 0.25
+Spawn Terrains: Grass, Sand, Grass_Farmlands, Grass_Woods, Grass_River, Mines_Ground
+Resource Drops:
+  - Bone: range 2-4, chance 0.1, minX 0, maxX Infinity, requiredQuest none
+  - Leather: range 4-18, chance 1, minX 0, maxX Infinity, requiredQuest none
+  - Eznorb Ingot: range 7-14, chance 0.8, minX 40, maxX Infinity, requiredQuest none
+  - Nori Ingot: range 7-14, chance 0.7, minX 100, maxX Infinity, requiredQuest none
+  - Dlog Ingot: range 7-14, chance 0.6, minX 150, maxX Infinity, requiredQuest none
+  - Erif Ingot: range 7-14, chance 0.5, minX 200, maxX Infinity, requiredQuest none
+  - Lirium Ingot: range 7-14, chance 0.4, minX 300, maxX Infinity, requiredQuest none
+  - Copium Ingot: range 7-14, chance 0.3, minX 500, maxX Infinity, requiredQuest none
+  - Idle Ingot: range 7-14, chance 0.2, minX 1000, maxX Infinity, requiredQuest none
+  - Vastium Ingot: range 7-14, chance 0.1, minX 2500, maxX Infinity, requiredQuest none
+Min Spawn X: 1000
+Max Spawn X: 2500
+
+Copium Chest | ID: 51
+XP: 20
+Duration: 0.5s
+Weight: 0.1
+Spawn Terrains: Grass, Sand, Grass_Farmlands, Grass_Woods, Grass_River, Mines_Ground
+Resource Drops:
+  - Bone: range 2-4, chance 0.1, minX 0, maxX Infinity, requiredQuest none
+  - Leather: range 7-18, chance 1, minX 0, maxX Infinity, requiredQuest none
+  - Eznorb Ingot: range 10-14, chance 0.8, minX 40, maxX Infinity, requiredQuest none
+  - Nori Ingot: range 10-14, chance 0.7, minX 100, maxX Infinity, requiredQuest none
+  - Dlog Ingot: range 10-14, chance 0.6, minX 150, maxX Infinity, requiredQuest none
+  - Erif Ingot: range 10-14, chance 0.5, minX 200, maxX Infinity, requiredQuest none
+  - Lirium Ingot: range 10-14, chance 0.4, minX 300, maxX Infinity, requiredQuest none
+  - Copium Ingot: range 10-14, chance 0.3, minX 500, maxX Infinity, requiredQuest none
+  - Idle Ingot: range 10-14, chance 0.2, minX 1000, maxX Infinity, requiredQuest none
+  - Vastium Ingot: range 10-14, chance 0.1, minX 2500, maxX Infinity, requiredQuest none
+Min Spawn X: 1000
+Max Spawn X: 2500
+
+Idle Chest | ID: 52
+XP: 25
+Duration: 0.5s
+Weight: 0.05
+Spawn Terrains: Grass, Sand, Grass_Farmlands, Grass_Woods, Grass_River, Mines_Ground
+Resource Drops:
+  - Bone: range 2-4, chance 0.1, minX 0, maxX Infinity, requiredQuest none
+  - Leather: range 10-22, chance 1, minX 0, maxX Infinity, requiredQuest none
+  - Eznorb Ingot: range 10-17, chance 0.8, minX 40, maxX Infinity, requiredQuest none
+  - Nori Ingot: range 10-17, chance 0.7, minX 100, maxX Infinity, requiredQuest none
+  - Dlog Ingot: range 10-17, chance 0.6, minX 150, maxX Infinity, requiredQuest none
+  - Erif Ingot: range 10-17, chance 0.5, minX 200, maxX Infinity, requiredQuest none
+  - Lirium Ingot: range 10-17, chance 0.4, minX 300, maxX Infinity, requiredQuest none
+  - Copium Ingot: range 10-17, chance 0.3, minX 500, maxX Infinity, requiredQuest none
+  - Idle Ingot: range 10-17, chance 0.2, minX 1000, maxX Infinity, requiredQuest none
+  - Vastium Ingot: range 10-17, chance 0.1, minX 2500, maxX Infinity, requiredQuest none
+Min Spawn X: 1000
+Max Spawn X: 2500
+
+Vastium Chest | ID: 53
+XP: 50
+Duration: 0.5s
+Weight: 0.025
+Spawn Terrains: Grass, Sand, Grass_Farmlands, Grass_Woods, Grass_River, Mines_Ground
+Resource Drops:
+  - Bone: range 1-5, chance 0.1, minX 0, maxX Infinity, requiredQuest none
+  - Leather: range 10-33, chance 1, minX 0, maxX Infinity, requiredQuest none
+  - Eznorb Ingot: range 10-22, chance 0.8, minX 40, maxX Infinity, requiredQuest none
+  - Nori Ingot: range 10-22, chance 0.7, minX 100, maxX Infinity, requiredQuest none
+  - Dlog Ingot: range 10-22, chance 0.6, minX 150, maxX Infinity, requiredQuest none
+  - Erif Ingot: range 10-22, chance 0.5, minX 200, maxX Infinity, requiredQuest none
+  - Lirium Ingot: range 10-22, chance 0.4, minX 300, maxX Infinity, requiredQuest none
+  - Copium Ingot: range 10-22, chance 0.3, minX 500, maxX Infinity, requiredQuest none
+  - Idle Ingot: range 10-22, chance 0.2, minX 1000, maxX Infinity, requiredQuest none
+  - Vastium Ingot: range 10-22, chance 0.1, minX 2500, maxX Infinity, requiredQuest none
+Min Spawn X: 1000
+Max Spawn X: 2500
+
+## Mining
+Eznorb Ore | ID: 12
+XP: 3
+Duration: 2s
+Weight: 1
+Spawn Terrains: Sand, Mines_Ground, Grass_Woods, Grass_River
+Resource Drops:
+  - Stone: range 4-12, chance 1, minX 0, maxX Infinity, requiredQuest none
+  - Eznorb Chunks: range 2-5, chance 0.7, minX 10, maxX Infinity, requiredQuest none
+  - Eznorb Crystal: range 1-4, chance 0.4, minX 10, maxX Infinity, requiredQuest none
+Min Spawn X: 10
+Max Spawn X: 500
+
+Nori Ore | ID: 13
+XP: 5
+Duration: 3s
+Weight: 1
+Spawn Terrains: Sand, Mines_Ground, Grass_Woods, Grass_River
+Resource Drops:
+  - Stone: range 4-12, chance 1, minX 0, maxX Infinity, requiredQuest none
+  - Nori Chunks: range 2-5, chance 0.7, minX 60, maxX Infinity, requiredQuest none
+  - Nori Crystal: range 1-4, chance 0.4, minX 60, maxX Infinity, requiredQuest none
+Min Spawn X: 60
+Max Spawn X: 1000
+
+Dlog Ore | ID: 14
+XP: 7
+Duration: 4s
+Weight: 1
+Spawn Terrains: Sand, Mines_Ground, Grass_Woods, Grass_River
+Resource Drops:
+  - Stone: range 4-12, chance 1, minX 0, maxX Infinity, requiredQuest none
+  - Dlog Chunks: range 2-5, chance 0.7, minX 150, maxX Infinity, requiredQuest none
+  - Dlog Crystal: range 1-4, chance 0.4, minX 150, maxX Infinity, requiredQuest none
+Min Spawn X: 150
+Max Spawn X: 1500
+
+Erif Ore | ID: 15
+XP: 10
+Duration: 5s
+Weight: 1
+Spawn Terrains: Sand, Mines_Ground, Grass_Woods, Grass_River
+Resource Drops:
+  - Stone: range 4-12, chance 1, minX 0, maxX Infinity, requiredQuest none
+  - Erif Chunks: range 2-5, chance 0.7, minX 200, maxX Infinity, requiredQuest none
+  - Erif Crystal: range 1-4, chance 0.4, minX 200, maxX Infinity, requiredQuest none
+Min Spawn X: 200
+Max Spawn X: 2000
+
+Lirium Ore | ID: 16
+XP: 15
+Duration: 7s
+Weight: 1
+Spawn Terrains: Sand, Mines_Ground, Grass_Woods, Grass_River
+Resource Drops:
+  - Stone: range 4-12, chance 1, minX 0, maxX Infinity, requiredQuest none
+  - Lirium Chunks: range 2-5, chance 0.7, minX 300, maxX Infinity, requiredQuest none
+  - Lirium Crystal: range 1-4, chance 0.4, minX 300, maxX Infinity, requiredQuest none
+Min Spawn X: 300
+Max Spawn X: 2500
+
+Copium Ore | ID: 17
+XP: 20
+Duration: 10s
+Weight: 1
+Spawn Terrains: Sand, Mines_Ground, Grass_Woods, Grass_River
+Resource Drops:
+  - Stone: range 4-12, chance 1, minX 0, maxX Infinity, requiredQuest none
+  - Copium Chunks: range 2-5, chance 0.7, minX 500, maxX Infinity, requiredQuest none
+  - Copium Crystal: range 1-4, chance 0.4, minX 500, maxX Infinity, requiredQuest none
+Min Spawn X: 500
+Max Spawn X: 3000
+
+Idle Ore | ID: 18
+XP: 25
+Duration: 15s
+Weight: 1
+Spawn Terrains: Sand, Mines_Ground, Grass_Woods, Grass_River
+Resource Drops:
+  - Stone: range 4-12, chance 1, minX 0, maxX Infinity, requiredQuest none
+  - Idle Chunks: range 2-5, chance 0.7, minX 750, maxX Infinity, requiredQuest none
+  - Idle Crystal: range 1-4, chance 0.4, minX 750, maxX Infinity, requiredQuest none
+Min Spawn X: 750
+Max Spawn X: 3500
+
+Vastium Ore | ID: 19
+XP: 50
+Duration: 25s
+Weight: 1
+Spawn Terrains: Sand, Mines_Ground, Grass_Woods, Grass_River
+Resource Drops:
+  - Stone: range 4-12, chance 1, minX 0, maxX Infinity, requiredQuest none
+  - Vastium Chunks: range 2-5, chance 0.7, minX 1000, maxX Infinity, requiredQuest none
+  - Vastium Crystal: range 1-4, chance 0.4, minX 1000, maxX Infinity, requiredQuest none
+Min Spawn X: 1000
+Max Spawn X: 4000
+
+## Woodcutting
+Medium Tree | ID: 1
+XP: 3
+Duration: 2s
+Weight: 1
+Spawn Terrains: Grass, Grass_Farmlands, Grass_Woods, Grass_River, Grass_NoTasks
+Resource Drops:
+  - Stick: range 1-3, chance 1, minX 0, maxX Infinity, requiredQuest none
+  - Log: range 1-2, chance 1, minX 0, maxX Infinity, requiredQuest none
+Min Spawn X: 0
+Max Spawn X: 500
+
+Large Tree | ID: 2
+XP: 7
+Duration: 3s
+Weight: 1
+Spawn Terrains: Grass, Grass_Farmlands, Grass_Woods, Grass_River, Grass_NoTasks
+Resource Drops:
+  - Stick: range 2-8, chance 1, minX 0, maxX Infinity, requiredQuest none
+  - Feather: range 5-15, chance 0.15, minX 0, maxX Infinity, requiredQuest none
+  - Log: range 1-5, chance 1, minX 0, maxX Infinity, requiredQuest none
+Min Spawn X: 0
+Max Spawn X: 500
+
+Medium Oak Tree | ID: 4
+XP: 5
+Duration: 3s
+Weight: 1
+Spawn Terrains: Grass, Grass_Farmlands, Grass_Woods, Grass_River, Grass_NoTasks
+Resource Drops:
+  - Stick: range 1-5, chance 1, minX 100, maxX Infinity, requiredQuest none
+  - Log: range 1-3, chance 1, minX 0, maxX Infinity, requiredQuest none
+Min Spawn X: 100
+Max Spawn X: 2500
+
+Large Oak Tree | ID: 5
+XP: 10
+Duration: 6s
+Weight: 1
+Spawn Terrains: Grass, Grass_Farmlands, Grass_Woods, Grass_River, Grass_NoTasks
+Resource Drops:
+  - Stick: range 3-9, chance 1, minX 100, maxX Infinity, requiredQuest none
+  - Feather: range 5-15, chance 0.15, minX 0, maxX Infinity, requiredQuest none
+  - Log: range 3-8, chance 1, minX 0, maxX Infinity, requiredQuest none
+Min Spawn X: 100
+Max Spawn X: 2500
+
+Medium Birch Tree | ID: 7
+XP: 8
+Duration: 3s
+Weight: 1
+Spawn Terrains: Grass, Grass_Farmlands, Grass_Woods, Grass_River, Grass_NoTasks
+Resource Drops:
+  - Stick: range 1-6, chance 1, minX 500, maxX Infinity, requiredQuest none
+  - Log: range 2-4, chance 1, minX 0, maxX Infinity, requiredQuest none
+Min Spawn X: 500
+Max Spawn X: 5000
+
+Large Birch Tree | ID: 8
+XP: 25
+Duration: 7s
+Weight: 1
+Spawn Terrains: Grass, Grass_Farmlands, Grass_Woods, Grass_River, Grass_NoTasks
+Resource Drops:
+  - Stick: range 4-10, chance 1, minX 500, maxX Infinity, requiredQuest none
+  - Feather: range 5-15, chance 0.15, minX 0, maxX Infinity, requiredQuest none
+  - Log: range 5-12, chance 1, minX 0, maxX Infinity, requiredQuest none
+Min Spawn X: 500
+Max Spawn X: 5000
+
+Medium Spruce Tree | ID: 10
+XP: 15
+Duration: 4s
+Weight: 1
+Spawn Terrains: Grass, Grass_Farmlands, Grass_Woods, Grass_River, Grass_NoTasks
+Resource Drops:
+  - Stick: range 1-7, chance 1, minX 2500, maxX Infinity, requiredQuest none
+  - Log: range 4-8, chance 1, minX 0, maxX Infinity, requiredQuest none
+Min Spawn X: 2500
+Max Spawn X: 7500
+
+Large Spruce Tree | ID: 11
+XP: 50
+Duration: 10s
+Weight: 1
+Spawn Terrains: Grass, Grass_Farmlands, Grass_Woods, Grass_River, Grass_NoTasks
+Resource Drops:
+  - Stick: range 4-15, chance 1, minX 2500, maxX Infinity, requiredQuest none
+  - Feather: range 5-15, chance 0.15, minX 0, maxX Infinity, requiredQuest none
+  - Log: range 7-22, chance 1, minX 0, maxX Infinity, requiredQuest none
+Min Spawn X: 2500
+Max Spawn X: 7500
+


### PR DESCRIPTION
## Summary
- regenerate tasks summary with standardized blocks and resolved terrain/resource names

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_6896cd7a6a34832eb3af367dfb252c06