### PR TITLE
Fix summary window closing on right click

### DIFF
--- a/Assets/Scripts/Upgrades/RunResourceTrackerUI.cs
+++ b/Assets/Scripts/Upgrades/RunResourceTrackerUI.cs
@@ -40,14 +40,12 @@ namespace TimelessEchoes.Upgrades
         {
             if (resourceManager != null)
                 resourceManager.OnResourceAdded += OnResourceAdded;
-            TimelessEchoes.UI.UITicker.Instance?.Subscribe(PollHideWindow, 0.05f);
         }
 
         private void OnDisable()
         {
             if (resourceManager != null)
                 resourceManager.OnResourceAdded -= OnResourceAdded;
-            TimelessEchoes.UI.UITicker.Instance?.Unsubscribe(PollHideWindow);
         }
 
         /// <summary>
@@ -120,7 +118,7 @@ namespace TimelessEchoes.Upgrades
                 window.SetActive(true);
         }
 
-        private void PollHideWindow()
+        private void Update()
         {
             if (Mouse.current != null && Mouse.current.rightButton.wasPressedThisFrame)
                 if (window != null && window.activeSelf)


### PR DESCRIPTION
## Summary
- Replace UITicker polling with per-frame right-click check to hide summary window

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a281aecd58832eb68fb4517d9118a9