### PR TITLE
Display cooldown in buff descriptions

### DIFF
--- a/Assets/Scripts/Buffs/BuffRecipe.cs
+++ b/Assets/Scripts/Buffs/BuffRecipe.cs
@@ -221,7 +221,9 @@ namespace TimelessEchoes.Buffs
             if (durationType == BuffDurationType.DistancePercent)
                 lines.Add($"Distance: {Mathf.CeilToInt(GetDuration() * 100f)}%");
             else if (durationType != BuffDurationType.ExtraDistancePercent)
-                lines.Add($"Duration: {CalcUtils.FormatTime(GetDuration(), shortForm: true)}");
+                lines.Add(
+                    $"Duration: {CalcUtils.FormatTime(GetDuration(), shortForm: true)}, " +
+                    $"Cooldown: {CalcUtils.FormatTime(GetCooldown(), shortForm: true)}");
             return lines;
         }
 


### PR DESCRIPTION
## Summary
- show cooldown time after buff duration in description lines

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4400e4090832e9c82f90696e43e3f