### PR TITLE
Refactor managers to shared Singleton base

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -18,6 +18,7 @@ using TimelessEchoes.Tasks;
 using TimelessEchoes.Upgrades;
 using TimelessEchoes.UI;
 using TimelessEchoes.References.StatPanel;
+using TimelessEchoes.Utilities;
 using static TimelessEchoes.Quests.QuestUtils;
 using TMPro;
 using Unity.Cinemachine;
@@ -33,9 +34,8 @@ namespace TimelessEchoes
     /// <summary>
     ///     Controls map generation, camera switching and UI visibility.
     /// </summary>
-    public class GameManager : MonoBehaviour
+    public class GameManager : Singleton<GameManager>
     {
-        public static GameManager Instance { get; private set; }
         public static MapGenerationConfig CurrentGenerationConfig { get; private set; }
         [TitleGroup("Prefabs")]
         [SerializeField] private GameObject mapPrefab;
@@ -166,9 +166,10 @@ namespace TimelessEchoes
             }
         }
 
-        private void Awake()
+        protected override void Awake()
         {
-            Instance = this;
+            base.Awake();
+            if (Instance != this) return;
             cloudSpawner = CloudSpawner.Instance;
             foreach (var entry in generationButtons)
             {
@@ -199,10 +200,9 @@ namespace TimelessEchoes
             }
         }
 
-        private void OnDestroy()
+        protected override void OnDestroy()
         {
-            if (Instance == this)
-                Instance = null;
+            base.OnDestroy();
             if (returnToTavernButton != null)
                 returnToTavernButton.onClick.RemoveListener(OnReturnToTavernButton);
             if (returnOnDeathButton != null)

--- a/Assets/Scripts/NpcGeneration/DiscipleGenerationManager.cs
+++ b/Assets/Scripts/NpcGeneration/DiscipleGenerationManager.cs
@@ -6,6 +6,7 @@ using TimelessEchoes.Stats;
 using UnityEngine;
 using static Blindsided.EventHandler;
 using static Blindsided.Oracle;
+using TimelessEchoes.Utilities;
 
 namespace TimelessEchoes.NpcGeneration
 {
@@ -13,9 +14,8 @@ namespace TimelessEchoes.NpcGeneration
     /// Central manager that updates all NPC resource generators and applies offline progress.
     /// </summary>
     [DefaultExecutionOrder(-1)]
-    public class DiscipleGenerationManager : MonoBehaviour
+    public class DiscipleGenerationManager : Singleton<DiscipleGenerationManager>
     {
-        public static DiscipleGenerationManager Instance { get; private set; }
         [SerializeField] private DiscipleGenerator generatorPrefab;
 
         private readonly List<DiscipleGenerator> generators = new();
@@ -30,9 +30,10 @@ namespace TimelessEchoes.NpcGeneration
 
         private static Dictionary<string, Resource> lookup;
 
-        private void Awake()
+        protected override void Awake()
         {
-            Instance = this;
+            base.Awake();
+            if (Instance != this) return;
             resourceManager = ResourceManager.Instance;
             statTracker = GameplayStatTracker.Instance;
             if (resourceManager != null)
@@ -43,16 +44,15 @@ namespace TimelessEchoes.NpcGeneration
             OnQuestHandin += OnQuestHandinHandler;
         }
 
-        private void OnDestroy()
+        protected override void OnDestroy()
         {
+            base.OnDestroy();
             if (resourceManager != null)
                 resourceManager.OnInventoryChanged -= OnInventoryChanged;
             if (statTracker != null)
                 statTracker.OnRunEnded -= OnRunEnded;
             OnLoadData -= OnLoadDataHandler;
             OnQuestHandin -= OnQuestHandinHandler;
-            if (Instance == this)
-                Instance = null;
         }
 
         private void OnRunEnded(bool died)

--- a/Assets/Scripts/NpcGeneration/DiscipleGeneratorUIManager.cs
+++ b/Assets/Scripts/NpcGeneration/DiscipleGeneratorUIManager.cs
@@ -6,15 +6,15 @@ using UnityEngine;
 using UnityEngine.UI;
 using static Blindsided.EventHandler;
 using static Blindsided.SaveData.StaticReferences;
+using TimelessEchoes.Utilities;
 
 namespace TimelessEchoes.NpcGeneration
 {
     /// <summary>
     ///     Builds UI entries for all disciple generators and handles collecting resources.
     /// </summary>
-    public class DiscipleGeneratorUIManager : MonoBehaviour
+    public class DiscipleGeneratorUIManager : Singleton<DiscipleGeneratorUIManager>
     {
-        public static DiscipleGeneratorUIManager Instance { get; private set; }
         [SerializeField] private DiscipleGeneratorProgressUI progressUIPrefab;
         [SerializeField] private Transform progressUIParent;
         [SerializeField] private Button collectAllButton;
@@ -24,9 +24,10 @@ namespace TimelessEchoes.NpcGeneration
         private DiscipleGenerationManager generationManager;
         private readonly Dictionary<DiscipleGenerator, DiscipleGeneratorProgressUI> entries = new();
 
-        private void Awake()
+        protected override void Awake()
         {
-            Instance = this;
+            base.Awake();
+            if (Instance != this) return;
             generationManager = DiscipleGenerationManager.Instance;
             if (collectAllButton != null)
                 collectAllButton.onClick.AddListener(CollectAll);
@@ -53,14 +54,13 @@ namespace TimelessEchoes.NpcGeneration
             OnLoadData -= OnLoadDataHandler;
         }
 
-        private void OnDestroy()
+        protected override void OnDestroy()
         {
+            base.OnDestroy();
             if (collectAllButton != null)
                 collectAllButton.onClick.RemoveListener(CollectAll);
             if (generationManager != null)
                 generationManager.OnGeneratorsRebuilt -= OnGeneratorsRebuilt;
-            if (Instance == this)
-                Instance = null;
             OnQuestHandin -= OnQuestHandinHandler;
         }
 

--- a/Assets/Scripts/Quests/QuestManager.cs
+++ b/Assets/Scripts/Quests/QuestManager.cs
@@ -16,15 +16,15 @@ using static Blindsided.EventHandler;
 using static Blindsided.SaveData.StaticReferences;
 using static TimelessEchoes.TELogger;
 using Resources = UnityEngine.Resources;
+using TimelessEchoes.Utilities;
 
 namespace TimelessEchoes.Quests
 {
     /// <summary>
     ///     Handles quest logic and progress tracking.
     /// </summary>
-    public class QuestManager : MonoBehaviour
+    public class QuestManager : Singleton<QuestManager>
     {
-        public static QuestManager Instance { get; private set; }
         private ResourceManager resourceManager;
         private EnemyKillTracker killTracker;
         private DiscipleGenerationManager generationManager;
@@ -44,9 +44,10 @@ namespace TimelessEchoes.Quests
             public bool ReadyForTurnIn;
         }
 
-        private void Awake()
+        protected override void Awake()
         {
-            Instance = this;
+            base.Awake();
+            if (Instance != this) return;
             quests = new List<QuestData>(Blindsided.Utilities.AssetCache.GetAll<QuestData>(questResourcePath));
             resourceManager = ResourceManager.Instance;
             if (resourceManager == null)
@@ -79,8 +80,9 @@ namespace TimelessEchoes.Quests
             OnLoadData += OnLoadDataHandler;
         }
 
-        private void OnDestroy()
+        protected override void OnDestroy()
         {
+            base.OnDestroy();
             if (resourceManager != null)
                 resourceManager.OnInventoryChanged -= UpdateAllProgress;
             if (killTracker != null)
@@ -90,9 +92,6 @@ namespace TimelessEchoes.Quests
                 statTracker.OnDistanceAdded -= OnDistanceAdded;
                 statTracker.OnRunEnded -= OnRunEnded;
             }
-
-            if (Instance == this)
-                Instance = null;
 
             OnLoadData -= OnLoadDataHandler;
         }

--- a/Assets/Scripts/Upgrades/ResourceManager.cs
+++ b/Assets/Scripts/Upgrades/ResourceManager.cs
@@ -9,13 +9,13 @@ using static Blindsided.Oracle;
 using static TimelessEchoes.TELogger;
 using static Blindsided.SaveData.StaticReferences;
 using Resources = UnityEngine.Resources;
+using TimelessEchoes.Utilities;
 
 namespace TimelessEchoes.Upgrades
 {
     [DefaultExecutionOrder(-2)]
-    public class ResourceManager : MonoBehaviour
+    public class ResourceManager : Singleton<ResourceManager>
     {
-        public static ResourceManager Instance { get; private set; }
         private static Dictionary<string, Resource> lookup;
 
         /// <summary>
@@ -42,18 +42,18 @@ namespace TimelessEchoes.Upgrades
             OnInventoryChanged?.Invoke();
         }
 
-        private void Awake()
+        protected override void Awake()
         {
-            Instance = this;
+            base.Awake();
+            if (Instance != this) return;
             LoadState();
             OnSaveData += SaveState;
             OnLoadData += LoadState;
         }
 
-        private void OnDestroy()
+        protected override void OnDestroy()
         {
-            if (Instance == this)
-                Instance = null;
+            base.OnDestroy();
             OnSaveData -= SaveState;
             OnLoadData -= LoadState;
         }

--- a/Assets/Scripts/Utilities/Singleton.cs
+++ b/Assets/Scripts/Utilities/Singleton.cs
@@ -1,0 +1,40 @@
+using UnityEngine;
+
+namespace TimelessEchoes.Utilities
+{
+    /// <summary>
+    /// Generic singleton base class for MonoBehaviours.
+    /// </summary>
+    /// <typeparam name="T">Type deriving from MonoBehaviour.</typeparam>
+    public class Singleton<T> : MonoBehaviour where T : MonoBehaviour
+    {
+        /// <summary>
+        /// The current instance of <typeparamref name="T"/>.
+        /// </summary>
+        public static T Instance { get; private set; }
+
+        /// <summary>
+        /// Assigns the singleton instance and destroys duplicates.
+        /// </summary>
+        protected virtual void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+            Instance = this as T;
+        }
+
+        /// <summary>
+        /// Clears the singleton instance when destroyed.
+        /// </summary>
+        protected virtual void OnDestroy()
+        {
+            if (Instance == this)
+            {
+                Instance = null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add reusable `Singleton<T>` MonoBehaviour
- refactor GameManager and various NPC/resource/quest managers to derive from it

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689eace0ae90832ea737d71a6a8d058c