### PR TITLE
Scale distance run graph using displayed runs

### DIFF
--- a/Assets/Scripts/UI/RunStatsPanelUI.cs
+++ b/Assets/Scripts/UI/RunStatsPanelUI.cs
@@ -238,8 +238,16 @@ namespace TimelessEchoes.UI
 
             if (graphMode == GraphMode.Distance)
             {
-                longest = statTracker.LongestRun;
-                average = statTracker.AverageRun;
+                longest = 0f;
+                double sum = 0f;
+                foreach (var r in runs)
+                {
+                    if (r.Distance > longest)
+                        longest = r.Distance;
+                    sum += r.Distance;
+                }
+
+                average = runs.Count > 0 ? sum / runs.Count : 0f;
             }
             else if (graphMode == GraphMode.Duration)
             {


### PR DESCRIPTION
## Summary
- derive max distance from displayed runs to scale distance graph

## Testing
- `dotnet test` *(fails: MSB1003 no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a11a665c5c832ebd546e7c9ae4677a