### PR TITLE
Prevent buffs auto-casting before a run starts

### DIFF
--- a/Assets/Scripts/Buffs/BuffManager.cs
+++ b/Assets/Scripts/Buffs/BuffManager.cs
@@ -549,6 +549,11 @@ namespace TimelessEchoes.Buffs
 
         private void AutoCastBuffs()
         {
+            var tracker = GameplayStatTracker.Instance ??
+                          FindFirstObjectByType<GameplayStatTracker>();
+            if (tracker == null || !tracker.RunInProgress)
+                return;
+
             for (var i = 0; i < slotAssignments.Count && i < UnlockedSlots && i < autoCastSlots.Count && i < UnlockedAutoSlots; i++)
             {
                 if (!autoCastSlots[i]) continue;


### PR DESCRIPTION
## Summary
- Guard `AutoCastBuffs` with `GameplayStatTracker` and run state check
- Ensure `BuffManager` includes `TimelessEchoes.Stats` namespace

## Testing
- `dotnet build` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a799c5b884832ebb7da04d1b12dc1b