### PR TITLE
feat: add explicit critical hit flag

### DIFF
--- a/Assets/Scripts/Enemies/Enemy.cs
+++ b/Assets/Scripts/Enemies/Enemy.cs
@@ -321,7 +321,7 @@ namespace TimelessEchoes.Enemies
             projObj.transform.rotation = Quaternion.identity;
             var proj = projObj.GetComponent<Projectile>();
             if (proj != null)
-                proj.Init(setter.target, stats.GetDamageForLevel(level), false, null, null, 0f, level);
+                proj.Init(setter.target, stats.GetDamageForLevel(level), false, null, null, 0f, false, level);
         }
 
         private void OnDeath()

--- a/Assets/Scripts/Enemies/Health.cs
+++ b/Assets/Scripts/Enemies/Health.cs
@@ -45,9 +45,11 @@ namespace TimelessEchoes.Enemies
             return Blindsided.SaveData.StaticReferences.EnemyFloatingDamage;
         }
 
-        public override void TakeDamage(float amount, float bonusDamage = 0f)
+        public override void TakeDamage(float amount, float bonusDamage = 0f, bool isCritical = false)
         {
             if (CurrentHealth <= 0f) return;
+
+            lastHitWasCritical = isCritical;
 
             var enemy = GetComponent<Enemy>();
             var defense = enemy != null ? enemy.GetDefense() : 0f;

--- a/Assets/Scripts/HealthBase.cs
+++ b/Assets/Scripts/HealthBase.cs
@@ -25,7 +25,7 @@ namespace TimelessEchoes
             OnHealthChanged?.Invoke(CurrentHealth, MaxHealth);
         }
 
-        public virtual void TakeDamage(float amount, float bonusDamage = 0f)
+        public virtual void TakeDamage(float amount, float bonusDamage = 0f, bool isCritical = false)
         {
             if (CurrentHealth <= 0f) return;
 
@@ -34,8 +34,7 @@ namespace TimelessEchoes
             UpdateBar();
             OnHealthChanged?.Invoke(CurrentHealth, MaxHealth);
 
-            // Heuristic: consider it a crit if bonusDamage is at least the base portion
-            lastHitWasCritical = bonusDamage >= amount - 0.0001f;
+            lastHitWasCritical = isCritical;
 
             if (Application.isPlaying && ShouldShowFloatingText())
                 ShowFloatingText(total, bonusDamage);

--- a/Assets/Scripts/Hero/EchoHealthProxy.cs
+++ b/Assets/Scripts/Hero/EchoHealthProxy.cs
@@ -10,9 +10,9 @@ namespace TimelessEchoes.Hero
         public float CurrentHealth => HeroHealth.Instance != null ? HeroHealth.Instance.CurrentHealth : 0f;
         public float MaxHealth => HeroHealth.Instance != null ? HeroHealth.Instance.MaxHealth : 0f;
 
-        public void TakeDamage(float amount, float bonusDamage = 0f)
+        public void TakeDamage(float amount, float bonusDamage = 0f, bool isCritical = false)
         {
-            HeroHealth.Instance?.TakeDamage(amount, bonusDamage);
+            HeroHealth.Instance?.TakeDamage(amount, bonusDamage, isCritical);
         }
     }
 }

--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -1027,13 +1027,15 @@ namespace TimelessEchoes.Hero
                     }
                 }
 
+                bool isCritical = false;
                 if (critChance > 0f && Random.value < Mathf.Clamp01(critChance))
                 {
                     total *= 2f;
+                    isCritical = true;
                 }
 
                 var bonusDamage = total - dmgBase;
-                proj.Init(target, total, true, null, combatSkill, bonusDamage);
+                proj.Init(target, total, true, null, combatSkill, bonusDamage, isCritical);
             }
         }
 

--- a/Assets/Scripts/Hero/HeroHealth.cs
+++ b/Assets/Scripts/Hero/HeroHealth.cs
@@ -88,33 +88,33 @@ namespace TimelessEchoes.Hero
             return Blindsided.SaveData.StaticReferences.PlayerFloatingDamage;
         }
 
-        public override void TakeDamage(float amount, float bonusDamage = 0f)
+        public override void TakeDamage(float amount, float bonusDamage = 0f, bool isCritical = false)
         {
             if (Immortal) return;
             controller = controller != null ? controller : GetComponent<HeroController>();
             if (controller != null && controller.IsEcho && Instance != null && Instance != this)
             {
-                Instance.TakeDamage(amount * 0.5f, bonusDamage);
+                Instance.TakeDamage(amount * 0.5f, bonusDamage, isCritical);
                 return;
             }
-            base.TakeDamage(amount, bonusDamage);
+            base.TakeDamage(amount, bonusDamage, isCritical);
         }
 
         /// <summary>
         /// Apply damage from an enemy, providing the enemy's level so defense scaling can be applied.
         /// </summary>
-        public void TakeDamageFromEnemy(float amount, int enemyLevel, float bonusDamage = 0f)
+        public void TakeDamageFromEnemy(float amount, int enemyLevel, float bonusDamage = 0f, bool isCritical = false)
         {
             controller = controller != null ? controller : GetComponent<HeroController>();
             if (controller != null && controller.IsEcho && Instance != null && Instance != this)
             {
                 // Echo forwards to main hero with the echo damage reduction
-                Instance.TakeDamageFromEnemy(amount * 0.5f, enemyLevel, bonusDamage);
+                Instance.TakeDamageFromEnemy(amount * 0.5f, enemyLevel, bonusDamage, isCritical);
                 return;
             }
 
             pendingAttackerLevel = Mathf.Max(0, enemyLevel);
-            TakeDamage(amount, bonusDamage);
+            TakeDamage(amount, bonusDamage, isCritical);
         }
     }
 }

--- a/Assets/Scripts/IDamageable.cs
+++ b/Assets/Scripts/IDamageable.cs
@@ -12,6 +12,7 @@ namespace TimelessEchoes
         /// </summary>
         /// <param name="amount">Base damage dealt.</param>
         /// <param name="bonusDamage">Additional bonus damage displayed to the right at a smaller size.</param>
-        void TakeDamage(float amount, float bonusDamage = 0f);
+        /// <param name="isCritical">True if the hit was a critical strike.</param>
+        void TakeDamage(float amount, float bonusDamage = 0f, bool isCritical = false);
     }
 }

--- a/Assets/Scripts/Projectile.cs
+++ b/Assets/Scripts/Projectile.cs
@@ -29,6 +29,7 @@ namespace TimelessEchoes
         private float bonusDamage;
         private bool fromHero;
         private TimelessEchoes.Skills.Skill combatSkill;
+        private bool isCritical;
         private int attackerLevel = -1;
 
         private IHasHealth targetHasHealth;
@@ -51,6 +52,7 @@ namespace TimelessEchoes
             GameObject hitEffect = null,
             TimelessEchoes.Skills.Skill combatSkill = null,
             float bonusDamage = 0f,
+            bool isCritical = false,
             int attackerLevel = -1)
         {
             this.target = target;
@@ -58,6 +60,7 @@ namespace TimelessEchoes
             this.bonusDamage = bonusDamage;
             this.fromHero = fromHero;
             this.combatSkill = combatSkill;
+            this.isCritical = isCritical;
             this.attackerLevel = attackerLevel;
             effectPrefab = hitEffect ?? hitEffectPrefab;
             transform.rotation = Quaternion.identity;
@@ -117,7 +120,7 @@ namespace TimelessEchoes
                     var heroHealth = target.GetComponent<TimelessEchoes.Hero.HeroHealth>();
                     if (heroHealth != null)
                     {
-                        heroHealth.TakeDamageFromEnemy(baseAmount, attackerLevel, bonusDamage);
+                        heroHealth.TakeDamageFromEnemy(baseAmount, attackerLevel, bonusDamage, isCritical);
                         appliedCustom = true;
                     }
                     else
@@ -126,14 +129,14 @@ namespace TimelessEchoes
                         if (echoProxy != null)
                         {
                             // Echo forwards to main hero at 50% effectiveness
-                            TimelessEchoes.Hero.HeroHealth.Instance?.TakeDamageFromEnemy(baseAmount * 0.5f, attackerLevel, bonusDamage);
+                            TimelessEchoes.Hero.HeroHealth.Instance?.TakeDamageFromEnemy(baseAmount * 0.5f, attackerLevel, bonusDamage, isCritical);
                             appliedCustom = true;
                         }
                     }
                 }
 
                 if (!appliedCustom)
-                    targetDamageable?.TakeDamage(baseAmount, bonusDamage);
+                    targetDamageable?.TakeDamage(baseAmount, bonusDamage, isCritical);
                 if (fromHero)
                 {
                     var tracker = TimelessEchoes.Stats.GameplayStatTracker.Instance ??


### PR DESCRIPTION
## Summary
- add `isCritical` flag to `IDamageable` and health components
- compute critical hits in `HeroController` and propagate via `Projectile`
- update projectiles and health to display critical damage without heuristics

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689ee1e78700832e99a8a7e13b0eb913