### PR TITLE
Add crossfading music tracks for map generation

### DIFF
--- a/Assets/Scripts/Audio/AudioManager.cs
+++ b/Assets/Scripts/Audio/AudioManager.cs
@@ -1,4 +1,6 @@
 using Blindsided.SaveData;
+using System.Collections;
+using System.Collections.Generic;
 using TimelessEchoes.UI;
 using UnityEngine;
 using UnityEngine.Audio;
@@ -22,7 +24,8 @@ namespace TimelessEchoes.Audio
         [SerializeField] private AudioMixerGroup ambianceGroup;
 
         [Header("Music")] [SerializeField] private AudioSource musicSource;
-        [SerializeField] private AudioClip musicClip;
+        [SerializeField] private AudioSource musicSourceB;
+        [SerializeField] private Dictionary<MusicTrack, AudioClip> musicClips = new();
 
         [Header("Task Clips")] [SerializeField]
         private AudioClip[] woodcuttingClips;
@@ -42,6 +45,12 @@ namespace TimelessEchoes.Audio
 
         [Header("Hero Clips")] [SerializeField]
         private AudioClip heroDeathClip;
+
+        public enum MusicTrack
+        {
+            Main,
+            Mines
+        }
 
         public enum TaskType
         {
@@ -64,12 +73,22 @@ namespace TimelessEchoes.Audio
                 return;
             }
 
-            if (musicClip != null && musicSource != null)
+            if (musicSource != null)
             {
-                musicSource.clip = musicClip;
                 musicSource.loop = true;
                 musicSource.outputAudioMixerGroup = musicGroup;
-                musicSource.Play();
+                if (musicClips.TryGetValue(MusicTrack.Main, out var clip))
+                {
+                    musicSource.clip = clip;
+                    musicSource.Play();
+                }
+            }
+
+            if (musicSourceB != null)
+            {
+                musicSourceB.loop = true;
+                musicSourceB.outputAudioMixerGroup = musicGroup;
+                musicSourceB.volume = 0f;
             }
 
             ApplyVolumes();
@@ -172,6 +191,52 @@ namespace TimelessEchoes.Audio
         {
             if (clips == null || clips.Length == 0) return null;
             return clips[Random.Range(0, clips.Length)];
+        }
+
+        public void PlayMusic(MusicTrack track, float fadeDuration)
+        {
+            if (musicSource == null || musicSourceB == null) return;
+            if (!musicClips.TryGetValue(track, out var clip)) return;
+            if (musicSource.clip == clip) return;
+            StartCoroutine(CrossfadeRoutine(clip, fadeDuration));
+        }
+
+        private IEnumerator CrossfadeRoutine(AudioClip newClip, float duration)
+        {
+            var from = musicSource;
+            var to = musicSourceB;
+            if (from == null || to == null || newClip == null) yield break;
+
+            to.clip = newClip;
+            to.loop = true;
+            to.outputAudioMixerGroup = musicGroup;
+            to.volume = 0f;
+            to.Play();
+
+            if (duration <= 0f)
+            {
+                from.Stop();
+                to.volume = 1f;
+            }
+            else
+            {
+                float time = 0f;
+                float start = from.volume;
+                while (time < duration)
+                {
+                    time += Time.deltaTime;
+                    var t = time / duration;
+                    from.volume = Mathf.Lerp(start, 0f, t);
+                    to.volume = Mathf.Lerp(0f, 1f, t);
+                    yield return null;
+                }
+
+                from.Stop();
+                to.volume = 1f;
+            }
+
+            musicSource = to;
+            musicSourceB = from;
         }
 
         private static float LinearToDecibel(float value)

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -100,6 +100,7 @@ namespace TimelessEchoes
 
         [TitleGroup("Map Generation")]
         [SerializeField] private List<MapGenerationButton> generationButtons = new();
+        [SerializeField] private float fadeDuration = 1f;
 
         [Header("Cameras")] [SerializeField] private CinemachineCamera tavernCamera;
 
@@ -181,7 +182,12 @@ namespace TimelessEchoes
             {
                 if (entry?.button == null) continue;
                 var cfg = entry.config;
-                UnityEngine.Events.UnityAction action = () => StartRun(cfg);
+                var track = entry.musicTrack;
+                UnityEngine.Events.UnityAction action = () =>
+                {
+                    AudioManager.Instance.PlayMusic(track, fadeDuration);
+                    StartRun(cfg);
+                };
                 entry.button.onClick.AddListener(action);
                 _buttonActions.Add(entry.button, action);
             }

--- a/Assets/Scripts/MapGeneration/MapGenerationButton.cs
+++ b/Assets/Scripts/MapGeneration/MapGenerationButton.cs
@@ -1,5 +1,6 @@
 using System;
 using UnityEngine.UI;
+using TimelessEchoes.Audio;
 using TimelessEchoes.References.StatPanel;
 
 namespace TimelessEchoes.MapGeneration
@@ -10,5 +11,6 @@ namespace TimelessEchoes.MapGeneration
         public Button button;
         public MapGenerationConfig config;
         public GeneralStatsUIReferences statsUI;
+        public AudioManager.MusicTrack musicTrack;
     }
 }


### PR DESCRIPTION
## Summary
- Add `MusicTrack` enum and dictionary-based music clips
- Implement crossfading music playback with dual audio sources
- Allow map generation buttons to specify music track and trigger fades on run start

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a434af8af8832eb595321f5e2f20fc