### PR TITLE
docs: add August 18, 2025 patch notes to wiki

### DIFF
--- a/docs/wiki/index.html
+++ b/docs/wiki/index.html
@@ -471,6 +471,37 @@
             </div>
             <!-- Embedded source to avoid external file loads -->
             <script id="patchnotes-source" type="text/plain">
+# Version 1.1.24 | August 18th, 2025
+### Changes
+- Meeting cards now sit in the top left.
+- Library is now visible during a run.
+- Items that do not have an Alter-Echo now show N/A for AE Power.
+- Buffed the per level chances for rarer gear on Eznorb, Nori, and Dlog Cores.
+- Updated the Forge Library entry to show icons and give better explinations.
+- Removed the dedicated salvage button from the forge.
+- Fixed the value of attack rate so it now counts as an upgrade properly.
+- Forging should finally no longer count towards run stats.
+- Quests now scrolls to the top whenever you open the quests window.
+- Ivan now actually hands you his sword when you complete the quest.
+- The forge now automatically equips the first piece you craft for a slot.
+- Core counts now show at the bottom of their selection boxes.
+- Added comprehensive stat tracking to the forge.
+- There is now an inventory button in the forge to swap between stats and inventory.
+
+# Version 1.1.23 | August 18th, 2025
+### Changes
+- Reduced the min distance for Bloop down to 1750
+- Fixed an issue where all fish would entirely stop dropping resources beyond their softcaps.
+- Added a new field to the while you were away screen that shows your reap distance increase if it went up.
+- Dramatically reduced the size of the game by removing unused font files. Oops.
+- Right click should now consistently work on the run summary screen.
+
+# Version 1.1.22 | August 18th, 2025
+### Changes
+- Fixed an issue where the Lirium chestpieces looked like helmets.
+- Fixed the skill window not correctly showing its data.
+- Potentially fixed the issue where gear would disappear for some users.
+
 # Version 1.1.21 | August 18th, 2025
 ### Changes
 - Fixed an issue where the Lirium chestpieces looked like helmets.


### PR DESCRIPTION
## Summary
- add Version 1.1.24, 1.1.23, and 1.1.22 patch notes for August 18, 2025

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e20ad70c832ebefe1002965abc65