### PR TITLE
Add quest rewards and apply on completion

### DIFF
--- a/Assets/Scripts/Quests/QuestData.cs
+++ b/Assets/Scripts/Quests/QuestData.cs
@@ -24,6 +24,7 @@ namespace TimelessEchoes.Quests
         public bool autoPin;
         public List<QuestData> requiredQuests = new();
         public List<Requirement> requirements = new();
+        public List<Reward> rewards = new();
         public int unlockBuffSlots;
         public int unlockAutoBuffSlots;
         public float maxDistanceIncrease;
@@ -46,6 +47,13 @@ namespace TimelessEchoes.Quests
             [ShowIf("type", RequirementType.Kill)] public string killName;
             [ShowIf("type", RequirementType.Kill)] public Sprite killIcon;
             [ShowIf("type", RequirementType.Meet)] public string meetNpcId;
+        }
+
+        [Serializable]
+        public struct Reward
+        {
+            public Resource resource;
+            public int amount;
         }
 
         public enum RequirementType

--- a/Assets/Scripts/Quests/QuestManager.cs
+++ b/Assets/Scripts/Quests/QuestManager.cs
@@ -285,6 +285,9 @@ namespace TimelessEchoes.Quests
                     if (req.type == QuestData.RequirementType.Resource)
                         resourceManager.Spend(req.resource, req.amount);
 
+            foreach (var reward in inst.data.rewards)
+                ResourceManager.Instance.Add(reward.resource, reward.amount);
+
             record.Completed = true;
             if (inst.data.unlockBuffSlots > 0)
                 BuffManager.Instance?.UnlockSlots(inst.data.unlockBuffSlots);


### PR DESCRIPTION
## Summary
- add serializable Reward struct and list to quest data
- grant configured quest rewards when completing quests

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a117e5aa00832ebb97329bf14fc0a6