### PR TITLE
Show N/A AE Power when Alter Echo disabled

### DIFF
--- a/Assets/Scripts/UI/ItemStatsPanelUI.cs
+++ b/Assets/Scripts/UI/ItemStatsPanelUI.cs
@@ -179,16 +179,18 @@ namespace TimelessEchoes.UI
                     oracle.saveData.Resources.TryGetValue(res.name, out var record))
                     best = record.BestPerMinute;
 
+                string aePower = res.DisableAlterEcho ? "N/A" : CalcUtils.FormatNumber(best);
+
                 if (earned)
                 {
                     var minDist = minDistanceLookup.TryGetValue(res, out var d) ? d : 0f;
                     ui.bestPerMinuteText.text =
-                        $"Min Distance: {CalcUtils.FormatNumber(minDist)}\nAE Power: {CalcUtils.FormatNumber(best)}";
+                        $"Min Distance: {CalcUtils.FormatNumber(minDist)}\nAE Power: {aePower}";
                 }
                 else
                 {
                     ui.bestPerMinuteText.text =
-                        $"Min Distance: ???\nAE Power: {CalcUtils.FormatNumber(best)}";
+                        $"Min Distance: ???\nAE Power: {aePower}";
                 }
             }
         }


### PR DESCRIPTION
## Summary
- show AE Power as `N/A` for resources that disable Alter Echo
- reuse AE Power text for both earned and unearned entries

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2a28aae30832e8c6448610fd836ed