### PR TITLE
feat: allow disabling alter echo per resource

### DIFF
--- a/Assets/Scripts/NpcGeneration/DiscipleGenerationManager.cs
+++ b/Assets/Scripts/NpcGeneration/DiscipleGenerationManager.cs
@@ -113,8 +113,16 @@ namespace TimelessEchoes.NpcGeneration
             // purge legacy entries that no longer map to resources
             var toRemove = new List<string>();
             foreach (var key in oracle.saveData.Disciples.Keys)
+            {
                 if (!oracle.saveData.Resources.ContainsKey(key))
+                {
                     toRemove.Add(key);
+                    continue;
+                }
+
+                if (lookup.TryGetValue(key, out var res) && res != null && res.DisableAlterEcho)
+                    toRemove.Add(key);
+            }
             foreach (var k in toRemove)
                 oracle.saveData.Disciples.Remove(k);
 
@@ -123,7 +131,7 @@ namespace TimelessEchoes.NpcGeneration
             {
                 if (!pair.Value.Earned) continue;
                 lastUnlockedCount++;
-                if (!lookup.TryGetValue(pair.Key, out var res) || res == null)
+                if (!lookup.TryGetValue(pair.Key, out var res) || res == null || res.DisableAlterEcho)
                     continue;
 
                 var gen = Instantiate(generatorPrefab, transform);

--- a/Assets/Scripts/Upgrades/Resource.cs
+++ b/Assets/Scripts/Upgrades/Resource.cs
@@ -19,6 +19,9 @@ namespace TimelessEchoes.Upgrades
         [PreviewField(50, ObjectFieldAlignment.Left)]
         public Sprite UnknownIcon;
 
+        [Tooltip("If true, disciples will not generate this resource and Alter Echo data is ignored")]
+        public bool DisableAlterEcho;
+
         [HideInInspector] public int totalReceived;
         [HideInInspector] public int totalSpent;
     }

--- a/Assets/Scripts/Upgrades/ResourceManager.cs
+++ b/Assets/Scripts/Upgrades/ResourceManager.cs
@@ -173,14 +173,22 @@ namespace TimelessEchoes.Upgrades
             oracle.saveData.Resources ??= new Dictionary<string, GameData.ResourceEntry>();
             oracle.saveData.ResourceStats ??= new Dictionary<string, GameData.ResourceRecord>();
             oracle.saveData.Disciples ??= new Dictionary<string, GameData.DiscipleGenerationRecord>();
-            // purge legacy disciple keys that do not map to resources
+            EnsureLookup();
+            // purge legacy disciple keys that do not map to resources or are disabled
             var toRemove = new List<string>();
             foreach (var key in oracle.saveData.Disciples.Keys)
+            {
                 if (!oracle.saveData.Resources.ContainsKey(key))
+                {
                     toRemove.Add(key);
+                    continue;
+                }
+
+                if (lookup.TryGetValue(key, out var res) && res != null && res.DisableAlterEcho)
+                    toRemove.Add(key);
+            }
             foreach (var k in toRemove)
                 oracle.saveData.Disciples.Remove(k);
-            EnsureLookup();
             amounts.Clear();
             unlocked.Clear();
             foreach (var pair in oracle.saveData.Resources)


### PR DESCRIPTION
## Summary
- add `DisableAlterEcho` flag to resources
- skip disciple generation for flagged resources
- drop save data for disabled resources in resource manager

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a15e3c07b0832e9a76a7808e4b3e21