### PR TITLE
Remove crafting pity system

### DIFF
--- a/Assets/Resources/Gear/CraftingConfig.asset
+++ b/Assets/Resources/Gear/CraftingConfig.asset
@@ -12,10 +12,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ab91ad0292ba2944b587f46daf1488c, type: 3}
   m_Name: CraftingConfig
   m_EditorClassIdentifier: 
-  pityRareWithin: 10
-  pityEpicWithin: 40
-  pityLegendaryWithin: 120
-  pityMythicWithin: 300
   craftHistoryLimit: 0
   enableSmartSlotProtection: 1
   recentSlotPenalty: 0.25

--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -55,7 +55,6 @@ namespace Blindsided.SaveData
         [TabGroup("GameDataTabs", "Gear")] public List<GearItemRecord> CraftHistory = new();
         [TabGroup("GameDataTabs", "Gear")] public int CraftingMasteryLevel = 0; // Ivan's level
         [TabGroup("GameDataTabs", "Gear")] public float CraftingMasteryXP = 0f; // Ivan's current XP toward next level
-        [TabGroup("GameDataTabs", "Gear")] public int PityCraftsSinceLast = 0;
 
         [HideReferenceObjectPicker]
         [TabGroup("GameDataTabs", "Quests")] public List<string> PinnedQuests = new();

--- a/Assets/Scripts/Gear/SO/CraftingConfigSO.cs
+++ b/Assets/Scripts/Gear/SO/CraftingConfigSO.cs
@@ -7,13 +7,7 @@ namespace TimelessEchoes.Gear
     [CreateAssetMenu(fileName = "CraftingConfig", menuName = "SO/Gear/Crafting Config")]
     public class CraftingConfigSO : ScriptableObject
     {
-        [Title("Pity Thresholds")]
-        [MinValue(1)] public int pityRareWithin = 10;
-        [MinValue(1)] public int pityEpicWithin = 40;
-        [MinValue(1)] public int pityLegendaryWithin = 120;
-        [MinValue(1)] public int pityMythicWithin = 300;
-
-			[Title("Crafting")] public int craftHistoryLimit = 10;
+                        [Title("Crafting")] public int craftHistoryLimit = 10;
 
 			[Title("Slot Protection")]
         [Tooltip("If enabled, bias away from recently rolled slots to reduce streaks.")]

--- a/Assets/Scripts/Gear/UI/ForgeWindowUI/ForgeWindowUI.Crafting.cs
+++ b/Assets/Scripts/Gear/UI/ForgeWindowUI/ForgeWindowUI.Crafting.cs
@@ -95,8 +95,6 @@ namespace TimelessEchoes.Gear.UI
                 RefreshActionButtons();
                 return;
             }
-
-            crafting.RegisterCraftOutcome(lastCrafted.rarity);
             var eq = equipment?.GetEquipped(lastCrafted.slot);
             var summary = GearStatTextBuilder.BuildCraftResultSummary(lastCrafted, eq);
             ShowResult(summary);
@@ -105,7 +103,7 @@ namespace TimelessEchoes.Gear.UI
             OnResourcesChanged();
             ForceRefreshAllCoreSlots();
             RefreshActionButtons();
-            // Odds may change due to pity counter updates; refresh the pie/text
+            // Refresh the odds display after crafting
             RefreshOdds();
 
             // Persist resource spends and craft result to in-memory save (defer disk write)

--- a/Assets/Scripts/Gear/UI/RarityOddsCalculator.cs
+++ b/Assets/Scripts/Gear/UI/RarityOddsCalculator.cs
@@ -3,14 +3,13 @@ using System.Linq;
 using Blindsided;
 using Blindsided.Utilities;
 using UnityEngine;
-using TimelessEchoes.Upgrades;
 
 namespace TimelessEchoes.Gear.UI
 {
     public static class RarityOddsCalculator
     {
         /// <summary>
-        /// Computes rarity weight lines and raw weights for a given core, applying level scaling and pity rules.
+        /// Computes rarity weight lines and raw weights for a given core, applying level scaling.
         /// </summary>
         public static (List<string> lines, List<(RaritySO r, float w)> weights) BuildRarityWeightInfo(CoreSO core)
         {
@@ -19,15 +18,6 @@ namespace TimelessEchoes.Gear.UI
             var conf = svc != null ? svc.Config : null;
             var o = Oracle.oracle;
             var level = o != null && o.saveData != null ? Mathf.Max(0, o.saveData.CraftingMasteryLevel) : 0;
-            var craftsSince = o != null && o.saveData != null ? Mathf.Max(0, o.saveData.PityCraftsSinceLast) : 0;
-            var pityMinTier = 0;
-            if (conf != null && !UpgradeFeatureToggle.DisableCraftingPity)
-            {
-                if (craftsSince >= conf.pityMythicWithin) pityMinTier = 5;
-                else if (craftsSince >= conf.pityLegendaryWithin) pityMinTier = 4;
-                else if (craftsSince >= conf.pityEpicWithin) pityMinTier = 3;
-                else if (craftsSince >= conf.pityRareWithin) pityMinTier = 2;
-            }
 
             var weights = new List<(RaritySO r, float w)>();
             foreach (var r in rarities)
@@ -37,8 +27,6 @@ namespace TimelessEchoes.Gear.UI
                     ? core.GetRarityWeightPerLevel(r) * level
                     : 0f;
                 var w = Mathf.Max(0f, baseW + bonus);
-                if (r != null && r.tierIndex < pityMinTier)
-                    w = 0f;
                 weights.Add((r, w));
             }
 

--- a/Assets/Scripts/Upgrades/UpgradeFeatureToggle.cs
+++ b/Assets/Scripts/Upgrades/UpgradeFeatureToggle.cs
@@ -8,18 +8,12 @@ namespace TimelessEchoes.Upgrades
 	/// </summary>
 	public static class UpgradeFeatureToggle
 	{
-		/// <summary>
-		/// When true, stat upgrades (levels and costs) are ignored and upgrade UI is disabled.
-		/// Base values defined on <see cref="StatUpgrade"/> assets and bonuses from skills/gear remain.
-		/// </summary>
-		public static bool DisableStatUpgrades = true;
-
-		/// <summary>
-		/// When true, disables the crafting pity system (minimum rarity clamping based on recent crafts).
-		/// Crafting rarity odds will use only core/base weights without any pity floor.
-		/// </summary>
-		public static bool DisableCraftingPity = true;
-	}
+                /// <summary>
+                /// When true, stat upgrades (levels and costs) are ignored and upgrade UI is disabled.
+                /// Base values defined on <see cref="StatUpgrade"/> assets and bonuses from skills/gear remain.
+                /// </summary>
+                public static bool DisableStatUpgrades = true;
+        }
 }
 
 


### PR DESCRIPTION
## Summary
- eliminate pity mechanics from gear crafting
- simplify rarity odds calculation and config
- drop unused pity save data field

## Testing
- `dotnet build` *(fails: MSBUILD error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a1afa56b14832e8786a6f0809e31d0