### PR TITLE
chore: show fixed precision in core weight tooltip

### DIFF
--- a/Assets/Scripts/Gear/UI/ForgeWindowUI.cs
+++ b/Assets/Scripts/Gear/UI/ForgeWindowUI.cs
@@ -290,7 +290,7 @@ namespace TimelessEchoes.Gear.UI
             {
                 var p = total > 0f ? w / total : 0f;
                 var name = r != null ? r.GetName() : "(null)";
-                lines.Add($"{name}: {p * 100f:0.###}%");
+                lines.Add($"{name}: {p * 100f:0.000}%");
             }
 
             return (lines, weights);


### PR DESCRIPTION
## Summary
- format core weight tooltip percentages with fixed three-decimal precision

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f173186f4832e887355daa8d4ebf6