### PR TITLE
Trigger AutoBuff animator on distance buffs

### DIFF
--- a/Assets/Scripts/Buffs/BuffManager.cs
+++ b/Assets/Scripts/Buffs/BuffManager.cs
@@ -220,6 +220,7 @@ namespace TimelessEchoes.Buffs
                 expireAtDistance = expireDist
             };
             activeBuffs.Add(buff);
+            AutoBuffChanged?.Invoke();
             Log($"Buff {recipe.name} added", TELogCategory.Buff, this);
 
             var echoCount = recipe.GetEchoCount();
@@ -460,6 +461,7 @@ namespace TimelessEchoes.Buffs
             foreach (var buff in activeBuffs)
                 DestroyEchoes(buff);
             activeBuffs.Clear();
+            AutoBuffChanged?.Invoke();
         }
 
         public void UpdateDistance(float heroX)
@@ -479,6 +481,7 @@ namespace TimelessEchoes.Buffs
             activeBuffs.RemoveAt(index);
             if (buff.recipe != null)
                 Log($"Buff {buff.recipe.name} expired", TELogCategory.Buff, this);
+            AutoBuffChanged?.Invoke();
         }
 
         private void DestroyEchoes(ActiveBuff buff)

--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using Pathfinding;
 using Pathfinding.RVO;
 using Sirenix.OdinInspector;
@@ -423,7 +424,14 @@ namespace TimelessEchoes.Hero
         {
             if (AutoBuffAnimator == null) return;
             var manager = BuffManager.Instance;
-            var active = manager != null && manager.AnySlotAutoBuffing && !IsEcho;
+            var active = false;
+            if (manager != null && !IsEcho)
+            {
+                active = manager.ActiveBuffs.Any(b =>
+                    b.effects.Any(e =>
+                        (e.type == BuffEffectType.MaxDistancePercent ||
+                         e.type == BuffEffectType.MaxDistanceIncrease) && e.value > 0f));
+            }
             AutoBuffAnimator.gameObject.SetActive(active);
             if (animator != null && AutoBuffAnimator.isActiveAndEnabled)
             {


### PR DESCRIPTION
## Summary
- Activate the AutoBuff animator only when a buff with Max Reap Distance effects is active
- Notify listeners when buffs are added, removed, or cleared

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a400f026dc832ebc9beec1e8e1c3dc