### PR TITLE
Add selectable enemy death sounds

### DIFF
--- a/Assets/Scripts/Audio/AudioManager.cs
+++ b/Assets/Scripts/Audio/AudioManager.cs
@@ -50,6 +50,9 @@ namespace TimelessEchoes.Audio
         [Header("Hero Clips")] [SerializeField]
         private AudioClip heroDeathClip;
 
+        [Header("Enemy Death Clips")] [SerializeField]
+        private AudioClip[] skeletonDeathClips;
+
         public enum MusicTrack
         {
             Main,
@@ -194,6 +197,11 @@ namespace TimelessEchoes.Audio
         public void PlayHeroDeathClip()
         {
             PlaySfx(heroDeathClip);
+        }
+
+        public void PlaySkeletonDeathClip()
+        {
+            PlaySfx(GetRandom(skeletonDeathClips));
         }
 
         private void PlaySfx(AudioClip clip)

--- a/Assets/Scripts/Enemies/Health.cs
+++ b/Assets/Scripts/Enemies/Health.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using Blindsided.Utilities;
 using TMPro;
+using TimelessEchoes.Audio;
 
 namespace TimelessEchoes.Enemies
 {
@@ -9,8 +10,15 @@ namespace TimelessEchoes.Enemies
     /// </summary>
     public class Health : HealthBase
     {
+        public enum DeathSfx
+        {
+            None,
+            Skeleton
+        }
+
         [SerializeField] private GameObject healthBarParent;
         [SerializeField] private TMP_Text healthText;
+        [SerializeField] private DeathSfx deathSfx = DeathSfx.None;
 
         protected override void Awake()
         {
@@ -106,6 +114,14 @@ namespace TimelessEchoes.Enemies
         protected override void OnZeroHealth()
         {
             base.OnZeroHealth();
+
+            switch (deathSfx)
+            {
+                case DeathSfx.Skeleton:
+                    AudioManager.Instance?.PlaySkeletonDeathClip();
+                    break;
+            }
+
             if (GetComponent<Enemy>() != null)
                 Destroy(gameObject);
         }


### PR DESCRIPTION
## Summary
- add `DeathSfx` enum to `Health` for choosing death sound clips
- extend `AudioManager` with skeleton death clips and playback helper

## Testing
- `dotnet build` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a43c61e438832e8f537fb39716c841