### PR TITLE
feat: configure run stats hover sprite based on screen side

### DIFF
--- a/Assets/Scripts/References/UI/RunStatUIReferences.cs
+++ b/Assets/Scripts/References/UI/RunStatUIReferences.cs
@@ -1,5 +1,6 @@
 using TMPro;
 using UnityEngine;
+using UnityEngine.UI;
 
 namespace TimelessEchoes.References.UI
 {
@@ -13,5 +14,8 @@ namespace TimelessEchoes.References.UI
         public TMP_Text distanceTasksResourcesText;
         public TMP_Text killsDamageDoneDamageTakenText;
         public TMP_Text statusText;
+        public Image image;
+        public Sprite leftSprite;
+        public Sprite rightSprite;
     }
 }

--- a/Assets/Scripts/UI/RunStatsPanelUI.cs
+++ b/Assets/Scripts/UI/RunStatsPanelUI.cs
@@ -25,7 +25,8 @@ namespace TimelessEchoes.UI
         [SerializeField] private TMP_Text graphLabelText;
         private GameplayStatTracker statTracker;
         [SerializeField] private RunStatUIReferences runStatUI;
-        [SerializeField] private Vector2 statOffset = Vector2.zero;
+        [SerializeField] private Vector2 statOffset = new Vector2(0.12f, 0.78f);
+        [SerializeField] private Vector2 hoverOffset = Vector2.zero;
         [SerializeField] private Color deathBarColor = Color.red;
         [SerializeField] private Color retreatBarColor = Color.green;
         [SerializeField] private Color abandonedBarColor = Color.gray;
@@ -145,7 +146,7 @@ namespace TimelessEchoes.UI
             var record = runs[index];
 
             var pos = bar.transform.position;
-            pos.x += statOffset.x;
+            pos.x += hoverOffset.x;
 
             var canvas = runStatUI.GetComponentInParent<Canvas>();
             var cam = canvas != null ? canvas.worldCamera : null;
@@ -157,7 +158,20 @@ namespace TimelessEchoes.UI
                 ? cam.ScreenToWorldPoint(screenPoint)
                 : runStatUI.transform.position;
 
-            pos.y = mouseWorld.y + statOffset.y;
+            pos.y = mouseWorld.y + hoverOffset.y;
+
+            var isLeftSide = screenPoint.x < Screen.width / 2f;
+            if (runStatUI.image != null)
+                runStatUI.image.sprite = isLeftSide ? runStatUI.leftSprite : runStatUI.rightSprite;
+
+            var rect = runStatUI.GetComponent<RectTransform>();
+            if (rect != null)
+            {
+                var pivot = rect.pivot;
+                pivot.x = isLeftSide ? statOffset.x : statOffset.y;
+                rect.pivot = pivot;
+            }
+
             runStatUI.transform.position = pos;
 
             if (runStatUI.runIdText != null)


### PR DESCRIPTION
## Summary
- add image and sprites to RunStatUIReferences for hover graphics
- toggle hover sprite and pivot based on which side of the screen is hovered
- expose pivot settings and hover offset via serialized fields

## Testing
- `dotnet build` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689ff65f9a00832e80d29a6fcc9bb929