### PR TITLE
Retrieve core counts from resource manager

### DIFF
--- a/Assets/Scripts/Gear/UI/ForgeWindowUI.cs
+++ b/Assets/Scripts/Gear/UI/ForgeWindowUI.cs
@@ -750,7 +750,17 @@ namespace TimelessEchoes.Gear.UI
             }
 
             if (selectedCoreCountText != null)
-                selectedCoreCountText.text = slot != null && slot.CoreResource != null ? "1" : string.Empty;
+            {
+                if (slot != null && slot.CoreResource != null && rm != null)
+                {
+                    var amount = rm.GetAmount(slot.CoreResource);
+                    selectedCoreCountText.text = amount > 0 ? amount.ToString("0") : "0";
+                }
+                else
+                {
+                    selectedCoreCountText.text = "0";
+                }
+            }
         }
 
         private void UpdateIngotPreview(CoreSO core)


### PR DESCRIPTION
## Summary
- Display the actual core amount in forge window instead of a placeholder value

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689efa8f3f70832eb997b53cc1458cda