### PR TITLE
Use actual movement speed for animation

### DIFF
--- a/Assets/Scripts/Hero/HeroController.Movement.cs
+++ b/Assets/Scripts/Hero/HeroController.Movement.cs
@@ -29,22 +29,22 @@ namespace TimelessEchoes.Hero
             }
 
             if (dir.sqrMagnitude > 0.0001f)
-                lastMoveDir = dir;
+                lastMoveDir = dir.normalized;
 
-            var mag = dir.magnitude;
+            var speed = vel.magnitude;
 
             if (animator != null)
             {
                 animator.SetFloat("MoveX", lastMoveDir.x);
                 animator.SetFloat("MoveY", lastMoveDir.y);
-                animator.SetFloat("MoveMagnitude", mag);
+                animator.SetFloat("MoveMagnitude", speed);
             }
 
             if (AutoBuffAnimator != null && AutoBuffAnimator.isActiveAndEnabled)
             {
                 AutoBuffAnimator.SetFloat("MoveX", lastMoveDir.x);
                 AutoBuffAnimator.SetFloat("MoveY", lastMoveDir.y);
-                AutoBuffAnimator.SetFloat("MoveMagnitude", mag);
+                AutoBuffAnimator.SetFloat("MoveMagnitude", speed);
             }
 
             if (spriteRenderer != null)


### PR DESCRIPTION
## Summary
- Compute move speed from `ai.desiredVelocity.magnitude` and use it for `MoveMagnitude`.
- Normalize direction solely for orientation and update main and auto-buff animators with new speed value.

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a179ddede0832eac975f32b125eceb