### PR TITLE
Defer buff cooldowns until removal and allow cooldowns outside runs

### DIFF
--- a/Assets/Scripts/Buffs/BuffManager.cs
+++ b/Assets/Scripts/Buffs/BuffManager.cs
@@ -97,12 +97,20 @@ namespace TimelessEchoes.Buffs
 
             Instance = this;
 
+            // Ensure no active buffs linger between sessions
+            ClearActiveBuffs();
+
             OnLoadData += LoadSlots;
         }
 
         private void Start()
         {
             StartCoroutine(DelayedLoad());
+        }
+
+        private void Update()
+        {
+            Tick(Time.deltaTime);
         }
 
         private IEnumerator DelayedLoad()
@@ -237,7 +245,6 @@ namespace TimelessEchoes.Buffs
                 expireAtDistance = expireDist
             };
             activeBuffs.Add(buff);
-            cooldowns[recipe] = recipe.GetCooldown();
             NotifyAutoBuffChanged();
             Log($"Buff {recipe.name} added", TELogCategory.Buff, this);
 
@@ -481,10 +488,8 @@ namespace TimelessEchoes.Buffs
 
         public void ClearActiveBuffs()
         {
-            foreach (var buff in activeBuffs)
-                DestroyEchoes(buff);
-            activeBuffs.Clear();
-            NotifyAutoBuffChanged();
+            for (var i = activeBuffs.Count - 1; i >= 0; i--)
+                RemoveBuffAt(i);
         }
 
         public void UpdateDistance(float heroX)
@@ -503,7 +508,10 @@ namespace TimelessEchoes.Buffs
             DestroyEchoes(buff);
             activeBuffs.RemoveAt(index);
             if (buff.recipe != null)
+            {
+                cooldowns[buff.recipe] = buff.recipe.GetCooldown();
                 Log($"Buff {buff.recipe.name} expired", TELogCategory.Buff, this);
+            }
             NotifyAutoBuffChanged();
         }
 

--- a/Assets/Scripts/Buffs/BuffUIManager.cs
+++ b/Assets/Scripts/Buffs/BuffUIManager.cs
@@ -151,7 +151,7 @@ namespace TimelessEchoes.Buffs
                                 ui.durationText.text = FormatTime(cooldown, showDecimal: cooldown < 10f, shortForm: true);
                                 if (ui.radialFillImage != null)
                                     ui.radialFillImage.fillAmount = recipe != null
-                                        ? Mathf.Clamp01(cooldown / recipe.GetCooldown())
+                                        ? 1f - Mathf.Clamp01(cooldown / recipe.GetCooldown())
                                         : 0f;
                             }
                             else
@@ -192,7 +192,7 @@ namespace TimelessEchoes.Buffs
                                     ui.durationText.text = FormatTime(cooldown, showDecimal: cooldown < 10f, shortForm: true);
                                     if (ui.radialFillImage != null)
                                         ui.radialFillImage.fillAmount = recipe != null
-                                            ? Mathf.Clamp01(cooldown / recipe.GetCooldown())
+                                            ? 1f - Mathf.Clamp01(cooldown / recipe.GetCooldown())
                                             : 0f;
                                 }
                                 else
@@ -228,7 +228,7 @@ namespace TimelessEchoes.Buffs
                                 ui.durationText.text = FormatTime(cooldown, showDecimal: cooldown < 10f, shortForm: true);
                                 if (ui.radialFillImage != null)
                                     ui.radialFillImage.fillAmount = recipe != null
-                                        ? Mathf.Clamp01(cooldown / recipe.GetCooldown())
+                                        ? 1f - Mathf.Clamp01(cooldown / recipe.GetCooldown())
                                         : 0f;
                             }
                             else

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -853,7 +853,6 @@ namespace TimelessEchoes
 
         private IEnumerator CleanupMapRoutine()
         {
-            BuffManager.Instance?.Pause();
             if (stallMonitorCoroutine != null)
             {
                 StopCoroutine(stallMonitorCoroutine);

--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -233,8 +233,6 @@ namespace TimelessEchoes.Hero
         {
             if (!logicActive)
                 return;
-            if (!IsEcho)
-                BuffManager.Instance?.Tick(Time.deltaTime);
             if (stats != null)
                 ai.maxSpeed = (baseMoveSpeed + moveSpeedBonus + gearMoveSpeedBonus) *
                               (buffController != null ? buffController.MoveSpeedMultiplier : 1f);
@@ -358,9 +356,6 @@ namespace TimelessEchoes.Hero
 
         private void OnDisable()
         {
-            if (!IsEcho)
-                buffController?.Pause();
-
             if (CurrentTask is BaseTask baseTask)
                 baseTask.ReleaseClaim(this);
 


### PR DESCRIPTION
## Summary
- Clear active buffs at startup so no buffs linger between sessions
- Begin cooldowns when buffs end or runs finish instead of on purchase
- Keep buff cooldowns ticking and UI filling upward even in town

## Testing
- `dotnet build` *(fails: project or solution file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a429ee8d78832ea5ab3ff12c7861dd