### PR TITLE
Add random username naming for enemies

### DIFF
--- a/Assets/Scripts/Enemies/Enemy.cs
+++ b/Assets/Scripts/Enemies/Enemy.cs
@@ -100,10 +100,15 @@ namespace TimelessEchoes.Enemies
                 health.Init(stats.GetMaxHealthForLevel(level));
             }
 
+            var displayName = stats != null ? stats.enemyName : null;
+            displayName = EnemyNameProvider.GetName(displayName);
+            if (!string.IsNullOrEmpty(displayName))
+                gameObject.name = displayName;
+
             if (levelText != null)
             {
-                if (stats != null && !string.IsNullOrEmpty(stats.enemyName))
-                    levelText.text = $"{stats.enemyName} Lvl {level}";
+                if (!string.IsNullOrEmpty(displayName))
+                    levelText.text = $"{displayName} Lvl {level}";
                 else
                     levelText.text = $"Lvl {level}";
             }

--- a/Assets/Scripts/Enemies/EnemyNameProvider.cs
+++ b/Assets/Scripts/Enemies/EnemyNameProvider.cs
@@ -1,0 +1,33 @@
+using UnityEngine;
+
+namespace TimelessEchoes.Enemies
+{
+    /// <summary>
+    /// Provides occasional special names for enemies.
+    /// </summary>
+    public static class EnemyNameProvider
+    {
+        private static readonly string[] SpecialNames =
+        {
+            "ArcaneMage",
+            "ShadowWalker",
+            "MysticEcho",
+        };
+
+        /// <summary>
+        /// Chance (0-1) that an enemy will use a special name.
+        /// Defaults to 1 in 100.
+        /// </summary>
+        public static float SpecialNameChance = 0.01f;
+
+        /// <summary>
+        /// Returns either the provided default name or a special name.
+        /// </summary>
+        public static string GetName(string defaultName)
+        {
+            if (SpecialNames.Length > 0 && Random.value < SpecialNameChance)
+                return SpecialNames[Random.Range(0, SpecialNames.Length)];
+            return defaultName;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add EnemyNameProvider to supply occasional special names
- rename enemies and update level text using provider

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a057271164832eab383570afecb631