### PR TITLE
Grey out buff icon when out of range

### DIFF
--- a/Assets/Scripts/Buffs/BuffUIManager.cs
+++ b/Assets/Scripts/Buffs/BuffUIManager.cs
@@ -110,6 +110,8 @@ namespace TimelessEchoes.Buffs
                         ui.iconImage.color = recipe ? grey : transparent;
                     else if (recipe == null)
                         ui.iconImage.color = transparent;
+                    else if (!distanceOk)
+                        ui.iconImage.color = grey;
                     else if (cooldown > 0f)
                         ui.iconImage.color = grey;
                     else


### PR DESCRIPTION
## Summary
- Grey out buff icons when player is beyond allowed distance before cooldown checks

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_68a5855e9d10832eb96c9576eacca93c