### PR TITLE
Use dedicated cooldown radial fill in buff UI

### DIFF
--- a/Assets/Scripts/Buffs/BuffUIManager.cs
+++ b/Assets/Scripts/Buffs/BuffUIManager.cs
@@ -81,6 +81,8 @@ namespace TimelessEchoes.Buffs
                 if (ui == null) continue;
                 if (ui.radialFillImage != null)
                     ui.radialFillImage.fillAmount = 0f;
+                if (ui.cooldownRadialFillImage != null)
+                    ui.cooldownRadialFillImage.fillAmount = 0f;
                 var cooldown = recipe != null && buffManager != null ? buffManager.GetCooldownRemaining(recipe) : 0f;
                 var canActivate = recipe != null && buffManager != null && buffManager.CanActivate(recipe) && heroAlive;
                 var distanceOk = true;
@@ -151,10 +153,12 @@ namespace TimelessEchoes.Buffs
                             else if (cooldown > 0f)
                             {
                                 ui.durationText.text = FormatTime(cooldown, showDecimal: cooldown < 10f, shortForm: true);
-                                if (ui.radialFillImage != null)
-                                    ui.radialFillImage.fillAmount = recipe != null
-                                        ? 1f - Mathf.Clamp01(cooldown / recipe.GetCooldown())
+                                if (ui.cooldownRadialFillImage != null)
+                                    ui.cooldownRadialFillImage.fillAmount = recipe != null
+                                        ? Mathf.Clamp01(cooldown / recipe.GetCooldown())
                                         : 0f;
+                                if (ui.radialFillImage != null)
+                                    ui.radialFillImage.fillAmount = 0f;
                             }
                             else
                             {
@@ -208,10 +212,12 @@ namespace TimelessEchoes.Buffs
                             else if (cooldown > 0f)
                             {
                                 ui.durationText.text = FormatTime(cooldown, showDecimal: cooldown < 10f, shortForm: true);
-                                if (ui.radialFillImage != null)
-                                    ui.radialFillImage.fillAmount = recipe != null
-                                        ? 1f - Mathf.Clamp01(cooldown / recipe.GetCooldown())
+                                if (ui.cooldownRadialFillImage != null)
+                                    ui.cooldownRadialFillImage.fillAmount = recipe != null
+                                        ? Mathf.Clamp01(cooldown / recipe.GetCooldown())
                                         : 0f;
+                                if (ui.radialFillImage != null)
+                                    ui.radialFillImage.fillAmount = 0f;
                             }
                             else
                             {
@@ -239,10 +245,12 @@ namespace TimelessEchoes.Buffs
                             else if (cooldown > 0f)
                             {
                                 ui.durationText.text = FormatTime(cooldown, showDecimal: cooldown < 10f, shortForm: true);
-                                if (ui.radialFillImage != null)
-                                    ui.radialFillImage.fillAmount = recipe != null
-                                        ? 1f - Mathf.Clamp01(cooldown / recipe.GetCooldown())
+                                if (ui.cooldownRadialFillImage != null)
+                                    ui.cooldownRadialFillImage.fillAmount = recipe != null
+                                        ? Mathf.Clamp01(cooldown / recipe.GetCooldown())
                                         : 0f;
+                                if (ui.radialFillImage != null)
+                                    ui.radialFillImage.fillAmount = 0f;
                             }
                             else
                             {

--- a/Assets/Scripts/References/UI/BuffSlotUIReferences.cs
+++ b/Assets/Scripts/References/UI/BuffSlotUIReferences.cs
@@ -14,11 +14,14 @@ namespace References.UI
         public TMP_Text durationText;
         public Image autoCastImage;
         public MPImage radialFillImage;
+        public MPImage cooldownRadialFillImage;
 
         private void Awake()
         {
             if (radialFillImage != null)
                 radialFillImage.StrokeWidth = 1f;
+            if (cooldownRadialFillImage != null)
+                cooldownRadialFillImage.StrokeWidth = 1f;
         }
 
         public event Action<BuffSlotUIReferences> PointerEnter;


### PR DESCRIPTION
## Summary
- add `cooldownRadialFillImage` reference for buff slots
- show cooldown using its own image and drain fill as time elapses
- revert prefab link so existing BuffUISlot stays unchanged

## Testing
- `dotnet test` *(fails: MSB1003 – specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a5716f7acc832e954c5f3b1423fda6