### PR TITLE
Close forge info with forge window

### DIFF
--- a/Assets/Scripts/Gear/UI/ForgeWindowUI/ForgeWindowUI.cs
+++ b/Assets/Scripts/Gear/UI/ForgeWindowUI/ForgeWindowUI.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Blindsided;
 using Blindsided.Utilities;
 using TimelessEchoes.Upgrades;
+using TimelessEchoes.UI;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using static Blindsided.SaveData.StaticReferences;
@@ -255,6 +256,7 @@ namespace TimelessEchoes.Gear.UI
 
             EventHandler.OnLoadData -= OnPostLoad;
             StopAutoCrafting();
+            TownWindowManager.Instance?.CloseForgeInfo();
         }
     }
 }

--- a/Assets/Scripts/UI/TownWindowManager.cs
+++ b/Assets/Scripts/UI/TownWindowManager.cs
@@ -259,6 +259,12 @@ namespace TimelessEchoes.UI
                 forgeInfoButtonText.text = showInventory ? "Info" : "Inventory";
         }
 
+        public void CloseForgeInfo()
+        {
+            if (forgeInfo != null)
+                forgeInfo.SetActive(false);
+        }
+
         private void ToggleWindow(WindowReference reference)
         {
             if (reference.window == null || reference.button == null)


### PR DESCRIPTION
## Summary
- ensure forge info panel hides whenever the forge window is closed
- notify TownWindowManager when the forge UI is disabled

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a5710c975c832eb1bc95157eb514b1