### PR TITLE
feat: reset quest scroll to top

### DIFF
--- a/Assets/Scripts/Quests/QuestUIManager.cs
+++ b/Assets/Scripts/Quests/QuestUIManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Blindsided.SaveData;
 using UnityEngine;
+using UnityEngine.UI;
 
 namespace TimelessEchoes.Quests
 {
@@ -15,6 +16,7 @@ namespace TimelessEchoes.Quests
         [SerializeField] private QuestEntryUI questEntryPrefab;
         [SerializeField] private GameObject dividerPrefab;
         [SerializeField] private Transform questParent;
+        [SerializeField] private ScrollRect questScroll;
         private readonly List<QuestEntryUI> entries = new();
         private readonly List<GameObject> extras = new();
 
@@ -72,6 +74,9 @@ namespace TimelessEchoes.Quests
             // Ensure the list is freshly built and sorted whenever the quest UI opens
             var qm = QuestManager.Instance ?? FindFirstObjectByType<QuestManager>();
             qm?.RefreshNoticeboard();
+            Canvas.ForceUpdateCanvases(); // ensure layout is valid
+            if (questScroll != null)
+                questScroll.verticalNormalizedPosition = 1f; // top
         }
 
     }


### PR DESCRIPTION
## Summary
- cache the quest window ScrollRect in QuestUIManager
- reset scroll to top when quest UI opens

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2b0e67f68832eb17cb8b7d1f77bcd