### PR TITLE
Randomize SFX pitch for subtle variation

### DIFF
--- a/Assets/Scripts/Audio/SfxPlayer.cs
+++ b/Assets/Scripts/Audio/SfxPlayer.cs
@@ -11,6 +11,9 @@ namespace TimelessEchoes.Audio
         private static AudioClip _lastClip;
         private static float _lastPlay;
 
+        private const float MinPitch = 0.95f;
+        private const float MaxPitch = 1.05f;
+
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         private static void Init()
         {
@@ -40,7 +43,9 @@ namespace TimelessEchoes.Audio
                 return;
             _lastClip = clip;
             _lastPlay = t;
+            _source.pitch = Random.Range(MinPitch, MaxPitch);
             _source.PlayOneShot(clip, StaticReferences.SfxVolume);
+            _source.pitch = 1f;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add configurable min and max pitch constants for SFX playback
- Randomize pitch for each SFX play and reset after playing

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4444b56d4832e8fceca5d5e688820