### PR TITLE
Start cooldown for distance buffs

### DIFF
--- a/Assets/Scripts/Buffs/BuffRecipe.cs
+++ b/Assets/Scripts/Buffs/BuffRecipe.cs
@@ -32,7 +32,6 @@ namespace TimelessEchoes.Buffs
         public float baseDuration = 30f;
 
         [TitleGroup("General")]
-        [HideIf("@durationType == BuffDurationType.ExtraDistancePercent")]
         [MinValue(0f)]
         public float baseCooldown = 60f;
 
@@ -155,13 +154,14 @@ namespace TimelessEchoes.Buffs
 
         public float GetCooldown()
         {
-            if (durationType == BuffDurationType.ExtraDistancePercent)
-                return 0f;
             var cooldown = baseCooldown;
             var qm = QuestManager.Instance ?? UnityEngine.Object.FindFirstObjectByType<QuestManager>();
             if (qm != null)
             {
-                foreach (var up in upgrades)
+                var upgradeList = durationType == BuffDurationType.ExtraDistancePercent
+                    ? extraDistanceUpgrades
+                    : upgrades;
+                foreach (var up in upgradeList)
                 {
                     if (up?.quest != null && qm.IsQuestCompleted(up.quest))
                         cooldown += up.cooldownDelta;

--- a/Assets/Scripts/Buffs/BuffUIManager.cs
+++ b/Assets/Scripts/Buffs/BuffUIManager.cs
@@ -133,6 +133,8 @@ namespace TimelessEchoes.Buffs
                             if (!distanceOk)
                             {
                                 ui.durationText.text = "Too Far";
+                                if (ui.radialFillImage != null)
+                                    ui.radialFillImage.fillAmount = 0f;
                             }
                             else if (remain > 0f)
                             {
@@ -167,40 +169,49 @@ namespace TimelessEchoes.Buffs
                                      e.type == BuffEffectType.MaxDistancePercent ||
                                      e.type == BuffEffectType.MaxDistanceIncrease))
                         {
-                            if (remain > 0f)
+                            if (!distanceOk)
+                            {
+                                ui.durationText.text = "Too Far";
+                                if (ui.radialFillImage != null)
+                                    ui.radialFillImage.fillAmount = 0f;
+                            }
+                            else if (remain > 0f)
                             {
                                 var baseMax = tracker.MaxRunDistance;
                                 var totalExtra = expireDist - baseMax;
-                                var remainExtra = expireDist - tracker.CurrentRunDistance;
                                 if (tracker.CurrentRunDistance < baseMax)
                                 {
                                     ui.durationText.text = "Active";
                                     if (ui.radialFillImage != null)
                                         ui.radialFillImage.fillAmount = 0f;
                                 }
-                                else if (remainExtra > 0f)
-                                {
-                                    ui.durationText.text = FormatNumber(remainExtra, true);
-                                    if (ui.radialFillImage != null)
-                                        // Use remaining distance so the radial fill drains instead of grows.
-                                        ui.radialFillImage.fillAmount = totalExtra > 0f
-                                            ? Mathf.Clamp01(remainExtra / totalExtra)
-                                            : 0f;
-                                }
-                                else if (cooldown > 0f)
-                                {
-                                    ui.durationText.text = FormatTime(cooldown, showDecimal: cooldown < 10f, shortForm: true);
-                                    if (ui.radialFillImage != null)
-                                        ui.radialFillImage.fillAmount = recipe != null
-                                            ? 1f - Mathf.Clamp01(cooldown / recipe.GetCooldown())
-                                            : 0f;
-                                }
                                 else
                                 {
-                                    ui.durationText.text = string.Empty;
-                                    if (ui.radialFillImage != null)
-                                        ui.radialFillImage.fillAmount = 0f;
+                                    var remainExtra = expireDist - tracker.CurrentRunDistance;
+                                    if (remainExtra > 0f)
+                                    {
+                                        ui.durationText.text = FormatNumber(remainExtra, true);
+                                        if (ui.radialFillImage != null)
+                                            // Use remaining distance so the radial fill drains instead of grows.
+                                            ui.radialFillImage.fillAmount = totalExtra > 0f
+                                                ? Mathf.Clamp01(remainExtra / totalExtra)
+                                                : 0f;
+                                    }
+                                    else
+                                    {
+                                        ui.durationText.text = string.Empty;
+                                        if (ui.radialFillImage != null)
+                                            ui.radialFillImage.fillAmount = 0f;
+                                    }
                                 }
+                            }
+                            else if (cooldown > 0f)
+                            {
+                                ui.durationText.text = FormatTime(cooldown, showDecimal: cooldown < 10f, shortForm: true);
+                                if (ui.radialFillImage != null)
+                                    ui.radialFillImage.fillAmount = recipe != null
+                                        ? 1f - Mathf.Clamp01(cooldown / recipe.GetCooldown())
+                                        : 0f;
                             }
                             else
                             {
@@ -212,6 +223,8 @@ namespace TimelessEchoes.Buffs
                         else if (!distanceOk)
                         {
                             ui.durationText.text = "Too Far";
+                            if (ui.radialFillImage != null)
+                                ui.radialFillImage.fillAmount = 0f;
                         }
                         else
                         {


### PR DESCRIPTION
## Summary
- Start cooldown immediately for distance-increasing buffs and skip duplicate cooldowns on removal.
- Expose `baseCooldown` and compute cooldown for `ExtraDistancePercent` recipes with upgrades.
- Update buff UI to hide cooldown while active or out of range and reset radial fill when hidden.

## Testing
- `dotnet test` *(fails: MSB1003 project/solution file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5194f51e0832eb2fc2562aa9fdd74