### PR TITLE
Remove duration-based cooldown override

### DIFF
--- a/Assets/Scripts/Buffs/BuffManager.cs
+++ b/Assets/Scripts/Buffs/BuffManager.cs
@@ -497,11 +497,18 @@ namespace TimelessEchoes.Buffs
             for (var i = activeBuffs.Count - 1; i >= 0; i--)
             {
                 var buff = activeBuffs[i];
-                if (heroX >= buff.expireAtDistance) RemoveBuffAt(i);
+                if (heroX >= buff.expireAtDistance)
+                {
+                    var startCooldown = buff.recipe == null ||
+                                        (buff.recipe.durationType != BuffDurationType.DistancePercent &&
+                                         buff.recipe.durationType != BuffDurationType.ExtraDistancePercent);
+                    // Distance-based buffs that expire from distance do not start their cooldown.
+                    RemoveBuffAt(i, startCooldown);
+                }
             }
         }
 
-        private void RemoveBuffAt(int index)
+        private void RemoveBuffAt(int index, bool startCooldown = true)
         {
             if (index < 0 || index >= activeBuffs.Count) return;
             var buff = activeBuffs[index];
@@ -509,7 +516,8 @@ namespace TimelessEchoes.Buffs
             activeBuffs.RemoveAt(index);
             if (buff.recipe != null)
             {
-                cooldowns[buff.recipe] = buff.recipe.GetCooldown();
+                if (startCooldown)
+                    cooldowns[buff.recipe] = buff.recipe.GetCooldown();
                 Log($"Buff {buff.recipe.name} expired", TELogCategory.Buff, this);
             }
             NotifyAutoBuffChanged();

--- a/Assets/Scripts/Buffs/BuffRecipe.cs
+++ b/Assets/Scripts/Buffs/BuffRecipe.cs
@@ -167,9 +167,8 @@ namespace TimelessEchoes.Buffs
                         cooldown += up.cooldownDelta;
                 }
             }
-            var duration = GetDuration();
-            if (cooldown <= duration)
-                cooldown = duration + 0.01f;
+            // Cooldown now starts after the buff duration finishes, so it is not
+            // forced to be longer than the duration.
             return cooldown;
         }
 


### PR DESCRIPTION
## Summary
- Avoid forcing buff cooldown to exceed its duration by removing duration check in BuffRecipe
- Skip applying cooldown when distance-based buffs expire by reaching their max distance

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a42efa76dc832e83e6a2cffc2e002b