### PR TITLE
Keep reap line position in sync with reaping distance

### DIFF
--- a/Assets/Scripts/MapGeneration/ReapLineSystem.cs
+++ b/Assets/Scripts/MapGeneration/ReapLineSystem.cs
@@ -1,0 +1,62 @@
+using TimelessEchoes.Buffs;
+using TimelessEchoes.Stats;
+using UnityEngine;
+
+namespace TimelessEchoes.MapGeneration
+{
+    /// <summary>
+    /// Keeps the reap line positioned at the current reaping distance.
+    /// Attach to an always-present object (e.g. GameManager).
+    /// </summary>
+    public class ReapLineSystem : MonoBehaviour
+    {
+        [SerializeField] private Transform reapLine;
+        private float cachedDistance;
+        private const float CheckInterval = 0.2f; // 5 checks per second
+
+        private void Start()
+        {
+            DontDestroyOnLoad(gameObject);
+            cachedDistance = ComputeReapDistance();
+            UpdateLine();
+            InvokeRepeating(nameof(CheckReapDistance), CheckInterval, CheckInterval);
+        }
+
+        private void CheckReapDistance()
+        {
+            var current = ComputeReapDistance();
+            if (!Mathf.Approximately(current, cachedDistance))
+            {
+                cachedDistance = current;
+                UpdateLine();
+            }
+        }
+
+        private float ComputeReapDistance()
+        {
+            var tracker = GameplayStatTracker.Instance;
+            if (tracker == null) return 0f;
+
+            var buff = BuffManager.Instance;
+            var baseDist = tracker.MaxRunDistance;
+            if (buff != null)
+            {
+                baseDist = baseDist * buff.MaxDistanceMultiplier + buff.MaxDistanceFlatBonus;
+            }
+            return baseDist;
+        }
+
+        private void UpdateLine()
+        {
+            if (reapLine == null) return;
+            var pos = reapLine.position;
+            pos.x = cachedDistance;
+            reapLine.position = pos;
+        }
+
+        private void OnDestroy()
+        {
+            CancelInvoke(nameof(CheckReapDistance));
+        }
+    }
+}

--- a/Assets/Scripts/MapGeneration/ReapLineSystem.cs.meta
+++ b/Assets/Scripts/MapGeneration/ReapLineSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bd7b8aca70bc401aad878e6a3fadce43
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Add `ReapLineSystem` that recalculates reaping distance 5× per second using `InvokeRepeating`
- Automatically cancels the invoke when destroyed to avoid leaks

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*


------
https://chatgpt.com/codex/tasks/task_e_68a3c8c88f68832ea66946f1f57f0951