### PR TITLE
Add location-based object state controller

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -113,6 +113,7 @@ namespace TimelessEchoes
         private CinemachineCamera mapCamera;
         private TaskController taskController;
         private NpcObjectStateController npcObjectStateController;
+        private LocationObjectStateController locationObjectStateController;
         private GameplayStatTracker statTracker;
         private System.Action<bool> runEndedAction;
         private bool returnOnDeathQueued;
@@ -190,6 +191,9 @@ namespace TimelessEchoes
             npcObjectStateController = NpcObjectStateController.Instance;
             if (npcObjectStateController == null)
                 Log("NpcObjectStateController missing", TELogCategory.General, this);
+            locationObjectStateController = LocationObjectStateController.Instance;
+            if (locationObjectStateController == null)
+                Log("LocationObjectStateController missing", TELogCategory.General, this);
             statTracker = GameplayStatTracker.Instance;
             if (statTracker == null)
                 Log("GameplayStatTracker missing", TELogCategory.General, this);
@@ -239,7 +243,8 @@ namespace TimelessEchoes
             if (returnOnDeathText != null)
                 returnOnDeathText.text = "Return On Death";
             npcObjectStateController?.UpdateObjectStates();
-            
+            locationObjectStateController?.UpdateObjectStates();
+
             UpdateGenerationButtonStats();
             nextStatsUpdateTime = Time.time + statsUpdateInterval;
         }
@@ -498,6 +503,7 @@ namespace TimelessEchoes
             if (runCalebUI != null)
                 runCalebUI.gameObject.SetActive(true);
             npcObjectStateController?.UpdateObjectStates();
+            locationObjectStateController?.UpdateObjectStates();
 
             // Start monitoring for stalled distance after run begins
             if (stallMonitorCoroutine != null)
@@ -753,6 +759,7 @@ namespace TimelessEchoes
             runResourceTracker?.ShowWindow();
             resetRunResourceTracker = true;
             npcObjectStateController?.UpdateObjectStates();
+            locationObjectStateController?.UpdateObjectStates();
 #if !DISABLESTEAMWORKS
             RichPresenceManager.Instance?.SetInTown();
 #endif

--- a/Assets/Scripts/LocationObjectStateController.cs
+++ b/Assets/Scripts/LocationObjectStateController.cs
@@ -1,0 +1,83 @@
+using System.Collections.Generic;
+using Blindsided;
+using TimelessEchoes.Quests;
+using UnityEngine;
+using static TimelessEchoes.Quests.QuestUtils;
+
+namespace TimelessEchoes
+{
+    /// <summary>
+    /// Enables or disables objects based on whether the player is in town or in a run.
+    /// Entries may optionally require a quest to be completed before activation.
+    /// </summary>
+    public class LocationObjectStateController : MonoBehaviour
+    {
+        public static LocationObjectStateController Instance { get; private set; }
+
+        [System.Serializable]
+        public class Entry
+        {
+            public GameObject gameObject;
+            public QuestData requiredQuest;
+        }
+
+        [SerializeField]
+        private List<Entry> enableInTown = new();
+        [SerializeField]
+        private List<Entry> enableInRun = new();
+
+        private void Awake()
+        {
+            Instance = this;
+        }
+
+        private void OnDestroy()
+        {
+            if (Instance == this)
+                Instance = null;
+        }
+
+        private void OnEnable()
+        {
+            EventHandler.OnLoadData += UpdateObjectStates;
+            EventHandler.OnQuestHandin += OnQuestHandin;
+        }
+
+        private void OnDisable()
+        {
+            EventHandler.OnLoadData -= UpdateObjectStates;
+            EventHandler.OnQuestHandin -= OnQuestHandin;
+        }
+
+        private void Start()
+        {
+            UpdateObjectStates();
+        }
+
+        private void OnQuestHandin(string questId)
+        {
+            UpdateObjectStates();
+        }
+
+        /// <summary>
+        /// Iterates over all entries and updates the active state of their objects.
+        /// </summary>
+        public void UpdateObjectStates()
+        {
+            bool inRun = GameManager.Instance != null && GameManager.Instance.CurrentMap != null;
+            foreach (var entry in enableInTown)
+            {
+                if (entry?.gameObject == null) continue;
+                bool questOk = entry.requiredQuest == null || QuestCompleted(entry.requiredQuest.questId);
+                entry.gameObject.SetActive(!inRun && questOk);
+            }
+            foreach (var entry in enableInRun)
+            {
+                if (entry?.gameObject == null) continue;
+                bool questOk = entry.requiredQuest == null || QuestCompleted(entry.requiredQuest.questId);
+                entry.gameObject.SetActive(inRun && questOk);
+            }
+        }
+    }
+}
+

--- a/Assets/Scripts/LocationObjectStateController.cs.meta
+++ b/Assets/Scripts/LocationObjectStateController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: aa930b9f118c4f10a5507ccef5d9cdaf


### PR DESCRIPTION
## Summary
- add LocationObjectStateController for toggling objects in town vs run with optional quest requirements
- update GameManager to trigger location object updates when transitioning between town and run

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689eba538fcc832eba9f1c6b2f50a9a8