### PR TITLE
Fix buff and quest window closing behavior

### DIFF
--- a/Assets/Scripts/UI/TownWindowManager.cs
+++ b/Assets/Scripts/UI/TownWindowManager.cs
@@ -184,15 +184,16 @@ namespace TimelessEchoes.UI
         {
             bool wasActive = buffs.window != null && buffs.window.activeSelf;
             ToggleWindow(buffs);
-            if (wasActive && buffs.window != null)
-                buffs.window.GetComponent<BuffUIManager>()?.ClosePurchaseWindow();
+            if (wasActive)
+                buffs.window?.GetComponentInChildren<BuffUIManager>(true)?.ClosePurchaseWindow();
         }
 
         private void OpenQuests()
         {
+            bool wasActive = quests.window != null && quests.window.activeSelf;
             ToggleWindow(quests);
             if (autoPin != null)
-                autoPin.SetActive(true);
+                autoPin.SetActive(!wasActive);
         }
 
         private void OpenCredits()


### PR DESCRIPTION
## Summary
- ensure closing buff window shuts its purchase panel
- stop quest button from leaving autopin active when closing

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a4f630c4832ea0b62b4ff063c56a