### PR TITLE
Remove prefix from distance readout

### DIFF
--- a/Assets/Scripts/UI/MapUI.cs
+++ b/Assets/Scripts/UI/MapUI.cs
@@ -24,7 +24,7 @@ namespace TimelessEchoes.UI
             if (distanceText != null)
             {
                 var x = Mathf.FloorToInt(distance);
-                distanceText.text = $"Distance Reached: {x}";
+                distanceText.text = x.ToString();
             }
 
             if (distanceSlider != null)


### PR DESCRIPTION
## Summary
- show only the numeric distance in the map UI

## Testing
- `dotnet test` (fails: MSB1003 project/solution file not found)


------
https://chatgpt.com/codex/tasks/task_e_689ed8f254a0832e9324f82c4b0d8ecf