### PR TITLE
Add optional stat tracking flag to ResourceManager.Add

### DIFF
--- a/Assets/Scripts/Gear/SalvageService.cs
+++ b/Assets/Scripts/Gear/SalvageService.cs
@@ -33,7 +33,7 @@ namespace TimelessEchoes.Gear
             int totalAwardedEntries = 0;
             foreach (var res in results)
             {
-                rm.Add(res.resource, res.count);
+                rm.Add(res.resource, res.count, trackStats: false);
                 totalAwardedEntries++;
             }
 

--- a/Assets/Scripts/Gear/UI/ForgeWindowUI/ForgeWindowUI.Crafting.cs
+++ b/Assets/Scripts/Gear/UI/ForgeWindowUI/ForgeWindowUI.Crafting.cs
@@ -322,7 +322,7 @@ namespace TimelessEchoes.Gear.UI
                 rm.Spend(core.chunkResource, core.chunkCostPerIngot * amount);
             if (core.crystalResource != null && core.crystalCostPerIngot > 0)
                 rm.Spend(core.crystalResource, core.crystalCostPerIngot * amount);
-            rm.Add(core.requiredIngot, amount);
+            rm.Add(core.requiredIngot, amount, trackStats: false);
             // Persist desired amount
             ingotCraftAmount = Mathf.Max(1, ingotCraftAmount);
             PlayerPrefs.SetInt("IngotCraftAmount", ingotCraftAmount);
@@ -343,7 +343,7 @@ namespace TimelessEchoes.Gear.UI
             if (slimeResource != null)
                 rm.Spend(slimeResource, 1 * amount);
             if (core.crystalResource != null)
-                rm.Add(core.crystalResource, amount);
+                rm.Add(core.crystalResource, amount, trackStats: false);
             crystalCraftAmount = Mathf.Max(1, crystalCraftAmount);
             PlayerPrefs.SetInt("CrystalCraftAmount", crystalCraftAmount);
             PlayerPrefs.Save();
@@ -363,7 +363,7 @@ namespace TimelessEchoes.Gear.UI
             if (stoneResource != null)
                 rm.Spend(stoneResource, 2 * amount);
             if (core.chunkResource != null)
-                rm.Add(core.chunkResource, amount);
+                rm.Add(core.chunkResource, amount, trackStats: false);
             chunkCraftAmount = Mathf.Max(1, chunkCraftAmount);
             PlayerPrefs.SetInt("ChunkCraftAmount", chunkCraftAmount);
             PlayerPrefs.Save();

--- a/Assets/Scripts/NpcGeneration/DiscipleGenerator.cs
+++ b/Assets/Scripts/NpcGeneration/DiscipleGenerator.cs
@@ -122,7 +122,7 @@ namespace TimelessEchoes.NpcGeneration
                 return;
             }
 
-            resourceManager.Add(resource, stored);
+            resourceManager.Add(resource, stored, trackStats: false);
             totalCollected += stored;
             stored = 0;
             SaveState();

--- a/Assets/Scripts/Quests/QuestManager.cs
+++ b/Assets/Scripts/Quests/QuestManager.cs
@@ -286,7 +286,7 @@ namespace TimelessEchoes.Quests
                         resourceManager.Spend(req.resource, req.amount);
 
             foreach (var reward in inst.data.rewards)
-                ResourceManager.Instance.Add(reward.resource, reward.amount);
+                ResourceManager.Instance.Add(reward.resource, reward.amount, trackStats: false);
 
             record.Completed = true;
             if (inst.data.unlockBuffSlots > 0)

--- a/Assets/Scripts/Upgrades/ResourceManager.cs
+++ b/Assets/Scripts/Upgrades/ResourceManager.cs
@@ -80,7 +80,7 @@ namespace TimelessEchoes.Upgrades
             return amounts.TryGetValue(resource, out var value) ? value : 0;
         }
 
-        public void Add(Resource resource, double amount, bool bonus = false)
+        public void Add(Resource resource, double amount, bool bonus = false, bool trackStats = true)
         {
             if (resource == null || amount <= 0) return;
             var newlyUnlocked = unlocked.Add(resource);
@@ -89,11 +89,14 @@ namespace TimelessEchoes.Upgrades
             else
                 amounts[resource] = amount;
             resource.totalReceived += Mathf.RoundToInt((float)amount);
-            var tracker = GameplayStatTracker.Instance;
-            if (tracker == null)
-                Log("GameplayStatTracker missing", TELogCategory.Resource, this);
-            else
-                tracker.AddResources(amount, bonus);
+            if (trackStats)
+            {
+                var tracker = GameplayStatTracker.Instance;
+                if (tracker == null)
+                    Log("GameplayStatTracker missing", TELogCategory.Resource, this);
+                else
+                    tracker.AddResources(amount, bonus);
+            }
             OnResourceAdded?.Invoke(resource, amount, bonus);
             InvokeInventoryChanged();
             if (newlyUnlocked)


### PR DESCRIPTION
## Summary
- allow skipping stat tracking on ResourceManager.Add
- avoid tracking stats for forge conversions, salvage, quest rewards, and disciple collection

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a157e8710c832e9d7a7f3ca2d501bc