### PR TITLE
Add cooldown tracking and UI feedback for buffs

### DIFF
--- a/Assets/Scripts/Buffs/BuffRecipe.cs
+++ b/Assets/Scripts/Buffs/BuffRecipe.cs
@@ -33,6 +33,11 @@ namespace TimelessEchoes.Buffs
 
         [TitleGroup("General")]
         [HideIf("@durationType == BuffDurationType.ExtraDistancePercent")]
+        [MinValue(0f)]
+        public float baseCooldown = 60f;
+
+        [TitleGroup("General")]
+        [HideIf("@durationType == BuffDurationType.ExtraDistancePercent")]
         [MinValue(0)]
         public int baseEchoCount;
 
@@ -146,6 +151,26 @@ namespace TimelessEchoes.Buffs
                 }
             }
             return duration;
+        }
+
+        public float GetCooldown()
+        {
+            if (durationType == BuffDurationType.ExtraDistancePercent)
+                return 0f;
+            var cooldown = baseCooldown;
+            var qm = QuestManager.Instance ?? UnityEngine.Object.FindFirstObjectByType<QuestManager>();
+            if (qm != null)
+            {
+                foreach (var up in upgrades)
+                {
+                    if (up?.quest != null && qm.IsQuestCompleted(up.quest))
+                        cooldown += up.cooldownDelta;
+                }
+            }
+            var duration = GetDuration();
+            if (cooldown <= duration)
+                cooldown = duration + 0.01f;
+            return cooldown;
         }
 
         public float GetExtraDistance(float baseDistance)

--- a/Assets/Scripts/Buffs/BuffTypes.cs
+++ b/Assets/Scripts/Buffs/BuffTypes.cs
@@ -38,5 +38,6 @@ namespace TimelessEchoes.Buffs
         public List<BuffEffect> additionalEffects = new();
         public float durationDelta;
         public int echoCountDelta;
+        public float cooldownDelta = 0f;
     }
 }

--- a/Assets/Scripts/Buffs/BuffUIManager.cs
+++ b/Assets/Scripts/Buffs/BuffUIManager.cs
@@ -81,6 +81,7 @@ namespace TimelessEchoes.Buffs
                 if (ui == null) continue;
                 if (ui.radialFillImage != null)
                     ui.radialFillImage.fillAmount = 0f;
+                var cooldown = recipe != null && buffManager != null ? buffManager.GetCooldownRemaining(recipe) : 0f;
                 var canActivate = recipe != null && buffManager != null && buffManager.CanActivate(recipe) && heroAlive;
                 var distanceOk = true;
                 var tracker = GameplayStatTracker.Instance;
@@ -145,6 +146,14 @@ namespace TimelessEchoes.Buffs
                                         : 0f;
                                 }
                             }
+                            else if (cooldown > 0f)
+                            {
+                                ui.durationText.text = FormatTime(cooldown, showDecimal: cooldown < 10f, shortForm: true);
+                                if (ui.radialFillImage != null)
+                                    ui.radialFillImage.fillAmount = recipe != null
+                                        ? Mathf.Clamp01(cooldown / recipe.GetCooldown())
+                                        : 0f;
+                            }
                             else
                             {
                                 ui.durationText.text = string.Empty;
@@ -178,6 +187,14 @@ namespace TimelessEchoes.Buffs
                                             ? Mathf.Clamp01(remainExtra / totalExtra)
                                             : 0f;
                                 }
+                                else if (cooldown > 0f)
+                                {
+                                    ui.durationText.text = FormatTime(cooldown, showDecimal: cooldown < 10f, shortForm: true);
+                                    if (ui.radialFillImage != null)
+                                        ui.radialFillImage.fillAmount = recipe != null
+                                            ? Mathf.Clamp01(cooldown / recipe.GetCooldown())
+                                            : 0f;
+                                }
                                 else
                                 {
                                     ui.durationText.text = string.Empty;
@@ -198,13 +215,28 @@ namespace TimelessEchoes.Buffs
                         }
                         else
                         {
-                            ui.durationText.text = remain > 0f
-                                ? FormatTime(remain, showDecimal: remain < 10f, shortForm: true)
-                                : string.Empty;
-                            if (ui.radialFillImage != null)
-                                ui.radialFillImage.fillAmount = remain > 0f && recipe != null
-                                    ? Mathf.Clamp01(remain / recipe.GetDuration())
-                                    : 0f;
+                            if (remain > 0f)
+                            {
+                                ui.durationText.text = FormatTime(remain, showDecimal: remain < 10f, shortForm: true);
+                                if (ui.radialFillImage != null)
+                                    ui.radialFillImage.fillAmount = recipe != null
+                                        ? Mathf.Clamp01(remain / recipe.GetDuration())
+                                        : 0f;
+                            }
+                            else if (cooldown > 0f)
+                            {
+                                ui.durationText.text = FormatTime(cooldown, showDecimal: cooldown < 10f, shortForm: true);
+                                if (ui.radialFillImage != null)
+                                    ui.radialFillImage.fillAmount = recipe != null
+                                        ? Mathf.Clamp01(cooldown / recipe.GetCooldown())
+                                        : 0f;
+                            }
+                            else
+                            {
+                                ui.durationText.text = string.Empty;
+                                if (ui.radialFillImage != null)
+                                    ui.radialFillImage.fillAmount = 0f;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Extend buff upgrades and recipes with cooldown data
- Track per-buff cooldown timers and block activation during cooldown
- Show remaining cooldown in buff UI slots

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a41fc32510832ea1a416acfb61eb46