### PR TITLE
refactor: add UIUtils.ClearChildren helper and use it across UI

### DIFF
--- a/Assets/Scripts/NpcGeneration/DiscipleGeneratorProgressUI.cs
+++ b/Assets/Scripts/NpcGeneration/DiscipleGeneratorProgressUI.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 using UnityEngine.UI;
 using static TimelessEchoes.TELogger;
 using References.UI;
+using TimelessEchoes.Utilities;
 
 namespace TimelessEchoes.NpcGeneration
 {
@@ -33,8 +34,7 @@ namespace TimelessEchoes.NpcGeneration
             if (generatedParent == null || generatedPrefab == null || generator == null)
                 return;
 
-            foreach (Transform child in generatedParent)
-                Destroy(child.gameObject);
+            UIUtils.ClearChildren(generatedParent);
             resourceUI = null;
 
             var res = generator.Resource;

--- a/Assets/Scripts/NpcGeneration/DiscipleGeneratorUIManager.cs
+++ b/Assets/Scripts/NpcGeneration/DiscipleGeneratorUIManager.cs
@@ -4,6 +4,7 @@ using Blindsided.Utilities;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
+using TimelessEchoes.Utilities;
 using static Blindsided.EventHandler;
 using static Blindsided.SaveData.StaticReferences;
 
@@ -69,8 +70,7 @@ namespace TimelessEchoes.NpcGeneration
             if (progressUIPrefab == null || progressUIParent == null || generationManager == null)
                 return;
 
-            foreach (Transform child in progressUIParent)
-                Destroy(child.gameObject);
+            UIUtils.ClearChildren(progressUIParent);
             entries.Clear();
 
             foreach (var gen in generationManager.Generators)

--- a/Assets/Scripts/Quests/PinnedQuestUIManager.cs
+++ b/Assets/Scripts/Quests/PinnedQuestUIManager.cs
@@ -10,6 +10,7 @@ using UnityEngine.Localization;
 using static Blindsided.EventHandler;
 using static Blindsided.Oracle;
 using static Blindsided.SaveData.StaticReferences;
+using TimelessEchoes.Utilities;
 
 namespace TimelessEchoes.Quests
 {
@@ -72,8 +73,7 @@ namespace TimelessEchoes.Quests
             if (entryPrefab == null || entryParent == null || oracle == null)
                 return;
 
-            foreach (Transform child in entryParent)
-                Destroy(child.gameObject);
+            UIUtils.ClearChildren(entryParent);
             entries.Clear();
 
             foreach (var id in oracle.saveData.PinnedQuests)

--- a/Assets/Scripts/Quests/QuestEntryUI.cs
+++ b/Assets/Scripts/Quests/QuestEntryUI.cs
@@ -9,6 +9,7 @@ using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
 using UnityEngine.Localization;
+using TimelessEchoes.Utilities;
 
 namespace TimelessEchoes.Quests
 {
@@ -113,8 +114,7 @@ namespace TimelessEchoes.Quests
             costSlots.Clear();
             if (costParent != null)
             {
-                foreach (Transform child in costParent)
-                    Destroy(child.gameObject);
+                UIUtils.ClearChildren(costParent);
                 if (data != null && costSlotPrefab != null && showRequirements)
                 {
                     var inventoryUI = ResourceInventoryUI.Instance;

--- a/Assets/Scripts/Skills/MilestoneBonusUI.cs
+++ b/Assets/Scripts/Skills/MilestoneBonusUI.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 using UnityEngine.UI;
 using References.UI;
 using TimelessEchoes;
+using TimelessEchoes.Utilities;
 
 namespace TimelessEchoes.Skills
 {
@@ -69,8 +70,7 @@ namespace TimelessEchoes.Skills
             if (entryParent == null)
                 return;
 
-            foreach (Transform child in entryParent)
-                Destroy(child.gameObject);
+            UIUtils.ClearChildren(entryParent);
 
 
             foreach (var milestone in skill.milestones)

--- a/Assets/Scripts/UI/EnemyStatsPanelUI.cs
+++ b/Assets/Scripts/UI/EnemyStatsPanelUI.cs
@@ -6,6 +6,7 @@ using TimelessEchoes.Enemies;
 using TimelessEchoes.Stats;
 using Blindsided.Utilities;
 using static TimelessEchoes.TELogger;
+using TimelessEchoes.Utilities;
 
 namespace TimelessEchoes.UI
 {
@@ -70,8 +71,7 @@ namespace TimelessEchoes.UI
             if (references == null || references.enemyEntryParent == null || references.enemyEntryPrefab == null)
                 return;
 
-            foreach (Transform child in references.enemyEntryParent)
-                Destroy(child.gameObject);
+            UIUtils.ClearChildren(references.enemyEntryParent);
 
             var allStats = Blindsided.Utilities.AssetCache.GetAll<EnemyData>("");
             var sorted = allStats

--- a/Assets/Scripts/UI/ItemStatsPanelUI.cs
+++ b/Assets/Scripts/UI/ItemStatsPanelUI.cs
@@ -8,6 +8,7 @@ using TimelessEchoes.Enemies;
 using UnityEngine;
 using static Blindsided.Oracle;
 using static TimelessEchoes.TELogger;
+using TimelessEchoes.Utilities;
 
 namespace TimelessEchoes.UI
 {
@@ -73,8 +74,7 @@ namespace TimelessEchoes.UI
             if (references == null || references.itemEntryParent == null || references.itemEntryPrefab == null)
                 return;
 
-            foreach (Transform child in references.itemEntryParent)
-                Destroy(child.gameObject);
+            UIUtils.ClearChildren(references.itemEntryParent);
 
             var allResources = Blindsided.Utilities.AssetCache.GetAll<Resource>("Resource Items");
             var sorted = allResources

--- a/Assets/Scripts/UI/TaskStatsPanelUI.cs
+++ b/Assets/Scripts/UI/TaskStatsPanelUI.cs
@@ -6,6 +6,7 @@ using TimelessEchoes.Stats;
 using TimelessEchoes.Tasks;
 using UnityEngine;
 using static TimelessEchoes.TELogger;
+using TimelessEchoes.Utilities;
 
 namespace TimelessEchoes.UI
 {
@@ -81,8 +82,7 @@ namespace TimelessEchoes.UI
             if (references == null || references.taskEntryParent == null || references.taskEntryPrefab == null)
                 return;
 
-            foreach (Transform child in references.taskEntryParent)
-                Destroy(child.gameObject);
+            UIUtils.ClearChildren(references.taskEntryParent);
 
             var allTasks = Blindsided.Utilities.AssetCache.GetAll<TaskData>("Tasks");
             var sorted = allTasks

--- a/Assets/Scripts/Upgrades/RunResourceTrackerUI.cs
+++ b/Assets/Scripts/Upgrades/RunResourceTrackerUI.cs
@@ -5,6 +5,7 @@ using UnityEngine.InputSystem;
 using static TimelessEchoes.TELogger;
 using static Blindsided.Utilities.CalcUtils;
 using TMPro;
+using TimelessEchoes.Utilities;
 
 namespace TimelessEchoes.Upgrades
 {
@@ -67,10 +68,7 @@ namespace TimelessEchoes.Upgrades
 
         private void ClearSlots()
         {
-            if (slotParent == null)
-                return;
-            foreach (Transform child in slotParent)
-                Destroy(child.gameObject);
+            UIUtils.ClearChildren(slotParent);
         }
 
         private void OnResourceAdded(Resource resource, double amount, bool bonus)

--- a/Assets/Scripts/Upgrades/StatUpgradeUIManager.cs
+++ b/Assets/Scripts/Upgrades/StatUpgradeUIManager.cs
@@ -7,6 +7,7 @@ using UnityEngine;
 using static Blindsided.SaveData.StaticReferences;
 using static Blindsided.EventHandler;
 using static TimelessEchoes.TELogger;
+using TimelessEchoes.Utilities;
 
 namespace TimelessEchoes.Upgrades
 {
@@ -138,8 +139,7 @@ namespace TimelessEchoes.Upgrades
 
                 if (parent != null && prefab != null)
                 {
-                    foreach (Transform child in parent.transform)
-                        Destroy(child.gameObject);
+                    UIUtils.ClearChildren(parent);
 
                     var threshold = GetThreshold(upgrades[i]);
                     if (threshold != null)

--- a/Assets/Scripts/Utilities/UIUtils.cs
+++ b/Assets/Scripts/Utilities/UIUtils.cs
@@ -1,0 +1,23 @@
+using UnityEngine;
+
+namespace TimelessEchoes.Utilities
+{
+    /// <summary>
+    ///     Common UI helper methods.
+    /// </summary>
+    public static class UIUtils
+    {
+        /// <summary>
+        ///     Destroys all child GameObjects of the given parent Transform.
+        /// </summary>
+        /// <param name="parent">The parent transform whose children will be destroyed.</param>
+        public static void ClearChildren(Transform parent)
+        {
+            if (parent == null)
+                return;
+
+            foreach (Transform child in parent)
+                Object.Destroy(child.gameObject);
+        }
+    }
+}

--- a/Assets/Scripts/Utilities/UIUtils.cs.meta
+++ b/Assets/Scripts/Utilities/UIUtils.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a89257f456964ad0b139e51511cd28ef


### PR DESCRIPTION
## Summary
- add `UIUtils.ClearChildren` utility for clearing child transforms
- use `UIUtils.ClearChildren` in disciple generator, quest, stats panels, and various UI managers

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689eacbfbd58832e9fe061d0bf015241