### PR TITLE
Add CraftSection2x1 UI references

### DIFF
--- a/Assets/Scripts/Gear/UI/CraftSection2x1UIReferences.cs
+++ b/Assets/Scripts/Gear/UI/CraftSection2x1UIReferences.cs
@@ -1,0 +1,25 @@
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TimelessEchoes.Gear.UI
+{
+    /// <summary>
+    /// Reference holder for a 2x1 craft section UI.
+    /// </summary>
+    public class CraftSection2x1UIReferences : MonoBehaviour
+    {
+        public ImageReference craftArrow;
+        public Sprite invalidArrow;
+        public Sprite validArrow;
+        public Image resultImage;
+        public TMP_Text resultText;
+        public Image cost1Image;
+        public TMP_Text cost1Text;
+        public Image cost2Image;
+        public TMP_Text cost2Text;
+        public TMP_Text maxCraftsText;
+        public Button craftButton;
+        public Button craftAllButton;
+    }
+}


### PR DESCRIPTION
## Summary
- add CraftSection2x1UIReferences MonoBehaviour to wire craft arrow, result, cost, and button elements

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f0db0c7c4832eb818d3827d448c44