### PR TITLE
Add inspector display for equipment slots

### DIFF
--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -49,7 +49,7 @@ namespace Blindsided.SaveData
         [TabGroup("GameDataTabs", "Quests")] public Dictionary<string, QuestRecord> Quests = new();
 
         // --- Gear system (phase 1) ---
-        [HideReferenceObjectPicker]
+        [ShowInInspector, HideReferenceObjectPicker]
         [TabGroup("GameDataTabs", "Gear")] public Dictionary<string, GearItemRecord> EquipmentBySlot = new();
         [HideReferenceObjectPicker]
         [TabGroup("GameDataTabs", "Gear")] public List<GearItemRecord> CraftHistory = new();


### PR DESCRIPTION
## Summary
- show equipment-by-slot dictionary in the ES3 save editor with ShowInInspector

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a04414dd98832e9af432151aa19479