### PR TITLE
Adjust cooldown radial fill behavior

### DIFF
--- a/Assets/Scripts/Buffs/BuffUIManager.cs
+++ b/Assets/Scripts/Buffs/BuffUIManager.cs
@@ -155,7 +155,7 @@ namespace TimelessEchoes.Buffs
                                 ui.durationText.text = FormatTime(cooldown, showDecimal: cooldown < 10f, shortForm: true);
                                 if (ui.cooldownRadialFillImage != null)
                                     ui.cooldownRadialFillImage.fillAmount = recipe != null
-                                        ? Mathf.Clamp01(cooldown / recipe.GetCooldown())
+                                        ? Mathf.Clamp01(1f - cooldown / recipe.GetCooldown())
                                         : 0f;
                                 if (ui.radialFillImage != null)
                                     ui.radialFillImage.fillAmount = 0f;
@@ -214,7 +214,7 @@ namespace TimelessEchoes.Buffs
                                 ui.durationText.text = FormatTime(cooldown, showDecimal: cooldown < 10f, shortForm: true);
                                 if (ui.cooldownRadialFillImage != null)
                                     ui.cooldownRadialFillImage.fillAmount = recipe != null
-                                        ? Mathf.Clamp01(cooldown / recipe.GetCooldown())
+                                        ? Mathf.Clamp01(1f - cooldown / recipe.GetCooldown())
                                         : 0f;
                                 if (ui.radialFillImage != null)
                                     ui.radialFillImage.fillAmount = 0f;
@@ -247,7 +247,7 @@ namespace TimelessEchoes.Buffs
                                 ui.durationText.text = FormatTime(cooldown, showDecimal: cooldown < 10f, shortForm: true);
                                 if (ui.cooldownRadialFillImage != null)
                                     ui.cooldownRadialFillImage.fillAmount = recipe != null
-                                        ? Mathf.Clamp01(cooldown / recipe.GetCooldown())
+                                        ? Mathf.Clamp01(1f - cooldown / recipe.GetCooldown())
                                         : 0f;
                                 if (ui.radialFillImage != null)
                                     ui.radialFillImage.fillAmount = 0f;

--- a/Assets/Scripts/References/UI/BuffSlotUIReferences.cs
+++ b/Assets/Scripts/References/UI/BuffSlotUIReferences.cs
@@ -20,8 +20,6 @@ namespace References.UI
         {
             if (radialFillImage != null)
                 radialFillImage.StrokeWidth = 1f;
-            if (cooldownRadialFillImage != null)
-                cooldownRadialFillImage.StrokeWidth = 1f;
         }
 
         public event Action<BuffSlotUIReferences> PointerEnter;


### PR DESCRIPTION
## Summary
- Remove hardcoded stroke width on cooldown radial image
- Invert cooldown radial fill so it fills over time instead of draining

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a57694d7f4832e82780df622a0aff0