### PR TITLE
feat: add craft mode selection for resource conversions

### DIFF
--- a/Assets/Scripts/Gear/UI/ForgeWindowUI/ForgeWindowUI.cs
+++ b/Assets/Scripts/Gear/UI/ForgeWindowUI/ForgeWindowUI.cs
@@ -69,9 +69,11 @@ namespace TimelessEchoes.Gear.UI
                                  ingotConversionSection.craftButton.gameObject.AddComponent<RepeatButtonClick>();
                     repeat.button = ingotConversionSection.craftButton;
                 }
-
                 if (ingotConversionSection.modeButton != null)
-                    ingotConversionSection.modeButton.onClick.AddListener(OnCraftAllIngotsClicked);
+                {
+                    ingotConversionSection.modeButton.onClick.AddListener(OnIngotModeClicked);
+                    UpdateModeButtonText(ingotConversionSection, ingotCraftMode);
+                }
             }
 
             if (crystalConversionSection != null)
@@ -83,9 +85,11 @@ namespace TimelessEchoes.Gear.UI
                                  crystalConversionSection.craftButton.gameObject.AddComponent<RepeatButtonClick>();
                     repeat.button = crystalConversionSection.craftButton;
                 }
-
                 if (crystalConversionSection.modeButton != null)
-                    crystalConversionSection.modeButton.onClick.AddListener(OnCraftAllCrystalsClicked);
+                {
+                    crystalConversionSection.modeButton.onClick.AddListener(OnCrystalModeClicked);
+                    UpdateModeButtonText(crystalConversionSection, crystalCraftMode);
+                }
             }
 
             if (chunkConversionSection != null)
@@ -97,9 +101,11 @@ namespace TimelessEchoes.Gear.UI
                                  chunkConversionSection.craftButton.gameObject.AddComponent<RepeatButtonClick>();
                     repeat.button = chunkConversionSection.craftButton;
                 }
-
                 if (chunkConversionSection.modeButton != null)
-                    chunkConversionSection.modeButton.onClick.AddListener(OnCraftAllChunksClicked);
+                {
+                    chunkConversionSection.modeButton.onClick.AddListener(OnChunkModeClicked);
+                    UpdateModeButtonText(chunkConversionSection, chunkCraftMode);
+                }
             }
 
             // Wire gear slot buttons with fallback to EquipmentController order


### PR DESCRIPTION
## Summary
- add craft mode enum with per-section persistence
- change mode button to cycle between 1, 50%, and all crafts
- apply mode when crafting ingots, crystals, or chunks

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689fd4794808832eb7937376aa63c1d0