### PR TITLE
Add skeleton archer and mage combat clips

### DIFF
--- a/Assets/Scripts/Audio/AudioManager.cs
+++ b/Assets/Scripts/Audio/AudioManager.cs
@@ -37,6 +37,10 @@ namespace TimelessEchoes.Audio
 
         [SerializeField] private AudioClip[] weaponSwingClips;
 
+        [SerializeField] private AudioClip[] skeletonArcherClips;
+
+        [SerializeField] private AudioClip[] skeletonMageClips;
+
         [Header("Chest Clips")] [SerializeField]
         private AudioClip[] chestOpenClips;
 
@@ -146,6 +150,16 @@ namespace TimelessEchoes.Audio
         public void PlayWeaponSwingClip()
         {
             PlayCombatClip(weaponSwingClips);
+        }
+
+        public void PlaySkeletonArcherClip()
+        {
+            PlayCombatClip(skeletonArcherClips);
+        }
+
+        public void PlaySkeletonMageClip()
+        {
+            PlayCombatClip(skeletonMageClips);
         }
 
         public void PlayChestOpenClip()

--- a/Assets/Scripts/Audio/ProjectileHitSfx.cs
+++ b/Assets/Scripts/Audio/ProjectileHitSfx.cs
@@ -14,7 +14,9 @@ namespace TimelessEchoes.Audio
         public enum HitType
         {
             Slime,
-            Sword
+            Sword,
+            SkeletonArcher,
+            SkeletonMage
         }
 
         [SerializeField] private HitType hitType = HitType.Slime;
@@ -28,6 +30,12 @@ namespace TimelessEchoes.Audio
                     break;
                 case HitType.Sword:
                     Audio?.PlayWeaponSwingClip();
+                    break;
+                case HitType.SkeletonArcher:
+                    Audio?.PlaySkeletonArcherClip();
+                    break;
+                case HitType.SkeletonMage:
+                    Audio?.PlaySkeletonMageClip();
                     break;
             }
         }


### PR DESCRIPTION
## Summary
- add skeleton archer and mage combat clip lists
- expose audio manager methods for new combat clips
- extend projectile hit SFX types for skeleton archer and mage

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a43506b5f8832e84f500128642a518