### PR TITLE
Add ingot crafting UI and logic

### DIFF
--- a/Assets/Scripts/Gear/SO/CoreSO.cs
+++ b/Assets/Scripts/Gear/SO/CoreSO.cs
@@ -19,8 +19,12 @@ namespace TimelessEchoes.Gear
     public class CoreSO : ScriptableObject
     {
         [Range(0, 7)] public int tierIndex;
-        [Title("Cost")] public Resource requiredIngot;
+        [Title("Associated Resources")] public Resource requiredIngot;
         [MinValue(0)] public int ingotCost = 1;
+        public Resource chunkResource;
+        [MinValue(0)] public int chunkCostPerIngot = 0;
+        public Resource crystalResource;
+        [MinValue(0)] public int crystalCostPerIngot = 0;
 
         [Title("Rarity Weights (manual)")]
         [Tooltip("Manual weights normalized at runtime to pick a rarity. Leave 0 to exclude a rarity.")]


### PR DESCRIPTION
## Summary
- Rename CoreSO cost section to Associated Resources and add chunk/crystal requirements for ingot crafting
- Display fixed core and ingot costs in forge previews and show chunk/crystal conversion costs
- Implement ingot crafting with single and bulk buttons including hold-to-craft behavior

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689eac9bd060832ebfaaf1bcee45b152