### PR TITLE
Allow town window buttons to toggle their windows

### DIFF
--- a/Assets/Scripts/UI/TownWindowManager.cs
+++ b/Assets/Scripts/UI/TownWindowManager.cs
@@ -11,8 +11,9 @@ namespace TimelessEchoes.UI
 {
     /// <summary>
     ///     Manages the town UI windows. Clicking a button closes all windows,
-    ///     opens the associated one, and shows a global close button. Right-click
-    ///     or the close button closes all windows.
+    ///     opens the associated one, and shows a global close button. Selecting the
+    ///     same button again closes its window. Right-click or the close button
+    ///     closes all windows.
     /// </summary>
     public class TownWindowManager : MonoBehaviour
     {
@@ -230,8 +231,6 @@ namespace TimelessEchoes.UI
             if (inventory.window != null)
             {
                 inventory.window.SetActive(false);
-                if (inventory.button != null)
-                    inventory.button.interactable = true;
             }
             if (forgeInfo != null)
                 forgeInfo.SetActive(true);
@@ -253,8 +252,6 @@ namespace TimelessEchoes.UI
             bool showInventory = !inventoryActive;
 
             inventory.window.SetActive(showInventory);
-            if (inventory.button != null)
-                inventory.button.interactable = !showInventory;
 
             forgeInfo.SetActive(!showInventory);
 
@@ -274,15 +271,12 @@ namespace TimelessEchoes.UI
             if (!windowWasActive)
             {
                 reference.window.SetActive(true);
-                reference.button.interactable = false;
 
                 if (reference.openInventory)
                 {
                     if (inventory.window != null)
                     {
                         inventory.window.SetActive(true);
-                        if (inventory.button != null)
-                            inventory.button.interactable = false;
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Keep town window buttons interactable so tapping again closes their window
- Update TownWindowManager to stop disabling window buttons and inventory button
- Document new toggle behavior in TownWindowManager summary

## Testing
- `dotnet format Assets/Scripts/UI/TownWindowManager.cs` *(fails: file is not a valid project)*
- `dotnet build` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a510c685b0832ea0f3e87df655ca6c