### PR TITLE
Separate core and craft counts in CoreSlotUIReferences

### DIFF
--- a/Assets/Scripts/Gear/UI/CoreSlotUIReferences.cs
+++ b/Assets/Scripts/Gear/UI/CoreSlotUIReferences.cs
@@ -8,7 +8,7 @@ namespace TimelessEchoes.Gear.UI
 {
     /// <summary>
     ///     Reference holder for a single Core slot button in the Forge UI.
-    ///     Handles selection visuals and shows core discovery and craftable count using ResourceManager.
+    ///     Handles selection visuals and shows core discovery, core count, and craftable count using ResourceManager.
     /// </summary>
     public class CoreSlotUIReferences : MonoBehaviour
     {
@@ -26,6 +26,7 @@ namespace TimelessEchoes.Gear.UI
         [SerializeField] private Image selectionImage;
         [SerializeField] private Image coreImage;
         [SerializeField] private TMP_Text coreCountText;
+        [SerializeField] private TMP_Text craftCountText;
 
         [Header("Core Resource (for discovery/amount)")] [SerializeField]
         private Resource coreResource;
@@ -34,6 +35,7 @@ namespace TimelessEchoes.Gear.UI
         public Image SelectionImage => selectionImage;
         public Image CoreImage => coreImage;
         public TMP_Text CoreCountText => coreCountText;
+        public TMP_Text CraftCountText => craftCountText;
 
         public CoreSO Core
         {
@@ -81,7 +83,7 @@ namespace TimelessEchoes.Gear.UI
         }
 
         /// <summary>
-        ///     Refreshes discovery visibility and craftable count from the ResourceManager.
+        ///     Refreshes discovery visibility, core count, and craftable count from the ResourceManager.
         ///     If no resource is assigned, the count displays 0.
         /// </summary>
         public void Refresh()
@@ -106,9 +108,13 @@ namespace TimelessEchoes.Gear.UI
                 coreImage.enabled = discovered;
             }
 
+            var coreAmount = hasCoreResource && rm != null ? rm.GetAmount(coreResource) : 0;
+
             if (coreCountText != null)
+                coreCountText.text = Math.Floor(coreAmount).ToString("0");
+
+            if (craftCountText != null)
             {
-                var coreAmount = hasCoreResource && rm != null ? rm.GetAmount(coreResource) : 0;
                 var crafts = Math.Floor(coreAmount);
                 if (rm != null)
                 {
@@ -118,7 +124,7 @@ namespace TimelessEchoes.Gear.UI
                         crafts = Math.Min(crafts, Math.Floor(ingotAmount) / cost);
                 }
 
-                coreCountText.text = crafts.ToString("0");
+                craftCountText.text = crafts.ToString("0");
             }
         }
     }


### PR DESCRIPTION
## Summary
- add CraftCountText field to CoreSlotUIReferences
- display core count separately from craftable count

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a2b7d4349c832eaacba8c7f65a443b