### PR TITLE
Add Discord and Autopin toggles to TownWindowManager

### DIFF
--- a/Assets/Scripts/UI/TownWindowManager.cs
+++ b/Assets/Scripts/UI/TownWindowManager.cs
@@ -36,6 +36,8 @@ namespace TimelessEchoes.UI
         [SerializeField] [Space] private WindowReference forge = new();
         [SerializeField] [Space] private WindowReference inventory = new();
         [SerializeField] [Space] private WindowReference options = new();
+        [SerializeField] [Space] private GameObject discord;
+        [SerializeField] [Space] private GameObject autoPin;
         [SerializeField] [Space] private GameObject townButtons;
         [SerializeField] [Space] private GameObject windowsOpenIndicator;
         [SerializeField] [Space] private Button closeButton;
@@ -140,6 +142,8 @@ namespace TimelessEchoes.UI
                 if (quests.window != null)
                 {
                     quests.window.SetActive(true);
+                    if (autoPin != null)
+                        autoPin.SetActive(true);
                     if (quests.button != null)
                         quests.button.interactable = false;
                 }
@@ -168,6 +172,8 @@ namespace TimelessEchoes.UI
         private void OpenQuests()
         {
             ToggleWindow(quests);
+            if (autoPin != null)
+                autoPin.SetActive(true);
         }
 
         private void OpenCredits()
@@ -193,6 +199,8 @@ namespace TimelessEchoes.UI
         private void OpenOptions()
         {
             ToggleWindow(options);
+            if (discord != null)
+                discord.SetActive(true);
         }
 
         private void OpenForge()
@@ -256,6 +264,10 @@ namespace TimelessEchoes.UI
                 forge.window.SetActive(false);
             if (inventory.window != null)
                 inventory.window.SetActive(false);
+            if (discord != null)
+                discord.SetActive(false);
+            if (autoPin != null)
+                autoPin.SetActive(false);
 
             EnableAllWindowButtons();
             UpdateTownButtonsVisibility();


### PR DESCRIPTION
## Summary
- Add Discord and Autopin GameObject references in TownWindowManager
- Show AutoPin when quests open and hide on close
- Show Discord link with options window and hide with others

## Testing
- `dotnet test` *(fails: MSB1003 Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689ecb1f4fb0832e9105b5a6a1155b47