### PR TITLE
Show craft costs and resource availability in forge UI

### DIFF
--- a/Assets/Scripts/Gear/UI/CoreSlotUIReferences.cs
+++ b/Assets/Scripts/Gear/UI/CoreSlotUIReferences.cs
@@ -68,7 +68,7 @@ namespace TimelessEchoes.Gear.UI
 
         /// <summary>
         /// Refreshes discovery visibility and amount text from the ResourceManager.
-        /// If no resource is assigned, the core image remains as-is and count is cleared.
+        /// If no resource is assigned, the count displays 0.
         /// </summary>
         public void Refresh()
         {
@@ -81,15 +81,8 @@ namespace TimelessEchoes.Gear.UI
 
             if (coreCountText != null)
             {
-                if (hasResource && rm != null)
-                {
-                    var amount = rm.GetAmount(coreResource);
-                    coreCountText.text = amount > 0 ? amount.ToString("0") : "0";
-                }
-                else
-                {
-                    coreCountText.text = string.Empty;
-                }
+                var amount = hasResource && rm != null ? rm.GetAmount(coreResource) : 0;
+                coreCountText.text = amount.ToString("0");
             }
         }
     }

--- a/Assets/Scripts/Gear/UI/ForgeWindowUI.cs
+++ b/Assets/Scripts/Gear/UI/ForgeWindowUI.cs
@@ -737,12 +737,13 @@ namespace TimelessEchoes.Gear.UI
                 Sprite sprite = null;
                 if (res != null)
                 {
+                    const int coreCost = 1;
                     var discovered = rm != null && rm.IsUnlocked(res);
-                    sprite = discovered
-                        ? slot != null && slot.CoreImage != null && slot.CoreImage.sprite != null
-                            ? slot.CoreImage.sprite
-                            : res.icon
-                        : res.UnknownIcon;
+                    var have = rm != null && rm.GetAmount(res) >= coreCost;
+                    var baseSprite = slot != null && slot.CoreImage != null && slot.CoreImage.sprite != null
+                        ? slot.CoreImage.sprite
+                        : res.icon;
+                    sprite = discovered && have ? baseSprite : res.UnknownIcon;
                 }
 
                 selectedCoreImage.sprite = sprite;
@@ -751,15 +752,8 @@ namespace TimelessEchoes.Gear.UI
 
             if (selectedCoreCountText != null)
             {
-                if (slot != null && slot.CoreResource != null && rm != null)
-                {
-                    var amount = rm.GetAmount(slot.CoreResource);
-                    selectedCoreCountText.text = amount > 0 ? amount.ToString("0") : "0";
-                }
-                else
-                {
-                    selectedCoreCountText.text = "0";
-                }
+                const int coreCost = 1;
+                selectedCoreCountText.text = selectedCore != null ? coreCost.ToString("0") : "0";
             }
         }
 
@@ -777,7 +771,8 @@ namespace TimelessEchoes.Gear.UI
                 {
                     var rm = ResourceManager.Instance ?? FindFirstObjectByType<ResourceManager>();
                     var discovered = rm != null && rm.IsUnlocked(ingot);
-                    sprite = discovered ? ingot.icon : ingot.UnknownIcon;
+                    var have = rm != null && rm.GetAmount(ingot) >= (core != null ? core.ingotCost : 0);
+                    sprite = discovered && have ? ingot.icon : ingot.UnknownIcon;
                 }
 
                 selectedIngotImage.sprite = sprite;
@@ -785,7 +780,7 @@ namespace TimelessEchoes.Gear.UI
             }
 
             if (selectedIngotCountText != null)
-                selectedIngotCountText.text = core != null ? Mathf.Max(0, core.ingotCost).ToString("0") : string.Empty;
+                selectedIngotCountText.text = core != null ? Mathf.Max(0, core.ingotCost).ToString("0") : "0";
         }
 
         private void UpdateIngotCraftPreview(CoreSO core)
@@ -837,7 +832,8 @@ namespace TimelessEchoes.Gear.UI
                 if (core != null && core.chunkResource != null)
                 {
                     var discovered = rm != null && rm.IsUnlocked(core.chunkResource);
-                    sprite = discovered ? core.chunkResource.icon : core.chunkResource.UnknownIcon;
+                    var have = rm != null && rm.GetAmount(core.chunkResource) >= core.chunkCostPerIngot;
+                    sprite = discovered && have ? core.chunkResource.icon : core.chunkResource.UnknownIcon;
                 }
 
                 chunkCostImage.sprite = sprite;
@@ -852,7 +848,8 @@ namespace TimelessEchoes.Gear.UI
                 if (core != null && core.crystalResource != null)
                 {
                     var discovered = rm != null && rm.IsUnlocked(core.crystalResource);
-                    sprite = discovered ? core.crystalResource.icon : core.crystalResource.UnknownIcon;
+                    var have = rm != null && rm.GetAmount(core.crystalResource) >= core.crystalCostPerIngot;
+                    sprite = discovered && have ? core.crystalResource.icon : core.crystalResource.UnknownIcon;
                 }
 
                 crystalCostImage.sprite = sprite;


### PR DESCRIPTION
## Summary
- Ensure each core slot shows the player's owned core amount.
- Display craft costs for selected core and ingot while hiding their sprites if resources are insufficient.
- Apply same resource availability check to chunk and crystal cost images for ingot crafting.

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689f021efd0c832eb5a6909791024a74