### PR TITLE
Grey buff icons only during cooldown

### DIFF
--- a/Assets/Scripts/Buffs/BuffUIManager.cs
+++ b/Assets/Scripts/Buffs/BuffUIManager.cs
@@ -110,8 +110,10 @@ namespace TimelessEchoes.Buffs
                         ui.iconImage.color = recipe ? grey : transparent;
                     else if (recipe == null)
                         ui.iconImage.color = transparent;
+                    else if (cooldown > 0f)
+                        ui.iconImage.color = grey;
                     else
-                        ui.iconImage.color = canActivate ? Color.white : grey;
+                        ui.iconImage.color = Color.white;
                 }
 
                 if (ui.activateButton != null)


### PR DESCRIPTION
## Summary
- Grey buff slot icons only when their cooldown is active

## Testing
- ❌ `dotnet test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a57eec3d58832e8ad8f891fb65f8cb