### PR TITLE
Add middle stat field to run UI and rearrange HUD stats

### DIFF
--- a/Assets/Scripts/References/UI/RunCalebUIReferences.cs
+++ b/Assets/Scripts/References/UI/RunCalebUIReferences.cs
@@ -8,6 +8,7 @@ namespace References.UI
     public class RunCalebUIReferences : MonoBehaviour
     {
         public TMP_Text leftText;
+        public TMP_Text middleText;
         public TMP_Text rightText;
         public Button skillsButton;
         public SlicedFilledImage healthBar;


### PR DESCRIPTION
## Summary
- add `middleText` to RunCalebUIReferences
- move defense/regen/health to left text and show attack stats in new middle text
- display move speed in right text and wire up sprite assets

## Testing
- ⚠️ `dotnet test` *(command not found: dotnet)*
- ⚠️ `apt-get install -y dotnet-sdk-8.0` *(package not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ed9f93344832e8aa2dc8faa64e485