### PR TITLE
Fix buff icon cooldown logic for inactive buffs

### DIFF
--- a/Assets/Scripts/Buffs/BuffUIManager.cs
+++ b/Assets/Scripts/Buffs/BuffUIManager.cs
@@ -83,7 +83,12 @@ namespace TimelessEchoes.Buffs
                     ui.radialFillImage.fillAmount = 0f;
                 if (ui.cooldownRadialFillImage != null)
                     ui.cooldownRadialFillImage.fillAmount = 0f;
-                var cooldown = recipe != null && buffManager != null ? buffManager.GetCooldownRemaining(recipe) : 0f;
+                var cooldown = recipe != null && buffManager != null
+                    ? buffManager.GetCooldownRemaining(recipe)
+                    : 0f;
+                var remain = recipe != null && buffManager != null
+                    ? buffManager.GetRemaining(recipe)
+                    : 0f;
                 var canActivate = recipe != null && buffManager != null && buffManager.CanActivate(recipe) && heroAlive;
                 var distanceOk = true;
                 var tracker = GameplayStatTracker.Instance;
@@ -110,7 +115,7 @@ namespace TimelessEchoes.Buffs
                         ui.iconImage.color = recipe ? grey : transparent;
                     else if (recipe == null)
                         ui.iconImage.color = transparent;
-                    else if (cooldown > 0f)
+                    else if (remain <= 0f && cooldown > 0f)
                         ui.iconImage.color = grey;
                     else
                         ui.iconImage.color = Color.white;
@@ -129,7 +134,6 @@ namespace TimelessEchoes.Buffs
                     }
                     else
                     {
-                        var remain = recipe ? buffManager.GetRemaining(recipe) : 0f;
                         if (!heroAlive)
                             ui.durationText.text = "Dead";
                         else if (recipe != null && tracker != null && recipe.durationType == BuffDurationType.DistancePercent)


### PR DESCRIPTION
## Summary
- compute remaining time before setting buff icon color
- grey out icons only when buffs are inactive and on cooldown
- ensure extra distance buffs stay highlighted while active

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: package has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_68a58539c520832eb6e430df087bedda