### PR TITLE
Refactor loot drops to weighted slot system

### DIFF
--- a/Assets/Scripts/Enemies/EnemyData.cs
+++ b/Assets/Scripts/Enemies/EnemyData.cs
@@ -33,6 +33,11 @@ namespace TimelessEchoes.Enemies
 
         [TitleGroup("Spawn Settings")] public List<ResourceDrop> resourceDrops = new();
 
+        [TitleGroup("Spawn Settings")]
+        [Tooltip("Chance (0-1) for each additional drop slot; evaluated sequentially after the first guaranteed slot.")]
+        [MinValue(0f), MaxValue(1f)]
+        public List<float> additionalLootChances = new();
+
         [TitleGroup("Balance Data")] public int experience = 10;
 
         [TitleGroup("Balance Data/Movement Stats")]

--- a/Assets/Scripts/Gear/SO/CoreSO.cs
+++ b/Assets/Scripts/Gear/SO/CoreSO.cs
@@ -31,9 +31,14 @@ namespace TimelessEchoes.Gear
         public List<string> slotNames = new();
         public List<float> slotWeights = new();
 
-        [Title("Salvage Drops")] 
+        [Title("Salvage Drops")]
         [Tooltip("Resources to award when salvaging an item crafted with this core. Similar format to enemy/task drops.")]
         public List<ResourceDrop> salvageDrops = new();
+
+        [Title("Additional Salvage Slot Chances")]
+        [Tooltip("Chance (0-1) for each additional salvage slot; evaluated sequentially after the first guaranteed slot.")]
+        [MinValue(0f), MaxValue(1f)]
+        public List<float> salvageAdditionalLootChances = new();
 
         public float GetRarityWeight(RaritySO rarity)
         {

--- a/Assets/Scripts/Gear/SalvageService.cs
+++ b/Assets/Scripts/Gear/SalvageService.cs
@@ -1,15 +1,11 @@
 using UnityEngine;
 using TimelessEchoes.Upgrades;
-using System.Collections.Generic;
 
 namespace TimelessEchoes.Gear
 {
     public class SalvageService : MonoBehaviour
     {
         public static SalvageService Instance { get; private set; }
-
-		// Salvage uses core-configured resource drops (chunks/crystals) rather than a single shards currency.
-		[SerializeField] private Vector2Int salvageYieldRange = new Vector2Int(1, 3);
 
         private void Awake()
         {
@@ -21,31 +17,27 @@ namespace TimelessEchoes.Gear
             Instance = this;
         }
 
-		public int Salvage(GearItem item)
+        public int Salvage(GearItem item)
         {
-			if (item == null) return 0;
-			var rm = ResourceManager.Instance ?? FindFirstObjectByType<ResourceManager>();
-			if (rm == null) return 0;
+            // Roll salvage drops using weights with optional extra slots from the core.
+            if (item == null) return 0;
+            var rm = ResourceManager.Instance ?? FindFirstObjectByType<ResourceManager>();
+            if (rm == null) return 0;
 
-			var drops = item.core != null ? item.core.salvageDrops : null;
-			if (drops == null || drops.Count == 0)
-				return 0;
+            var drops = item.core != null ? item.core.salvageDrops : null;
+            var extraChances = item.core != null ? item.core.salvageAdditionalLootChances : null;
+            if (drops == null || drops.Count == 0)
+                return 0;
 
-			int totalAwardedEntries = 0;
-			foreach (var drop in drops)
-			{
-				if (drop == null || drop.resource == null) continue;
-				if (Random.value > drop.dropChance) continue;
-				int min = Mathf.Max(0, drop.dropRange.x);
-				int max = Mathf.Max(min, drop.dropRange.y);
-				float t = Random.value;
-				t *= t; // bias towards lower values, consistent with other drop logic
-				int amount = Mathf.Clamp(Mathf.FloorToInt(Mathf.Lerp(min, max + 1, t)), min, max);
-				if (amount <= 0) continue;
-				rm.Add(drop.resource, amount);
-				totalAwardedEntries++;
-			}
-			return totalAwardedEntries;
+            var results = DropResolver.RollDrops(drops, extraChances, 0f, ignoreQuest: true);
+            int totalAwardedEntries = 0;
+            foreach (var res in results)
+            {
+                rm.Add(res.resource, res.count);
+                totalAwardedEntries++;
+            }
+
+            return totalAwardedEntries;
         }
     }
 }

--- a/Assets/Scripts/Tasks/TaskData.cs
+++ b/Assets/Scripts/Tasks/TaskData.cs
@@ -53,6 +53,11 @@ namespace TimelessEchoes.Tasks
         public List<ResourceDrop> resourceDrops = new();
 
         [TitleGroup("General")]
+        [Tooltip("Chance (0-1) for each additional drop slot; evaluated sequentially after the first guaranteed slot.")]
+        [MinValue(0f), MaxValue(1f)]
+        public List<float> additionalLootChances = new();
+
+        [TitleGroup("General")]
         [Tooltip("Restart task progress when returning after an interrupt.")]
         public bool resetProgressOnInterrupt;
 

--- a/Assets/Scripts/Upgrades/DropResolver.cs
+++ b/Assets/Scripts/Upgrades/DropResolver.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using static TimelessEchoes.Quests.QuestUtils;
+
+namespace TimelessEchoes.Upgrades
+{
+    /// <summary>
+    /// Utility for rolling weighted ResourceDrop tables with optional extra slots.
+    /// Handles world position and quest requirements.
+    /// </summary>
+    public static class DropResolver
+    {
+        public struct DropResult
+        {
+            public Resource resource;
+            public int count;
+        }
+
+        /// <summary>
+        /// Rolls from the provided drops, returning results with amounts calculated
+        /// using the same biased range logic as runtime systems.
+        /// </summary>
+        /// <param name="drops">Potential drops to choose from.</param>
+        /// <param name="additionalLootChances">Sequential extra slot chances after the first guaranteed roll (0-1 values).</param>
+        /// <param name="worldX">World position used for min/max filters.</param>
+        /// <param name="ignoreQuest">If true, required quest checks are skipped.</param>
+        /// <param name="rand">Optional random generator; defaults to UnityEngine.Random.value.</param>
+        public static List<DropResult> RollDrops(IEnumerable<ResourceDrop> drops, IList<float> additionalLootChances, float worldX, bool ignoreQuest = false, Func<float> rand = null)
+        {
+            float Rand() => rand != null ? rand() : UnityEngine.Random.value;
+
+            var results = new List<DropResult>();
+            if (drops == null) return results;
+
+            var available = new List<ResourceDrop>();
+            foreach (var drop in drops)
+            {
+                if (drop == null || drop.resource == null) continue;
+                if (drop.weight <= 0f) continue;
+                if (!ignoreQuest && drop.requiredQuest != null && !QuestCompleted(drop.requiredQuest.questId)) continue;
+                if (worldX < drop.minX || worldX > drop.maxX) continue;
+                available.Add(drop);
+            }
+
+            if (available.Count == 0) return results;
+
+            ResourceDrop ChooseWeighted(List<ResourceDrop> pool)
+            {
+                float total = 0f;
+                foreach (var d in pool) total += Mathf.Max(0f, d.weight);
+                float roll = Rand() * total;
+                foreach (var d in pool)
+                {
+                    roll -= Mathf.Max(0f, d.weight);
+                    if (roll <= 0f) return d;
+                }
+                return pool[pool.Count - 1];
+            }
+
+            int RollAmount(ResourceDrop drop)
+            {
+                int min = Mathf.Max(0, drop.dropRange.x);
+                int max = Mathf.Max(min, drop.dropRange.y);
+                float t = Rand();
+                t *= t; // bias towards lower values
+                return Mathf.Clamp(Mathf.FloorToInt(Mathf.Lerp(min, max + 1, t)), min, max);
+            }
+
+            void AddResult(ResourceDrop drop)
+            {
+                int amt = RollAmount(drop);
+                if (amt > 0)
+                    results.Add(new DropResult { resource = drop.resource, count = amt });
+            }
+
+            var selected = ChooseWeighted(available);
+            available.Remove(selected);
+            AddResult(selected);
+
+            if (additionalLootChances != null)
+            {
+                foreach (var chance in additionalLootChances)
+                {
+                    if (available.Count == 0) break;
+                    if (Rand() > Mathf.Clamp01(chance)) break;
+                    selected = ChooseWeighted(available);
+                    available.Remove(selected);
+                    AddResult(selected);
+                }
+            }
+
+            return results;
+        }
+    }
+}

--- a/Assets/Scripts/Upgrades/ResourceDrop.cs
+++ b/Assets/Scripts/Upgrades/ResourceDrop.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.Serialization;
 using TimelessEchoes.Quests;
 
 namespace TimelessEchoes.Upgrades
@@ -8,7 +9,9 @@ namespace TimelessEchoes.Upgrades
     {
         public Resource resource;
         public Vector2Int dropRange = new Vector2Int(1, 1);
-        [Range(0f, 1f)] public float dropChance = 1f;
+        [FormerlySerializedAs("dropChance")]
+        [Tooltip("Relative weight used when selecting this drop." )]
+        [Min(0f)] public float weight = 1f;
         // Minimum world X position required for this drop to occur
         public float minX;
         // Maximum world X position allowed for this drop to occur


### PR DESCRIPTION
## Summary
- replace `dropChance` with weight-based selection in ResourceDrop
- add configurable extra loot slot chances to TaskData, EnemyData, and cores
- overhaul resource drop logic for tasks, enemies, salvage, and editor simulations to use weighted pools
- centralize drop resolution in `DropResolver` utility to avoid duplication
- clamp additional loot chance values between 0 and 1 for safer rolls
- remove stray meta file and obsolete salvage yield field

## Testing
- `dotnet test` *(command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689e6b5e88c0832ea1b1a9819a933a33