### PR TITLE
feat: update patch notes

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -124,27 +124,27 @@
                     <details class="patch" open>
                         <summary>
                             <div class="patch-title">
-                    <strong>Version 1.0.4</strong>
-                    <time datetime="2025-08-12">August 12th, 2025</time>
+                                <strong>Version 1.1.18</strong>
+                                <time datetime="2025-08-17">August 17th, 2025</time>
                             </div>
                         </summary>
                         <div class="patch-body">
                             <h4>Changes</h4>
                             <ul>
-                                <li>Reworked looting tasks which now have a duration and hero animation.</li>
-                                <li>Reworked how fishing tasks finish to fix the casting while moving bug.</li>
-                                <li>Fixed a bug where the quests were not sorting correctly.</li>
-                                <li>Post session stats no longer count enemy reaps.</li>
-                                <li>Treks -> Runs.</li>
-                                <li>Autocasting now activates by default.</li>
-                                <li>Autocast should no longer get stuck on when wiping a save.</li>
-                                <li>Echo | Tasks is now the default starting buff.</li>
-                                <li>Fixed a bug where return on death would send the player back into a run after the death timer expired.</li>
-                                <li>Fixed an issue where the last saved was not accounting for auto saves.</li>
-                                <li>Library now shows quests instead of goals.</li>
-                                <li>Added new users to the credits.</li>
-                                <li>Steam Cloud is now enabled for everyone.</li>
-                                <li>New save regression detection system. Wow, that's a mouthful.</li>
+                                <li>New forge system.</li>
+                                <li>Removed upgrades tab (Your stats will migrate 70% of their value to a helmet slot item that you can choose to overwrite if you want the intended experience).</li>
+                                <li>Skeletons no longer drop ingots.</li>
+                                <li>Enemies all now drop crystals of various tiers.</li>
+                                <li>Slimes now also appear in the mines, The Vasterian scurge is growing.</li>
+                                <li>Chests now drop cores for the forge.</li>
+                                <li>Chests no longer drop ingots.</li>
+                                <li>Mining tasks no longer reward crystals.</li>
+                                <li>Loot has changed from a chance per item which was way too strong to guaranteed 1 item, then a chance at an additional item and in some cases a third chance if you succeed on the second. All loot is now weight based.</li>
+                                <li>Ingots are now created in the forge using crystals and chunks.</li>
+                                <li>Crystals can be converted to Chunks, 1 Crystal and 1 Stone makes 1 Chunk.</li>
+                                <li>Chunks can now be converted to Crystals, 2 Chunks and 1 Slime makes 1 Crystal.</li>
+                                <li>Enemies now have a small chance to pull from a list of random names as their name.</li>
+                                <li>Quests can now have a resource reward.</li>
                             </ul>
                             <p><a href="wiki/index.html#changes">View full patch history →</a></p>
                         </div>

--- a/docs/wiki/index.html
+++ b/docs/wiki/index.html
@@ -471,6 +471,36 @@
             </div>
             <!-- Embedded source to avoid external file loads -->
             <script id="patchnotes-source" type="text/plain">
+# Version 1.1.21 | August 18th, 2025
+### Changes
+- Fixed an issue where the Lirium chestpieces looked like helmets.
+- Fixed the skill window not correctly showing its data.
+- Potentially fixed the issue where gear would disappear for some users.
+
+# Version 1.1.21 | August 17th, 2025
+### Changes
+- Crafting no longer counts towards run stats.
+- Fixed an issue where some resources were not properly syncing.
+- There are no longer Alter-Echoes for ingots.
+- Patch notes are now in game.
+
+# Version 1.1.18 | August 17th, 2025
+### Changes
+- New forge system
+- Removed upgrades tab (Your stats will migrate 70% of their value to a helmet slot item that you can choose to overwrite if you want the intended experience)
+- Skeletons no longer drop ingots
+- Enemies all now drop crystals of various tiers.
+- Slimes now also appear in the mines, The Vasterian scurge is growing.
+- Chests now drop cores for the forge.
+- Chests no longer drop ingots.
+- Mining tasks no longer reward crystals.
+- Loot has changed from a chance per item which was way too strong to guaranteed 1 item, then a chance at an additional item and in some cases a third chance if you succeed on the second. All loot is now weight based.
+- Ingots are now created in the forge using crystals and chunks.
+- Crystals can be converted to Chunks, 1 Crystal and 1 Stone makes 1 Chunk.
+- Chunks can now be converted to Crystals, 2 Chunks and 1 Slime makes 1 Crystal.
+- Enemies now have a small chance to pull from a list of random names as their name.
+- Quests can now have a resource reward.
+
 # Version 1.0.4 | August 12th, 2025
 ### Changes
 - Reworked looting tasks which now have a duration and hero animation.


### PR DESCRIPTION
## Summary
- show version 1.1.18 notes on the homepage
- keep wiki patch history entries for versions 1.1.21 and 1.1.18

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a26e9e0a70832e8b7b7d39b433c8c9