### PR TITLE
Show grey buff icons only during cooldown

### DIFF
--- a/Assets/Scripts/Buffs/BuffUIManager.cs
+++ b/Assets/Scripts/Buffs/BuffUIManager.cs
@@ -84,6 +84,7 @@ namespace TimelessEchoes.Buffs
                 if (ui.cooldownRadialFillImage != null)
                     ui.cooldownRadialFillImage.fillAmount = 0f;
                 var cooldown = recipe != null && buffManager != null ? buffManager.GetCooldownRemaining(recipe) : 0f;
+                var onCooldown = cooldown > 0f;
                 var canActivate = recipe != null && buffManager != null && buffManager.CanActivate(recipe) && heroAlive;
                 var distanceOk = true;
                 var tracker = GameplayStatTracker.Instance;
@@ -111,7 +112,7 @@ namespace TimelessEchoes.Buffs
                     else if (recipe == null)
                         ui.iconImage.color = transparent;
                     else
-                        ui.iconImage.color = canActivate ? Color.white : grey;
+                        ui.iconImage.color = onCooldown ? grey : Color.white;
                 }
 
                 if (ui.activateButton != null)


### PR DESCRIPTION
## Summary
- Grey out buff icons only when their cooldown is active
- Leave distance-based buffs white until cooldown begins

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a57aeb94c0832eb8b81ff04c8ef6e9