### PR TITLE
Prevent forge crafting from affecting run stats

### DIFF
--- a/Assets/Scripts/Upgrades/ResourceManager.cs
+++ b/Assets/Scripts/Upgrades/ResourceManager.cs
@@ -96,8 +96,8 @@ namespace TimelessEchoes.Upgrades
                     Log("GameplayStatTracker missing", TELogCategory.Resource, this);
                 else
                     tracker.AddResources(amount, bonus);
+                OnResourceAdded?.Invoke(resource, amount, bonus);
             }
-            OnResourceAdded?.Invoke(resource, amount, bonus);
             InvokeInventoryChanged();
             if (newlyUnlocked)
                 UpdateCompletionPercentage();

--- a/Assets/Scripts/Upgrades/RunDropUI.cs
+++ b/Assets/Scripts/Upgrades/RunDropUI.cs
@@ -82,6 +82,8 @@ namespace TimelessEchoes.Upgrades
         private void OnResourceAdded(Resource resource, double amount, bool bonus)
         {
             if (bonus || resource == null || amount <= 0) return;
+            var tracker = TimelessEchoes.Stats.GameplayStatTracker.Instance;
+            if (tracker?.RunInProgress != true || resource.DisableAlterEcho) return;
 
             ResourceUIReferences slot = null;
             var index = resources.IndexOf(resource);

--- a/Assets/Scripts/Upgrades/RunResourceTrackerUI.cs
+++ b/Assets/Scripts/Upgrades/RunResourceTrackerUI.cs
@@ -76,6 +76,9 @@ namespace TimelessEchoes.Upgrades
         {
             if (resource == null || amount <= 0)
                 return;
+            var tracker = TimelessEchoes.Stats.GameplayStatTracker.Instance;
+            if (tracker?.RunInProgress != true || resource.DisableAlterEcho)
+                return;
             if (amounts.ContainsKey(resource))
                 amounts[resource] += amount;
             else


### PR DESCRIPTION
## Summary
- Only emit `OnResourceAdded` when tracking run stats
- Ignore run resource updates when no run is active or resource is excluded

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_68a2a2e20164832ebb6a7ee4a3212555