### PR TITLE
Refactor deferred coroutines with CoroutineUtils helper

### DIFF
--- a/Assets/Scripts/Buffs/BuffUIManager.cs
+++ b/Assets/Scripts/Buffs/BuffUIManager.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using System.Collections.Generic;
 using References.UI;
 using TimelessEchoes.Hero;
@@ -10,6 +9,7 @@ using UnityEngine.InputSystem;
 using static Blindsided.EventHandler;
 using static TimelessEchoes.TELogger;
 using static Blindsided.Utilities.CalcUtils;
+using TimelessEchoes.Utilities;
 
 namespace TimelessEchoes.Buffs
 {
@@ -334,19 +334,20 @@ namespace TimelessEchoes.Buffs
 
         private void OnLoadDataHandler()
         {
-            StartCoroutine(DeferredRefresh());
+            CoroutineUtils.RunNextFrame(this, () =>
+            {
+                BuildRecipeEntries();
+                RefreshSlots();
+            });
         }
 
         private void OnQuestHandinHandler(string questId)
         {
-            StartCoroutine(DeferredRefresh());
-        }
-
-        private IEnumerator DeferredRefresh()
-        {
-            yield return null;
-            BuildRecipeEntries();
-            RefreshSlots();
+            CoroutineUtils.RunNextFrame(this, () =>
+            {
+                BuildRecipeEntries();
+                RefreshSlots();
+            });
         }
 
         private void PurchaseBuff(BuffRecipe recipe)

--- a/Assets/Scripts/NpcGeneration/DiscipleGenerationManager.cs
+++ b/Assets/Scripts/NpcGeneration/DiscipleGenerationManager.cs
@@ -1,9 +1,9 @@
-using System.Collections;
 using System.Collections.Generic;
 using Blindsided.SaveData;
 using TimelessEchoes.Upgrades;
 using TimelessEchoes.Stats;
 using UnityEngine;
+using TimelessEchoes.Utilities;
 using static Blindsided.EventHandler;
 using static Blindsided.Oracle;
 
@@ -70,24 +70,18 @@ namespace TimelessEchoes.NpcGeneration
             if (count != lastUnlockedCount)
             {
                 lastUnlockedCount = count;
-                StartCoroutine(DeferredBuild());
+                CoroutineUtils.RunNextFrame(this, BuildGenerators);
             }
         }
 
         private void OnLoadDataHandler()
         {
-            StartCoroutine(DeferredBuild());
+            CoroutineUtils.RunNextFrame(this, BuildGenerators);
         }
 
         private void OnQuestHandinHandler(string questId)
         {
-            StartCoroutine(DeferredBuild());
-        }
-
-        private IEnumerator DeferredBuild()
-        {
-            yield return null;
-            BuildGenerators();
+            CoroutineUtils.RunNextFrame(this, BuildGenerators);
         }
 
         private static void EnsureLookup()

--- a/Assets/Scripts/NpcGeneration/DiscipleGeneratorUIManager.cs
+++ b/Assets/Scripts/NpcGeneration/DiscipleGeneratorUIManager.cs
@@ -1,9 +1,9 @@
-using System.Collections;
 using System.Collections.Generic;
 using Blindsided.Utilities;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
+using TimelessEchoes.Utilities;
 using static Blindsided.EventHandler;
 using static Blindsided.SaveData.StaticReferences;
 
@@ -37,7 +37,7 @@ namespace TimelessEchoes.NpcGeneration
 
         private void Start()
         {
-            StartCoroutine(DeferredBuild());
+            CoroutineUtils.RunNextFrame(this, BuildEntries, 2);
         }
 
         private void OnEnable()
@@ -96,24 +96,17 @@ namespace TimelessEchoes.NpcGeneration
 
         private void OnQuestHandinHandler(string questId)
         {
-            StartCoroutine(DeferredBuild());
+            CoroutineUtils.RunNextFrame(this, BuildEntries, 2);
         }
 
         private void OnLoadDataHandler()
         {
-            StartCoroutine(DeferredBuild());
+            CoroutineUtils.RunNextFrame(this, BuildEntries, 2);
         }
 
         private void OnGeneratorsRebuilt()
         {
-            StartCoroutine(DeferredBuild());
-        }
-
-        private IEnumerator DeferredBuild()
-        {
-            yield return null;
-            yield return null;
-            BuildEntries();
+            CoroutineUtils.RunNextFrame(this, BuildEntries, 2);
         }
 
         private void Update()

--- a/Assets/Scripts/Quests/PinnedQuestUIManager.cs
+++ b/Assets/Scripts/Quests/PinnedQuestUIManager.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using System.Collections.Generic;
 using System.Text;
 using Blindsided.Utilities;
@@ -7,6 +6,7 @@ using TimelessEchoes.Upgrades;
 using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.Localization;
+using TimelessEchoes.Utilities;
 using static Blindsided.EventHandler;
 using static Blindsided.Oracle;
 using static Blindsided.SaveData.StaticReferences;
@@ -268,14 +268,8 @@ namespace TimelessEchoes.Quests
 
         private void OnLoadDataHandler()
         {
-            StartCoroutine(DeferredRefresh());
+            CoroutineUtils.RunNextFrame(this, RefreshPins);
             ApplySavedState();
-        }
-
-        private IEnumerator DeferredRefresh()
-        {
-            yield return null; // wait one frame so data is loaded
-            RefreshPins();
         }
 
         private void OnToggle()

--- a/Assets/Scripts/Utilities/CoroutineUtils.cs
+++ b/Assets/Scripts/Utilities/CoroutineUtils.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections;
+using UnityEngine;
+
+namespace TimelessEchoes.Utilities
+{
+    /// <summary>
+    /// Utility helpers for running actions after waiting for frames using coroutines.
+    /// </summary>
+    public static class CoroutineUtils
+    {
+        /// <summary>
+        /// Runs an action after yielding the specified number of frames.
+        /// </summary>
+        /// <param name="host">MonoBehaviour used to start the coroutine.</param>
+        /// <param name="action">Action to invoke after the delay.</param>
+        /// <param name="frames">Number of frames to wait before invoking the action. Defaults to 1.</param>
+        public static void RunNextFrame(MonoBehaviour host, Action action, int frames = 1)
+        {
+            if (host == null || action == null)
+                return;
+
+            host.StartCoroutine(RunNextFrameRoutine(action, frames));
+        }
+
+        private static IEnumerator RunNextFrameRoutine(Action action, int frames)
+        {
+            for (var i = 0; i < frames; i++)
+                yield return null;
+            action();
+        }
+    }
+}

--- a/Assets/Scripts/Utilities/CoroutineUtils.cs.meta
+++ b/Assets/Scripts/Utilities/CoroutineUtils.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0c37e7c78ffc496885ae2de9377d7aa6


### PR DESCRIPTION
## Summary
- add `CoroutineUtils.RunNextFrame` to simplify running actions after waiting frames
- replace bespoke deferred coroutines in generation and UI managers with the helper

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689ead2e6f3c832eacce91dd9fc44b16