### PR TITLE
Remove manual salvage button and enable auto salvage

### DIFF
--- a/Assets/Scripts/Gear/UI/ForgeWindowUI/ForgeWindowUI.Crafting.cs
+++ b/Assets/Scripts/Gear/UI/ForgeWindowUI/ForgeWindowUI.Crafting.cs
@@ -133,24 +133,9 @@ namespace TimelessEchoes.Gear.UI
             // Clear result text and disable action buttons when no active craft
             if (resultText != null) resultText.text = string.Empty;
             if (replaceButton != null) replaceButton.interactable = false;
-            if (salvageButton != null) salvageButton.interactable = false;
             // Clear result preview when result is equipped
             ClearResultPreview();
             UpdateAllGearSlots();
-            RefreshActionButtons();
-        }
-
-        private void OnSalvageClicked()
-        {
-            if (lastCrafted == null) return;
-            SalvageService.Instance?.Salvage(lastCrafted);
-            lastCrafted = null;
-            // Clear result text and disable action buttons when no active craft
-            if (resultText != null) resultText.text = string.Empty;
-            if (replaceButton != null) replaceButton.interactable = false;
-            if (salvageButton != null) salvageButton.interactable = false;
-            // Clear result preview when salvaged
-            ClearResultPreview();
             RefreshActionButtons();
         }
 

--- a/Assets/Scripts/Gear/UI/ForgeWindowUI/ForgeWindowUI.GearSlots.cs
+++ b/Assets/Scripts/Gear/UI/ForgeWindowUI/ForgeWindowUI.GearSlots.cs
@@ -29,6 +29,14 @@ namespace TimelessEchoes.Gear.UI
         // Called by UI slot buttons (e.g., Weapon/Helmet/Chest/Boots)
         public void SelectSlot(string slot)
         {
+            if (lastCrafted != null && !string.Equals(lastCrafted.slot, slot))
+            {
+                SalvageService.Instance?.Salvage(lastCrafted);
+                lastCrafted = null;
+                if (resultText != null) resultText.text = string.Empty;
+                ClearResultPreview();
+            }
+
             // Stop auto-crafting if the player changes the selected gear slot
             if (isAutoCrafting && !string.Equals(selectedSlot, slot))
                 StopAutoCrafting();

--- a/Assets/Scripts/Gear/UI/ForgeWindowUI/ForgeWindowUI.SerializedFields.cs
+++ b/Assets/Scripts/Gear/UI/ForgeWindowUI/ForgeWindowUI.SerializedFields.cs
@@ -15,7 +15,6 @@ namespace TimelessEchoes.Gear.UI
 
         [SerializeField] private TMP_Text resultText;
         [SerializeField] private Button replaceButton;
-        [SerializeField] private Button salvageButton;
         [SerializeField] private Button craftUntilUpgradeButton;
         [SerializeField] private TMP_Text craftUntilUpgradeButtonText;
 

--- a/Assets/Scripts/Gear/UI/ForgeWindowUI/ForgeWindowUI.UIUpdates.cs
+++ b/Assets/Scripts/Gear/UI/ForgeWindowUI/ForgeWindowUI.UIUpdates.cs
@@ -449,10 +449,9 @@ namespace TimelessEchoes.Gear.UI
                 }
             }
 
-            // Replace/Salvage depend only on having a pending result; do not gate on craftability
+            // Replace depends only on having a pending result; do not gate on craftability
             var hasResult = lastCrafted != null;
             if (replaceButton != null) replaceButton.interactable = hasResult && !isAutoCrafting;
-            if (salvageButton != null) salvageButton.interactable = hasResult && !isAutoCrafting;
             // Auto-craft button toggles; interactable if we can craft or we are currently auto-crafting (to allow stopping)
             if (craftUntilUpgradeButton != null) craftUntilUpgradeButton.interactable = isAutoCrafting || canCraft;
             if (craftUntilUpgradeButtonText != null)

--- a/Assets/Scripts/Gear/UI/ForgeWindowUI/ForgeWindowUI.cs
+++ b/Assets/Scripts/Gear/UI/ForgeWindowUI/ForgeWindowUI.cs
@@ -57,8 +57,6 @@ namespace TimelessEchoes.Gear.UI
                 craftButton.onClick.AddListener(OnCraftClicked);
             if (replaceButton != null)
                 replaceButton.onClick.AddListener(OnReplaceClicked);
-            if (salvageButton != null)
-                salvageButton.onClick.AddListener(OnSalvageClicked);
             if (craftUntilUpgradeButton != null)
                 craftUntilUpgradeButton.onClick.AddListener(OnCraftUntilUpgradeClicked);
             if (ingotConversionSection != null)
@@ -146,7 +144,6 @@ namespace TimelessEchoes.Gear.UI
             if (resultText != null)
                 resultText.text = string.Empty;
             if (replaceButton != null) replaceButton.interactable = false;
-            if (salvageButton != null) salvageButton.interactable = false;
 
             // Ensure TMP texts that use <sprite> tags render with the StatIcons sprite asset
             var statSpriteAsset = StatIconLookup.GetSpriteAsset();


### PR DESCRIPTION
## Summary
- remove salvage button fields, listeners, and manual salvage method
- auto-salvage last crafted item when changing gear slots or crafting again
- tidy Forge window UI refresh logic and restore untouched Main scene

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(warning: Failed to fetch https://mise.jdx.dev/deb stable InRelease)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ab5352d8832e9853d86665f0fa3d