### PR TITLE
feat: migrate stat upgrades to gear

### DIFF
--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -14,6 +14,8 @@ namespace Blindsided.SaveData
         [ShowInInspector, HideReferenceObjectPicker] [TabGroup("GameDataTabs", "UpgradeSystem")]
         public Dictionary<string, int> UpgradeLevels = new();
 
+        [TabGroup("GameDataTabs", "UpgradeSystem")] public bool StatUpgradesMigratedToGear = false;
+
         [TabGroup("GameDataTabs", "Time")] public float CurrentTime = 0;
         [TabGroup("GameDataTabs", "Time")] public string DateQuitString;
         [TabGroup("GameDataTabs", "Time")] public string DateStarted;

--- a/Assets/Scripts/Migration.meta
+++ b/Assets/Scripts/Migration.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1a9ea8b91dc94aa288c0df37811e055c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Migration/StatUpgradeGearMigrator.cs
+++ b/Assets/Scripts/Migration/StatUpgradeGearMigrator.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Blindsided.SaveData;
+using Blindsided.Utilities;
+using TimelessEchoes.Gear;
+using TimelessEchoes.Upgrades;
+using UnityEngine;
+using static Blindsided.EventHandler;
+using static Blindsided.Oracle;
+
+[DefaultExecutionOrder(-2)]
+public class StatUpgradeGearMigrator : MonoBehaviour
+{
+    private void Awake()
+    {
+        OnLoadData += OnLoadDataHandler;
+    }
+
+    private void OnDestroy()
+    {
+        OnLoadData -= OnLoadDataHandler;
+    }
+
+    private void OnLoadDataHandler()
+    {
+        var saveData = oracle?.saveData;
+        if (saveData == null)
+            return;
+        if (saveData.StatUpgradesMigratedToGear)
+            return;
+
+        saveData.EquipmentBySlot ??= new Dictionary<string, GearItemRecord>();
+        if (saveData.EquipmentBySlot.Count > 0)
+        {
+            saveData.StatUpgradesMigratedToGear = true;
+            return;
+        }
+
+        saveData.UpgradeLevels ??= new Dictionary<string, int>();
+        var gear = new GearItemRecord { slot = "Helmet", rarity = null, affixes = new List<GearAffixRecord>() };
+
+        var allUpgrades = AssetCache.GetAll<StatUpgrade>("");
+        var allStats = AssetCache.GetAll<StatDefSO>("");
+        var keys = saveData.UpgradeLevels.Keys.ToList();
+        foreach (var key in keys)
+        {
+            var level = saveData.UpgradeLevels[key];
+            if (level <= 0) continue;
+            var upgrade = allUpgrades?.FirstOrDefault(u => u != null && u.name == key);
+            if (upgrade == null) continue;
+            var stat = allStats?.FirstOrDefault(s => s != null && s.name == key);
+            if (stat == null) continue;
+            float bonus = level * upgrade.statIncreasePerLevel;
+            gear.affixes.Add(new GearAffixRecord { statId = stat.id ?? stat.name, value = bonus });
+            saveData.UpgradeLevels[key] = 0;
+        }
+
+        if (gear.affixes.Count > 0)
+        {
+            saveData.EquipmentBySlot["Helmet"] = gear;
+            var ctrl = StatUpgradeController.Instance;
+            if (ctrl != null)
+            {
+                var m = typeof(StatUpgradeController).GetMethod("LoadState", BindingFlags.Instance | BindingFlags.NonPublic);
+                m?.Invoke(ctrl, null);
+            }
+        }
+
+        saveData.StatUpgradesMigratedToGear = true;
+    }
+}

--- a/Assets/Scripts/Migration/StatUpgradeGearMigrator.cs.meta
+++ b/Assets/Scripts/Migration/StatUpgradeGearMigrator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2b5adffeae2d4a57a2e3ebc95d1ea052


### PR DESCRIPTION
## Summary
- add `StatUpgradesMigratedToGear` flag to save data so stat upgrades migrate only once
- add `StatUpgradeGearMigrator` to convert old stat upgrades into a helmet gear item and refresh stats

## Testing
- `dotnet test` *(fails: MSB1003 no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a024661a90832ebc7434d67f68a432