### PR TITLE
Reset run distance on new run

### DIFF
--- a/Assets/Scripts/Stats/GameplayStatTracker.cs
+++ b/Assets/Scripts/Stats/GameplayStatTracker.cs
@@ -405,6 +405,7 @@ namespace TimelessEchoes.Stats
             runStartTime = Time.time;
             lastHeroPos = Vector3.zero;
             RunInProgress = true;
+            CurrentRunDistance = 0f;
             CurrentRunSteps = 0f;
         }
 


### PR DESCRIPTION
## Summary
- Reset `CurrentRunDistance` to 0 whenever a new run begins

## Testing
- `mcs -langversion:latest Assets/Scripts/Stats/GameplayStatTracker.cs` *(fails: Unexpected symbol '?' indicating missing Unity/modern C# references)*

------
https://chatgpt.com/codex/tasks/task_e_68abcff7d2b0832ead9869e996de5ffb