### PR TITLE
Normalize sprite labels across farm animal variants

### DIFF
--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Cow/Cow_02.spriteLib
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Cow/Cow_02.spriteLib
@@ -1,0 +1,276 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5e6fedc2472449cead18ef23b5cb30d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.2D.Animation.Runtime::UnityEngine.U2D.Animation.SpriteLibrarySourceAsset
+  m_Library:
+  - m_Name: Idle
+    m_Hash: 1008081451
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_0
+      m_Hash: 500319545
+      m_Sprite: {fileID: 6132959444768226104, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6132959444768226104, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    - m_Name: Cow_01_1
+      m_Hash: 718632367
+      m_Sprite: {fileID: -1656498061108419285, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1656498061108419285, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleUp
+    m_Hash: 486716119
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_4
+      m_Hash: 448758048
+      m_Sprite: {fileID: 5965091898143296853, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5965091898143296853, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    - m_Name: Cow_01_5
+      m_Hash: 767078838
+      m_Sprite: {fileID: -7180009460180806010, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7180009460180806010, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleDown
+    m_Hash: 526694748
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_2
+      m_Hash: 870065173
+      m_Sprite: {fileID: 6641756274280773446, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6641756274280773446, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    - m_Name: Cow_01_3
+      m_Hash: 81466499
+      m_Sprite: {fileID: -2873002400819610265, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2873002400819610265, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: Walk
+    m_Hash: 765711723
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_6
+      m_Hash: 884072460
+      m_Sprite: {fileID: 4792975661432349497, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4792975661432349497, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    - m_Name: Cow_01_7
+      m_Hash: 62312602
+      m_Sprite: {fileID: 5895613105829880783, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5895613105829880783, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    - m_Name: Cow_01_8
+      m_Hash: 319409419
+      m_Sprite: {fileID: -846645968201530967, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -846645968201530967, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    - m_Name: Cow_01_9
+      m_Hash: 604962205
+      m_Sprite: {fileID: 5863452330883019616, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5863452330883019616, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    - m_Name: Cow_01_10
+      m_Hash: 840479789
+      m_Sprite: {fileID: -8858082278076559145, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8858082278076559145, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    - m_Name: Cow_01_11
+      m_Hash: 85951675
+      m_Sprite: {fileID: -2218657287798010397, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2218657287798010397, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    - m_Name: Cow_01_12
+      m_Hash: 471258369
+      m_Sprite: {fileID: -1997803533794049191, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1997803533794049191, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    - m_Name: Cow_01_13
+      m_Hash: 722593175
+      m_Sprite: {fileID: -3062865713386406072, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3062865713386406072, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkUp
+    m_Hash: 648049478
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_22
+      m_Hash: 926648002
+      m_Sprite: {fileID: 4889152986736303161, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4889152986736303161, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    - m_Name: Cow_01_23
+      m_Hash: 3978836
+      m_Sprite: {fileID: 3780160715020672943, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3780160715020672943, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    - m_Name: Cow_01_24
+      m_Hash: 509092855
+      m_Sprite: {fileID: 5539022746320519955, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5539022746320519955, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    - m_Name: Cow_01_25
+      m_Hash: 694096737
+      m_Sprite: {fileID: 1587631624097108688, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1587631624097108688, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    - m_Name: Cow_01_26
+      m_Hash: 810959579
+      m_Sprite: {fileID: -5996189623901047351, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5996189623901047351, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    - m_Name: Cow_01_27
+      m_Hash: 122778189
+      m_Sprite: {fileID: 383367867979446393, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 383367867979446393, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    - m_Name: Cow_01_28
+      m_Hash: 401502172
+      m_Sprite: {fileID: -171749884446475807, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -171749884446475807, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    - m_Name: Cow_01_29
+      m_Hash: 552165194
+      m_Sprite: {fileID: 7437124865902583540, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7437124865902583540, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkDown
+    m_Hash: 459082627
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_14
+      m_Hash: 896888884
+      m_Sprite: {fileID: 2119917728004284993, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2119917728004284993, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    - m_Name: Cow_01_15
+      m_Hash: 41042082
+      m_Sprite: {fileID: 6832354836382381709, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6832354836382381709, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    - m_Name: Cow_01_16
+      m_Hash: 461050136
+      m_Sprite: {fileID: 5226325070246228222, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5226325070246228222, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    - m_Name: Cow_01_17
+      m_Hash: 746332558
+      m_Sprite: {fileID: -7519575018274908637, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7519575018274908637, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    - m_Name: Cow_01_18
+      m_Hash: 1019427871
+      m_Sprite: {fileID: -5844945773140963529, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5844945773140963529, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    - m_Name: Cow_01_19
+      m_Hash: 197397641
+      m_Sprite: {fileID: 5090182651963957673, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5090182651963957673, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    - m_Name: Cow_01_20
+      m_Hash: 422963182
+      m_Sprite: {fileID: 5530344821537074221, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5530344821537074221, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    - m_Name: Cow_01_21
+      m_Hash: 775083896
+      m_Sprite: {fileID: -3358077611806558884, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3358077611806558884, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Attack
+    m_Hash: 7088141
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_30
+      m_Hash: 3069615
+      m_Sprite: {fileID: -9065592413669048807, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -9065592413669048807, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    - m_Name: Cow_01_31
+      m_Hash: 925492793
+      m_Sprite: {fileID: 4301597688519233216, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4301597688519233216, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    - m_Name: Cow_01_32
+      m_Hash: 773896067
+      m_Sprite: {fileID: -4102042389341535753, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4102042389341535753, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    - m_Name: Cow_01_33
+      m_Hash: 422020885
+      m_Sprite: {fileID: 4884567542063882640, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4884567542063882640, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    - m_Name: Cow_01_34
+      m_Hash: 121836214
+      m_Sprite: {fileID: -1521020269771389439, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1521020269771389439, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    - m_Name: Cow_01_35
+      m_Hash: 809771552
+      m_Sprite: {fileID: -390316870146939557, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -390316870146939557, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    - m_Name: Cow_01_36
+      m_Hash: 692941722
+      m_Sprite: {fileID: -3664779803952735476, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3664779803952735476, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    - m_Name: Cow_01_37
+      m_Hash: 508183308
+      m_Sprite: {fileID: -1646126925110410432, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1646126925110410432, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Die
+    m_Hash: 20298039
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_70
+      m_Hash: 608310187
+      m_Sprite: {fileID: 2129401767, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2129401767, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    - m_Name: Cow_01_71
+      m_Hash: 323298109
+      m_Sprite: {fileID: 349964809, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 349964809, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    - m_Name: Cow_01_72
+      m_Hash: 172782215
+      m_Sprite: {fileID: -1270501175, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1270501175, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    - m_Name: Cow_01_73
+      m_Hash: 1028342289
+      m_Sprite: {fileID: 1214058861, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1214058861, guid: 1c5b4ce3f44558d42a9626cc1853a931, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 4
+  m_PrimaryLibraryGUID: 
+  m_ModificationHash: 638924974477017144
+  m_Version: 1

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Cow/Cow_02.spriteLib.meta
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Cow/Cow_02.spriteLib.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 69e472ce185f422b83e1ad621d86150e
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 11500000, guid: db2778f6d440c47ddacff25997d7c062, type: 3}

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Cow/Cow_03.spriteLib
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Cow/Cow_03.spriteLib
@@ -1,0 +1,276 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5e6fedc2472449cead18ef23b5cb30d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.2D.Animation.Runtime::UnityEngine.U2D.Animation.SpriteLibrarySourceAsset
+  m_Library:
+  - m_Name: Idle
+    m_Hash: 1008081451
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_0
+      m_Hash: 500319545
+      m_Sprite: {fileID: 1230607505878603423, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1230607505878603423, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    - m_Name: Cow_01_1
+      m_Hash: 718632367
+      m_Sprite: {fileID: 2711773049610822139, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2711773049610822139, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleUp
+    m_Hash: 486716119
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_4
+      m_Hash: 448758048
+      m_Sprite: {fileID: 2909058430627721802, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2909058430627721802, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    - m_Name: Cow_01_5
+      m_Hash: 767078838
+      m_Sprite: {fileID: 9085580282719985758, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 9085580282719985758, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleDown
+    m_Hash: 526694748
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_2
+      m_Hash: 870065173
+      m_Sprite: {fileID: -2762471345777184818, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2762471345777184818, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    - m_Name: Cow_01_3
+      m_Hash: 81466499
+      m_Sprite: {fileID: 5503372250001963, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5503372250001963, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: Walk
+    m_Hash: 765711723
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_6
+      m_Hash: 884072460
+      m_Sprite: {fileID: 358055405466121004, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 358055405466121004, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    - m_Name: Cow_01_7
+      m_Hash: 62312602
+      m_Sprite: {fileID: 3791647588706499158, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3791647588706499158, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    - m_Name: Cow_01_8
+      m_Hash: 319409419
+      m_Sprite: {fileID: -4409814772660141188, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4409814772660141188, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    - m_Name: Cow_01_9
+      m_Hash: 604962205
+      m_Sprite: {fileID: -3784558025497551342, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3784558025497551342, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    - m_Name: Cow_01_10
+      m_Hash: 840479789
+      m_Sprite: {fileID: -5584627511280663579, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5584627511280663579, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    - m_Name: Cow_01_11
+      m_Hash: 85951675
+      m_Sprite: {fileID: -6337265926884597855, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6337265926884597855, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    - m_Name: Cow_01_12
+      m_Hash: 471258369
+      m_Sprite: {fileID: -5217847306844716016, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5217847306844716016, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    - m_Name: Cow_01_13
+      m_Hash: 722593175
+      m_Sprite: {fileID: -3464642493511730488, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3464642493511730488, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkUp
+    m_Hash: 648049478
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_22
+      m_Hash: 926648002
+      m_Sprite: {fileID: -3166079520617247710, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3166079520617247710, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    - m_Name: Cow_01_23
+      m_Hash: 3978836
+      m_Sprite: {fileID: 5298653491398159290, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5298653491398159290, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    - m_Name: Cow_01_24
+      m_Hash: 509092855
+      m_Sprite: {fileID: -2310685845093296028, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2310685845093296028, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    - m_Name: Cow_01_25
+      m_Hash: 694096737
+      m_Sprite: {fileID: -8107382766328590620, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8107382766328590620, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    - m_Name: Cow_01_26
+      m_Hash: 810959579
+      m_Sprite: {fileID: 6831865333736859705, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6831865333736859705, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    - m_Name: Cow_01_27
+      m_Hash: 122778189
+      m_Sprite: {fileID: 751566331350574889, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 751566331350574889, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    - m_Name: Cow_01_28
+      m_Hash: 401502172
+      m_Sprite: {fileID: -6848173015213388740, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6848173015213388740, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    - m_Name: Cow_01_29
+      m_Hash: 552165194
+      m_Sprite: {fileID: 5122810230947607563, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5122810230947607563, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkDown
+    m_Hash: 459082627
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_14
+      m_Hash: 896888884
+      m_Sprite: {fileID: -1564432479500703841, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1564432479500703841, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    - m_Name: Cow_01_15
+      m_Hash: 41042082
+      m_Sprite: {fileID: -5883664696849148045, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5883664696849148045, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    - m_Name: Cow_01_16
+      m_Hash: 461050136
+      m_Sprite: {fileID: 5187316792047121406, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5187316792047121406, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    - m_Name: Cow_01_17
+      m_Hash: 746332558
+      m_Sprite: {fileID: 4995125785674733903, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4995125785674733903, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    - m_Name: Cow_01_18
+      m_Hash: 1019427871
+      m_Sprite: {fileID: 5261293180029021015, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5261293180029021015, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    - m_Name: Cow_01_19
+      m_Hash: 197397641
+      m_Sprite: {fileID: 1348968065064695812, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1348968065064695812, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    - m_Name: Cow_01_20
+      m_Hash: 422963182
+      m_Sprite: {fileID: 6957401017780565054, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6957401017780565054, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    - m_Name: Cow_01_21
+      m_Hash: 775083896
+      m_Sprite: {fileID: -5165823064575494001, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5165823064575494001, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Attack
+    m_Hash: 7088141
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_30
+      m_Hash: 3069615
+      m_Sprite: {fileID: -720481936279834643, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -720481936279834643, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    - m_Name: Cow_01_31
+      m_Hash: 925492793
+      m_Sprite: {fileID: -1179745271689975081, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1179745271689975081, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    - m_Name: Cow_01_32
+      m_Hash: 773896067
+      m_Sprite: {fileID: 2643290305515390745, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2643290305515390745, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    - m_Name: Cow_01_33
+      m_Hash: 422020885
+      m_Sprite: {fileID: 7147087478460141301, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7147087478460141301, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    - m_Name: Cow_01_34
+      m_Hash: 121836214
+      m_Sprite: {fileID: 3343896972386937167, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3343896972386937167, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    - m_Name: Cow_01_35
+      m_Hash: 809771552
+      m_Sprite: {fileID: 296588404110421261, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 296588404110421261, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    - m_Name: Cow_01_36
+      m_Hash: 692941722
+      m_Sprite: {fileID: -8438987585756777117, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8438987585756777117, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    - m_Name: Cow_01_37
+      m_Hash: 508183308
+      m_Sprite: {fileID: -8116532663002324287, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8116532663002324287, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Die
+    m_Hash: 20298039
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_70
+      m_Hash: 608310187
+      m_Sprite: {fileID: 2129401767, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2129401767, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    - m_Name: Cow_01_71
+      m_Hash: 323298109
+      m_Sprite: {fileID: 349964809, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 349964809, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    - m_Name: Cow_01_72
+      m_Hash: 172782215
+      m_Sprite: {fileID: -1270501175, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1270501175, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    - m_Name: Cow_01_73
+      m_Hash: 1028342289
+      m_Sprite: {fileID: 1214058861, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1214058861, guid: d304ce006e24c2042b8c24f8d8ee0fc2, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 4
+  m_PrimaryLibraryGUID: 
+  m_ModificationHash: 638924974477017144
+  m_Version: 1

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Cow/Cow_03.spriteLib.meta
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Cow/Cow_03.spriteLib.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 701f5cc1a5794bea96b0de7a97eb6709
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 11500000, guid: db2778f6d440c47ddacff25997d7c062, type: 3}

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Cow/Cow_04.spriteLib
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Cow/Cow_04.spriteLib
@@ -1,0 +1,276 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5e6fedc2472449cead18ef23b5cb30d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.2D.Animation.Runtime::UnityEngine.U2D.Animation.SpriteLibrarySourceAsset
+  m_Library:
+  - m_Name: Idle
+    m_Hash: 1008081451
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_0
+      m_Hash: 500319545
+      m_Sprite: {fileID: -1560671891095415890, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1560671891095415890, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    - m_Name: Cow_01_1
+      m_Hash: 718632367
+      m_Sprite: {fileID: 7580775203408093867, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7580775203408093867, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleUp
+    m_Hash: 486716119
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_4
+      m_Hash: 448758048
+      m_Sprite: {fileID: -1910040738669634051, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1910040738669634051, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    - m_Name: Cow_01_5
+      m_Hash: 767078838
+      m_Sprite: {fileID: -6930128623924019817, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6930128623924019817, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleDown
+    m_Hash: 526694748
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_2
+      m_Hash: 870065173
+      m_Sprite: {fileID: 6134866864102996329, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6134866864102996329, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    - m_Name: Cow_01_3
+      m_Hash: 81466499
+      m_Sprite: {fileID: 3458112002600675128, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3458112002600675128, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: Walk
+    m_Hash: 765711723
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_6
+      m_Hash: 884072460
+      m_Sprite: {fileID: -4438791407414956561, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4438791407414956561, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    - m_Name: Cow_01_7
+      m_Hash: 62312602
+      m_Sprite: {fileID: -257743011123264925, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -257743011123264925, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    - m_Name: Cow_01_8
+      m_Hash: 319409419
+      m_Sprite: {fileID: 5920736482572166689, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5920736482572166689, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    - m_Name: Cow_01_9
+      m_Hash: 604962205
+      m_Sprite: {fileID: 5587568373909929354, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5587568373909929354, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    - m_Name: Cow_01_10
+      m_Hash: 840479789
+      m_Sprite: {fileID: -6442287728673579535, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6442287728673579535, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    - m_Name: Cow_01_11
+      m_Hash: 85951675
+      m_Sprite: {fileID: -1569232978519444727, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1569232978519444727, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    - m_Name: Cow_01_12
+      m_Hash: 471258369
+      m_Sprite: {fileID: -95755374431101864, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -95755374431101864, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    - m_Name: Cow_01_13
+      m_Hash: 722593175
+      m_Sprite: {fileID: 4989283789775996568, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4989283789775996568, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkUp
+    m_Hash: 648049478
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_22
+      m_Hash: 926648002
+      m_Sprite: {fileID: 1822554541254791143, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1822554541254791143, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    - m_Name: Cow_01_23
+      m_Hash: 3978836
+      m_Sprite: {fileID: -5278645346814481805, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5278645346814481805, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    - m_Name: Cow_01_24
+      m_Hash: 509092855
+      m_Sprite: {fileID: -4195752229568019355, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4195752229568019355, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    - m_Name: Cow_01_25
+      m_Hash: 694096737
+      m_Sprite: {fileID: -5142340163058630316, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5142340163058630316, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    - m_Name: Cow_01_26
+      m_Hash: 810959579
+      m_Sprite: {fileID: 1005767927146549567, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1005767927146549567, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    - m_Name: Cow_01_27
+      m_Hash: 122778189
+      m_Sprite: {fileID: -1419717308175189659, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1419717308175189659, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    - m_Name: Cow_01_28
+      m_Hash: 401502172
+      m_Sprite: {fileID: 756072658640943216, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 756072658640943216, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    - m_Name: Cow_01_29
+      m_Hash: 552165194
+      m_Sprite: {fileID: -4266998614158835886, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4266998614158835886, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkDown
+    m_Hash: 459082627
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_14
+      m_Hash: 896888884
+      m_Sprite: {fileID: 8712074818598400006, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8712074818598400006, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    - m_Name: Cow_01_15
+      m_Hash: 41042082
+      m_Sprite: {fileID: 3267810344532697745, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3267810344532697745, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    - m_Name: Cow_01_16
+      m_Hash: 461050136
+      m_Sprite: {fileID: 2882444101895040277, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2882444101895040277, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    - m_Name: Cow_01_17
+      m_Hash: 746332558
+      m_Sprite: {fileID: -5742311080256219460, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5742311080256219460, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    - m_Name: Cow_01_18
+      m_Hash: 1019427871
+      m_Sprite: {fileID: 1559974615741561907, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1559974615741561907, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    - m_Name: Cow_01_19
+      m_Hash: 197397641
+      m_Sprite: {fileID: -4310937989925913307, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4310937989925913307, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    - m_Name: Cow_01_20
+      m_Hash: 422963182
+      m_Sprite: {fileID: 8996452278597716809, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8996452278597716809, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    - m_Name: Cow_01_21
+      m_Hash: 775083896
+      m_Sprite: {fileID: -627019992394940151, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -627019992394940151, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Attack
+    m_Hash: 7088141
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_30
+      m_Hash: 3069615
+      m_Sprite: {fileID: -7261974508232844009, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7261974508232844009, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    - m_Name: Cow_01_31
+      m_Hash: 925492793
+      m_Sprite: {fileID: -617693763055771565, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -617693763055771565, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    - m_Name: Cow_01_32
+      m_Hash: 773896067
+      m_Sprite: {fileID: 7946571764568717766, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7946571764568717766, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    - m_Name: Cow_01_33
+      m_Hash: 422020885
+      m_Sprite: {fileID: -3920309166348221289, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3920309166348221289, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    - m_Name: Cow_01_34
+      m_Hash: 121836214
+      m_Sprite: {fileID: -8223556018945164501, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8223556018945164501, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    - m_Name: Cow_01_35
+      m_Hash: 809771552
+      m_Sprite: {fileID: 5939059525622156605, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5939059525622156605, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    - m_Name: Cow_01_36
+      m_Hash: 692941722
+      m_Sprite: {fileID: -3953320930157125184, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3953320930157125184, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    - m_Name: Cow_01_37
+      m_Hash: 508183308
+      m_Sprite: {fileID: -6513490774736326241, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6513490774736326241, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Die
+    m_Hash: 20298039
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_70
+      m_Hash: 608310187
+      m_Sprite: {fileID: 2129401767, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2129401767, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    - m_Name: Cow_01_71
+      m_Hash: 323298109
+      m_Sprite: {fileID: 349964809, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 349964809, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    - m_Name: Cow_01_72
+      m_Hash: 172782215
+      m_Sprite: {fileID: -1270501175, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1270501175, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    - m_Name: Cow_01_73
+      m_Hash: 1028342289
+      m_Sprite: {fileID: 1214058861, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1214058861, guid: e5beb8ab963b70d44a2dc9234fe41575, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 4
+  m_PrimaryLibraryGUID: 
+  m_ModificationHash: 638924974477017144
+  m_Version: 1

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Cow/Cow_04.spriteLib.meta
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Cow/Cow_04.spriteLib.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 3f049708068a4815b6eabbdb68e50f09
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 11500000, guid: db2778f6d440c47ddacff25997d7c062, type: 3}

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Cow/Cow_05.spriteLib
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Cow/Cow_05.spriteLib
@@ -1,0 +1,276 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5e6fedc2472449cead18ef23b5cb30d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.2D.Animation.Runtime::UnityEngine.U2D.Animation.SpriteLibrarySourceAsset
+  m_Library:
+  - m_Name: Idle
+    m_Hash: 1008081451
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_0
+      m_Hash: 500319545
+      m_Sprite: {fileID: -7938655577653876530, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7938655577653876530, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    - m_Name: Cow_01_1
+      m_Hash: 718632367
+      m_Sprite: {fileID: 8871360274681906931, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8871360274681906931, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleUp
+    m_Hash: 486716119
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_4
+      m_Hash: 448758048
+      m_Sprite: {fileID: -1993444523561526972, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1993444523561526972, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    - m_Name: Cow_01_5
+      m_Hash: 767078838
+      m_Sprite: {fileID: 5981323128412304267, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5981323128412304267, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleDown
+    m_Hash: 526694748
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_2
+      m_Hash: 870065173
+      m_Sprite: {fileID: -1189685756196560593, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1189685756196560593, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    - m_Name: Cow_01_3
+      m_Hash: 81466499
+      m_Sprite: {fileID: -5232429445964218996, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5232429445964218996, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: Walk
+    m_Hash: 765711723
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_6
+      m_Hash: 884072460
+      m_Sprite: {fileID: -1824965390403425887, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1824965390403425887, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    - m_Name: Cow_01_7
+      m_Hash: 62312602
+      m_Sprite: {fileID: -363185164777377695, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -363185164777377695, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    - m_Name: Cow_01_8
+      m_Hash: 319409419
+      m_Sprite: {fileID: -4797095179740939297, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4797095179740939297, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    - m_Name: Cow_01_9
+      m_Hash: 604962205
+      m_Sprite: {fileID: -6025777459405253798, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6025777459405253798, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    - m_Name: Cow_01_10
+      m_Hash: 840479789
+      m_Sprite: {fileID: 8239039369741320804, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8239039369741320804, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    - m_Name: Cow_01_11
+      m_Hash: 85951675
+      m_Sprite: {fileID: 561636144823573671, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 561636144823573671, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    - m_Name: Cow_01_12
+      m_Hash: 471258369
+      m_Sprite: {fileID: -6063187970296412543, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6063187970296412543, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    - m_Name: Cow_01_13
+      m_Hash: 722593175
+      m_Sprite: {fileID: -664125429743395693, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -664125429743395693, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkUp
+    m_Hash: 648049478
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_22
+      m_Hash: 926648002
+      m_Sprite: {fileID: 9077529938326693588, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 9077529938326693588, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    - m_Name: Cow_01_23
+      m_Hash: 3978836
+      m_Sprite: {fileID: -4887958054151772160, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4887958054151772160, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    - m_Name: Cow_01_24
+      m_Hash: 509092855
+      m_Sprite: {fileID: -1145667821335874456, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1145667821335874456, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    - m_Name: Cow_01_25
+      m_Hash: 694096737
+      m_Sprite: {fileID: -1454390421551974839, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1454390421551974839, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    - m_Name: Cow_01_26
+      m_Hash: 810959579
+      m_Sprite: {fileID: -9045093504740369734, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -9045093504740369734, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    - m_Name: Cow_01_27
+      m_Hash: 122778189
+      m_Sprite: {fileID: -3922337102062220403, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3922337102062220403, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    - m_Name: Cow_01_28
+      m_Hash: 401502172
+      m_Sprite: {fileID: 1180860552094342804, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1180860552094342804, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    - m_Name: Cow_01_29
+      m_Hash: 552165194
+      m_Sprite: {fileID: 3169853550178406776, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3169853550178406776, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkDown
+    m_Hash: 459082627
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_14
+      m_Hash: 896888884
+      m_Sprite: {fileID: 4789701441699405338, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4789701441699405338, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    - m_Name: Cow_01_15
+      m_Hash: 41042082
+      m_Sprite: {fileID: 1287112284238193124, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1287112284238193124, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    - m_Name: Cow_01_16
+      m_Hash: 461050136
+      m_Sprite: {fileID: 2766831689958721922, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2766831689958721922, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    - m_Name: Cow_01_17
+      m_Hash: 746332558
+      m_Sprite: {fileID: 1339895029662829817, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1339895029662829817, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    - m_Name: Cow_01_18
+      m_Hash: 1019427871
+      m_Sprite: {fileID: 3629275488079789981, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3629275488079789981, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    - m_Name: Cow_01_19
+      m_Hash: 197397641
+      m_Sprite: {fileID: -6954087310190623111, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6954087310190623111, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    - m_Name: Cow_01_20
+      m_Hash: 422963182
+      m_Sprite: {fileID: 6117453611522382627, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6117453611522382627, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    - m_Name: Cow_01_21
+      m_Hash: 775083896
+      m_Sprite: {fileID: -4506061694247305804, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4506061694247305804, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Attack
+    m_Hash: 7088141
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_30
+      m_Hash: 3069615
+      m_Sprite: {fileID: -4508001725641680268, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4508001725641680268, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    - m_Name: Cow_01_31
+      m_Hash: 925492793
+      m_Sprite: {fileID: -7579147402994734172, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7579147402994734172, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    - m_Name: Cow_01_32
+      m_Hash: 773896067
+      m_Sprite: {fileID: 8768235129168726075, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8768235129168726075, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    - m_Name: Cow_01_33
+      m_Hash: 422020885
+      m_Sprite: {fileID: -7776960774043537184, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7776960774043537184, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    - m_Name: Cow_01_34
+      m_Hash: 121836214
+      m_Sprite: {fileID: 6021090438895579860, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6021090438895579860, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    - m_Name: Cow_01_35
+      m_Hash: 809771552
+      m_Sprite: {fileID: 2383543406951482217, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2383543406951482217, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    - m_Name: Cow_01_36
+      m_Hash: 692941722
+      m_Sprite: {fileID: -5050730069869357949, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5050730069869357949, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    - m_Name: Cow_01_37
+      m_Hash: 508183308
+      m_Sprite: {fileID: -4297922758262787974, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4297922758262787974, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Die
+    m_Hash: 20298039
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_70
+      m_Hash: 608310187
+      m_Sprite: {fileID: 2129401767, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2129401767, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    - m_Name: Cow_01_71
+      m_Hash: 323298109
+      m_Sprite: {fileID: 349964809, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 349964809, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    - m_Name: Cow_01_72
+      m_Hash: 172782215
+      m_Sprite: {fileID: -1270501175, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1270501175, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    - m_Name: Cow_01_73
+      m_Hash: 1028342289
+      m_Sprite: {fileID: 1214058861, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1214058861, guid: 78c4e3330c1f1eb4b9cb5e65b5088617, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 4
+  m_PrimaryLibraryGUID: 
+  m_ModificationHash: 638924974477017144
+  m_Version: 1

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Cow/Cow_05.spriteLib.meta
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Cow/Cow_05.spriteLib.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: b06320036fc6427fbbf321f6fb6fd5d8
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 11500000, guid: db2778f6d440c47ddacff25997d7c062, type: 3}

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Cow/Cow_06.spriteLib
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Cow/Cow_06.spriteLib
@@ -1,0 +1,276 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5e6fedc2472449cead18ef23b5cb30d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.2D.Animation.Runtime::UnityEngine.U2D.Animation.SpriteLibrarySourceAsset
+  m_Library:
+  - m_Name: Idle
+    m_Hash: 1008081451
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_0
+      m_Hash: 500319545
+      m_Sprite: {fileID: 1526876446634462949, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1526876446634462949, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    - m_Name: Cow_01_1
+      m_Hash: 718632367
+      m_Sprite: {fileID: -378782251105497526, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -378782251105497526, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleUp
+    m_Hash: 486716119
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_4
+      m_Hash: 448758048
+      m_Sprite: {fileID: 1463483306301014568, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1463483306301014568, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    - m_Name: Cow_01_5
+      m_Hash: 767078838
+      m_Sprite: {fileID: 3574966703613763824, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3574966703613763824, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleDown
+    m_Hash: 526694748
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_2
+      m_Hash: 870065173
+      m_Sprite: {fileID: 8947541871487484778, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8947541871487484778, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    - m_Name: Cow_01_3
+      m_Hash: 81466499
+      m_Sprite: {fileID: 8139243834197699428, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8139243834197699428, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: Walk
+    m_Hash: 765711723
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_6
+      m_Hash: 884072460
+      m_Sprite: {fileID: -8520139494203108380, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8520139494203108380, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    - m_Name: Cow_01_7
+      m_Hash: 62312602
+      m_Sprite: {fileID: -2734314185403539393, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2734314185403539393, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    - m_Name: Cow_01_8
+      m_Hash: 319409419
+      m_Sprite: {fileID: -8311620481994407451, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8311620481994407451, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    - m_Name: Cow_01_9
+      m_Hash: 604962205
+      m_Sprite: {fileID: 2219979518438811221, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2219979518438811221, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    - m_Name: Cow_01_10
+      m_Hash: 840479789
+      m_Sprite: {fileID: -5506161187667559594, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5506161187667559594, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    - m_Name: Cow_01_11
+      m_Hash: 85951675
+      m_Sprite: {fileID: -4686247982344490232, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4686247982344490232, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    - m_Name: Cow_01_12
+      m_Hash: 471258369
+      m_Sprite: {fileID: -6539808287549008717, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6539808287549008717, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    - m_Name: Cow_01_13
+      m_Hash: 722593175
+      m_Sprite: {fileID: 5928993735836332134, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5928993735836332134, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkUp
+    m_Hash: 648049478
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_22
+      m_Hash: 926648002
+      m_Sprite: {fileID: -771442383239714631, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -771442383239714631, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    - m_Name: Cow_01_23
+      m_Hash: 3978836
+      m_Sprite: {fileID: 3903035200646602593, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3903035200646602593, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    - m_Name: Cow_01_24
+      m_Hash: 509092855
+      m_Sprite: {fileID: 2888315570342576900, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2888315570342576900, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    - m_Name: Cow_01_25
+      m_Hash: 694096737
+      m_Sprite: {fileID: -6342649624365919070, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6342649624365919070, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    - m_Name: Cow_01_26
+      m_Hash: 810959579
+      m_Sprite: {fileID: 4420331285902952001, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4420331285902952001, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    - m_Name: Cow_01_27
+      m_Hash: 122778189
+      m_Sprite: {fileID: 9129891730065598149, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 9129891730065598149, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    - m_Name: Cow_01_28
+      m_Hash: 401502172
+      m_Sprite: {fileID: -6032153836929797810, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6032153836929797810, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    - m_Name: Cow_01_29
+      m_Hash: 552165194
+      m_Sprite: {fileID: -3974914742733307654, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3974914742733307654, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkDown
+    m_Hash: 459082627
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_14
+      m_Hash: 896888884
+      m_Sprite: {fileID: 1379611589759388356, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1379611589759388356, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    - m_Name: Cow_01_15
+      m_Hash: 41042082
+      m_Sprite: {fileID: -669030319598868014, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -669030319598868014, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    - m_Name: Cow_01_16
+      m_Hash: 461050136
+      m_Sprite: {fileID: 8441309571484838992, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8441309571484838992, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    - m_Name: Cow_01_17
+      m_Hash: 746332558
+      m_Sprite: {fileID: 7666965450980675262, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7666965450980675262, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    - m_Name: Cow_01_18
+      m_Hash: 1019427871
+      m_Sprite: {fileID: -647988514411999271, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -647988514411999271, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    - m_Name: Cow_01_19
+      m_Hash: 197397641
+      m_Sprite: {fileID: -8584889834600453833, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8584889834600453833, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    - m_Name: Cow_01_20
+      m_Hash: 422963182
+      m_Sprite: {fileID: 9022425753530715032, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 9022425753530715032, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    - m_Name: Cow_01_21
+      m_Hash: 775083896
+      m_Sprite: {fileID: -8735614493694142607, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8735614493694142607, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Attack
+    m_Hash: 7088141
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_30
+      m_Hash: 3069615
+      m_Sprite: {fileID: 134450615114954948, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 134450615114954948, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    - m_Name: Cow_01_31
+      m_Hash: 925492793
+      m_Sprite: {fileID: -3424365827917798792, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3424365827917798792, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    - m_Name: Cow_01_32
+      m_Hash: 773896067
+      m_Sprite: {fileID: 4185745831793711087, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4185745831793711087, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    - m_Name: Cow_01_33
+      m_Hash: 422020885
+      m_Sprite: {fileID: 7084877071574508751, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7084877071574508751, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    - m_Name: Cow_01_34
+      m_Hash: 121836214
+      m_Sprite: {fileID: -7426070974761523131, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7426070974761523131, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    - m_Name: Cow_01_35
+      m_Hash: 809771552
+      m_Sprite: {fileID: -3909490351443080185, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3909490351443080185, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    - m_Name: Cow_01_36
+      m_Hash: 692941722
+      m_Sprite: {fileID: -425358725884075315, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -425358725884075315, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    - m_Name: Cow_01_37
+      m_Hash: 508183308
+      m_Sprite: {fileID: 6738505416730662270, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6738505416730662270, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Die
+    m_Hash: 20298039
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_70
+      m_Hash: 608310187
+      m_Sprite: {fileID: 2129401767, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2129401767, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    - m_Name: Cow_01_71
+      m_Hash: 323298109
+      m_Sprite: {fileID: 349964809, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 349964809, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    - m_Name: Cow_01_72
+      m_Hash: 172782215
+      m_Sprite: {fileID: -1270501175, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1270501175, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    - m_Name: Cow_01_73
+      m_Hash: 1028342289
+      m_Sprite: {fileID: 1214058861, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1214058861, guid: 72afd3dee5ece1046825c7415b95b90d, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 4
+  m_PrimaryLibraryGUID: 
+  m_ModificationHash: 638924974477017144
+  m_Version: 1

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Cow/Cow_06.spriteLib.meta
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Cow/Cow_06.spriteLib.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: de9972444eab4f4790f6ee39cee60c65
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 11500000, guid: db2778f6d440c47ddacff25997d7c062, type: 3}

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Cow/Cow_07.spriteLib
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Cow/Cow_07.spriteLib
@@ -1,0 +1,276 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5e6fedc2472449cead18ef23b5cb30d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.2D.Animation.Runtime::UnityEngine.U2D.Animation.SpriteLibrarySourceAsset
+  m_Library:
+  - m_Name: Idle
+    m_Hash: 1008081451
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_0
+      m_Hash: 500319545
+      m_Sprite: {fileID: -7413471138981615691, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7413471138981615691, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    - m_Name: Cow_01_1
+      m_Hash: 718632367
+      m_Sprite: {fileID: 8368837562293469461, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8368837562293469461, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleUp
+    m_Hash: 486716119
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_4
+      m_Hash: 448758048
+      m_Sprite: {fileID: -1772297693284715893, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1772297693284715893, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    - m_Name: Cow_01_5
+      m_Hash: 767078838
+      m_Sprite: {fileID: 7291205482760692473, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7291205482760692473, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleDown
+    m_Hash: 526694748
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_2
+      m_Hash: 870065173
+      m_Sprite: {fileID: 6045007163951313069, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6045007163951313069, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    - m_Name: Cow_01_3
+      m_Hash: 81466499
+      m_Sprite: {fileID: -6103065534314306229, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6103065534314306229, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: Walk
+    m_Hash: 765711723
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_6
+      m_Hash: 884072460
+      m_Sprite: {fileID: -7303494095014174576, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7303494095014174576, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    - m_Name: Cow_01_7
+      m_Hash: 62312602
+      m_Sprite: {fileID: -782701783542623808, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -782701783542623808, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    - m_Name: Cow_01_8
+      m_Hash: 319409419
+      m_Sprite: {fileID: 6368153478283322786, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6368153478283322786, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    - m_Name: Cow_01_9
+      m_Hash: 604962205
+      m_Sprite: {fileID: 3364885750205265704, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3364885750205265704, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    - m_Name: Cow_01_10
+      m_Hash: 840479789
+      m_Sprite: {fileID: -7662249947513692171, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7662249947513692171, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    - m_Name: Cow_01_11
+      m_Hash: 85951675
+      m_Sprite: {fileID: 3472245739301322766, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3472245739301322766, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    - m_Name: Cow_01_12
+      m_Hash: 471258369
+      m_Sprite: {fileID: 2679188105851048152, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2679188105851048152, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    - m_Name: Cow_01_13
+      m_Hash: 722593175
+      m_Sprite: {fileID: 1356639180139249532, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1356639180139249532, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkUp
+    m_Hash: 648049478
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_22
+      m_Hash: 926648002
+      m_Sprite: {fileID: -6435928226894916208, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6435928226894916208, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    - m_Name: Cow_01_23
+      m_Hash: 3978836
+      m_Sprite: {fileID: -2812179129200860652, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2812179129200860652, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    - m_Name: Cow_01_24
+      m_Hash: 509092855
+      m_Sprite: {fileID: 7957715248771463549, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7957715248771463549, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    - m_Name: Cow_01_25
+      m_Hash: 694096737
+      m_Sprite: {fileID: -6193405654421367398, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6193405654421367398, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    - m_Name: Cow_01_26
+      m_Hash: 810959579
+      m_Sprite: {fileID: -8479881971874914374, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8479881971874914374, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    - m_Name: Cow_01_27
+      m_Hash: 122778189
+      m_Sprite: {fileID: 352038971763397962, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 352038971763397962, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    - m_Name: Cow_01_28
+      m_Hash: 401502172
+      m_Sprite: {fileID: -7942619445706119034, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7942619445706119034, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    - m_Name: Cow_01_29
+      m_Hash: 552165194
+      m_Sprite: {fileID: -1130294535844100882, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1130294535844100882, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkDown
+    m_Hash: 459082627
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_14
+      m_Hash: 896888884
+      m_Sprite: {fileID: 1345042079257475193, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1345042079257475193, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    - m_Name: Cow_01_15
+      m_Hash: 41042082
+      m_Sprite: {fileID: -5008671013394773178, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5008671013394773178, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    - m_Name: Cow_01_16
+      m_Hash: 461050136
+      m_Sprite: {fileID: 2138250271112668599, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2138250271112668599, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    - m_Name: Cow_01_17
+      m_Hash: 746332558
+      m_Sprite: {fileID: -5245106932480513222, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5245106932480513222, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    - m_Name: Cow_01_18
+      m_Hash: 1019427871
+      m_Sprite: {fileID: -789395810748505259, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -789395810748505259, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    - m_Name: Cow_01_19
+      m_Hash: 197397641
+      m_Sprite: {fileID: -5832417886656038282, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5832417886656038282, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    - m_Name: Cow_01_20
+      m_Hash: 422963182
+      m_Sprite: {fileID: 8471973073378657112, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8471973073378657112, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    - m_Name: Cow_01_21
+      m_Hash: 775083896
+      m_Sprite: {fileID: 1351907101493343113, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1351907101493343113, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Attack
+    m_Hash: 7088141
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_30
+      m_Hash: 3069615
+      m_Sprite: {fileID: 8452567451216808822, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8452567451216808822, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    - m_Name: Cow_01_31
+      m_Hash: 925492793
+      m_Sprite: {fileID: -682350992819545484, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -682350992819545484, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    - m_Name: Cow_01_32
+      m_Hash: 773896067
+      m_Sprite: {fileID: 8665088908275342359, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8665088908275342359, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    - m_Name: Cow_01_33
+      m_Hash: 422020885
+      m_Sprite: {fileID: 3505158736507513172, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3505158736507513172, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    - m_Name: Cow_01_34
+      m_Hash: 121836214
+      m_Sprite: {fileID: -8364662380894438181, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8364662380894438181, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    - m_Name: Cow_01_35
+      m_Hash: 809771552
+      m_Sprite: {fileID: -8354012201804101652, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8354012201804101652, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    - m_Name: Cow_01_36
+      m_Hash: 692941722
+      m_Sprite: {fileID: 926334694008353126, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 926334694008353126, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    - m_Name: Cow_01_37
+      m_Hash: 508183308
+      m_Sprite: {fileID: 5784475162627617665, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5784475162627617665, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Die
+    m_Hash: 20298039
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_70
+      m_Hash: 608310187
+      m_Sprite: {fileID: 2129401767, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2129401767, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    - m_Name: Cow_01_71
+      m_Hash: 323298109
+      m_Sprite: {fileID: 349964809, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 349964809, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    - m_Name: Cow_01_72
+      m_Hash: 172782215
+      m_Sprite: {fileID: -1270501175, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1270501175, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    - m_Name: Cow_01_73
+      m_Hash: 1028342289
+      m_Sprite: {fileID: 1214058861, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1214058861, guid: 281256da7a6139f44a0a16fafd888e92, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 4
+  m_PrimaryLibraryGUID: 
+  m_ModificationHash: 638924974477017144
+  m_Version: 1

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Cow/Cow_07.spriteLib.meta
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Cow/Cow_07.spriteLib.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 9fabf34f6a2440258f802f9514daaafb
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 11500000, guid: db2778f6d440c47ddacff25997d7c062, type: 3}

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Cow/Cow_08.spriteLib
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Cow/Cow_08.spriteLib
@@ -1,0 +1,276 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5e6fedc2472449cead18ef23b5cb30d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.2D.Animation.Runtime::UnityEngine.U2D.Animation.SpriteLibrarySourceAsset
+  m_Library:
+  - m_Name: Idle
+    m_Hash: 1008081451
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_0
+      m_Hash: 500319545
+      m_Sprite: {fileID: 3939328757822307470, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3939328757822307470, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    - m_Name: Cow_01_1
+      m_Hash: 718632367
+      m_Sprite: {fileID: 4837466479065651021, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4837466479065651021, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleUp
+    m_Hash: 486716119
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_4
+      m_Hash: 448758048
+      m_Sprite: {fileID: 8195218391938883992, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8195218391938883992, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    - m_Name: Cow_01_5
+      m_Hash: 767078838
+      m_Sprite: {fileID: 3073516024672172884, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3073516024672172884, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleDown
+    m_Hash: 526694748
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_2
+      m_Hash: 870065173
+      m_Sprite: {fileID: 476954601198067777, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 476954601198067777, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    - m_Name: Cow_01_3
+      m_Hash: 81466499
+      m_Sprite: {fileID: -7735639533689841767, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7735639533689841767, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: Walk
+    m_Hash: 765711723
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_6
+      m_Hash: 884072460
+      m_Sprite: {fileID: -5647716559150167450, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5647716559150167450, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    - m_Name: Cow_01_7
+      m_Hash: 62312602
+      m_Sprite: {fileID: -2459027988072517758, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2459027988072517758, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    - m_Name: Cow_01_8
+      m_Hash: 319409419
+      m_Sprite: {fileID: 2774730420853691345, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2774730420853691345, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    - m_Name: Cow_01_9
+      m_Hash: 604962205
+      m_Sprite: {fileID: -1074001408604924525, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1074001408604924525, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    - m_Name: Cow_01_10
+      m_Hash: 840479789
+      m_Sprite: {fileID: 8857845090729047077, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8857845090729047077, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    - m_Name: Cow_01_11
+      m_Hash: 85951675
+      m_Sprite: {fileID: 4486728448428407855, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4486728448428407855, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    - m_Name: Cow_01_12
+      m_Hash: 471258369
+      m_Sprite: {fileID: 1816761741138641508, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1816761741138641508, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    - m_Name: Cow_01_13
+      m_Hash: 722593175
+      m_Sprite: {fileID: -6923249127079322358, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6923249127079322358, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkUp
+    m_Hash: 648049478
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_22
+      m_Hash: 926648002
+      m_Sprite: {fileID: -4423753143740201799, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4423753143740201799, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    - m_Name: Cow_01_23
+      m_Hash: 3978836
+      m_Sprite: {fileID: 3950164624468681025, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3950164624468681025, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    - m_Name: Cow_01_24
+      m_Hash: 509092855
+      m_Sprite: {fileID: 7095829262527380704, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7095829262527380704, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    - m_Name: Cow_01_25
+      m_Hash: 694096737
+      m_Sprite: {fileID: -4999413866914127540, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4999413866914127540, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    - m_Name: Cow_01_26
+      m_Hash: 810959579
+      m_Sprite: {fileID: 3293605517968380482, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3293605517968380482, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    - m_Name: Cow_01_27
+      m_Hash: 122778189
+      m_Sprite: {fileID: -853447343146116052, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -853447343146116052, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    - m_Name: Cow_01_28
+      m_Hash: 401502172
+      m_Sprite: {fileID: -6558030356386428475, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6558030356386428475, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    - m_Name: Cow_01_29
+      m_Hash: 552165194
+      m_Sprite: {fileID: 6654218807727029161, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6654218807727029161, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkDown
+    m_Hash: 459082627
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_14
+      m_Hash: 896888884
+      m_Sprite: {fileID: 471715362628929865, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 471715362628929865, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    - m_Name: Cow_01_15
+      m_Hash: 41042082
+      m_Sprite: {fileID: 8714055217502803835, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8714055217502803835, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    - m_Name: Cow_01_16
+      m_Hash: 461050136
+      m_Sprite: {fileID: 699191053459297651, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 699191053459297651, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    - m_Name: Cow_01_17
+      m_Hash: 746332558
+      m_Sprite: {fileID: -5971733793000493160, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5971733793000493160, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    - m_Name: Cow_01_18
+      m_Hash: 1019427871
+      m_Sprite: {fileID: -6280237492538052128, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6280237492538052128, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    - m_Name: Cow_01_19
+      m_Hash: 197397641
+      m_Sprite: {fileID: 4047350002336349696, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4047350002336349696, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    - m_Name: Cow_01_20
+      m_Hash: 422963182
+      m_Sprite: {fileID: -5328399594477325360, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5328399594477325360, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    - m_Name: Cow_01_21
+      m_Hash: 775083896
+      m_Sprite: {fileID: 6504898743924485802, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6504898743924485802, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Attack
+    m_Hash: 7088141
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_30
+      m_Hash: 3069615
+      m_Sprite: {fileID: 6349044081772920274, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6349044081772920274, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    - m_Name: Cow_01_31
+      m_Hash: 925492793
+      m_Sprite: {fileID: -143898397440289561, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -143898397440289561, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    - m_Name: Cow_01_32
+      m_Hash: 773896067
+      m_Sprite: {fileID: 7387209163152848140, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7387209163152848140, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    - m_Name: Cow_01_33
+      m_Hash: 422020885
+      m_Sprite: {fileID: -5185378581520057229, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5185378581520057229, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    - m_Name: Cow_01_34
+      m_Hash: 121836214
+      m_Sprite: {fileID: -5394929995722191822, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5394929995722191822, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    - m_Name: Cow_01_35
+      m_Hash: 809771552
+      m_Sprite: {fileID: 3019485479570933147, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3019485479570933147, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    - m_Name: Cow_01_36
+      m_Hash: 692941722
+      m_Sprite: {fileID: -562314179711098846, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -562314179711098846, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    - m_Name: Cow_01_37
+      m_Hash: 508183308
+      m_Sprite: {fileID: -6402903460115353281, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6402903460115353281, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Die
+    m_Hash: 20298039
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_70
+      m_Hash: 608310187
+      m_Sprite: {fileID: 2129401767, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2129401767, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    - m_Name: Cow_01_71
+      m_Hash: 323298109
+      m_Sprite: {fileID: 349964809, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 349964809, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    - m_Name: Cow_01_72
+      m_Hash: 172782215
+      m_Sprite: {fileID: -1270501175, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1270501175, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    - m_Name: Cow_01_73
+      m_Hash: 1028342289
+      m_Sprite: {fileID: 1214058861, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1214058861, guid: afa07ae617c0e5549bf421bd8cf357a0, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 4
+  m_PrimaryLibraryGUID: 
+  m_ModificationHash: 638924974477017144
+  m_Version: 1

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Cow/Cow_08.spriteLib.meta
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Cow/Cow_08.spriteLib.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 6b837bfbede44d78b65d99402fd5b4e1
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 11500000, guid: db2778f6d440c47ddacff25997d7c062, type: 3}

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Cow/Cow_09.spriteLib
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Cow/Cow_09.spriteLib
@@ -1,0 +1,276 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5e6fedc2472449cead18ef23b5cb30d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.2D.Animation.Runtime::UnityEngine.U2D.Animation.SpriteLibrarySourceAsset
+  m_Library:
+  - m_Name: Idle
+    m_Hash: 1008081451
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_0
+      m_Hash: 500319545
+      m_Sprite: {fileID: -6748476082922600888, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6748476082922600888, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    - m_Name: Cow_01_1
+      m_Hash: 718632367
+      m_Sprite: {fileID: -2114692613086811076, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2114692613086811076, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleUp
+    m_Hash: 486716119
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_4
+      m_Hash: 448758048
+      m_Sprite: {fileID: -3187269913645161512, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3187269913645161512, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    - m_Name: Cow_01_5
+      m_Hash: 767078838
+      m_Sprite: {fileID: -4983187680080552739, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4983187680080552739, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleDown
+    m_Hash: 526694748
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_2
+      m_Hash: 870065173
+      m_Sprite: {fileID: 3809540663379469168, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3809540663379469168, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    - m_Name: Cow_01_3
+      m_Hash: 81466499
+      m_Sprite: {fileID: -1620598615570519598, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1620598615570519598, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: Walk
+    m_Hash: 765711723
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_6
+      m_Hash: 884072460
+      m_Sprite: {fileID: 7642919269714480540, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7642919269714480540, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    - m_Name: Cow_01_7
+      m_Hash: 62312602
+      m_Sprite: {fileID: -3035502816339961246, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3035502816339961246, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    - m_Name: Cow_01_8
+      m_Hash: 319409419
+      m_Sprite: {fileID: -6232303192810943380, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6232303192810943380, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    - m_Name: Cow_01_9
+      m_Hash: 604962205
+      m_Sprite: {fileID: -2728376898750274470, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2728376898750274470, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    - m_Name: Cow_01_10
+      m_Hash: 840479789
+      m_Sprite: {fileID: -6009688451312154854, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6009688451312154854, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    - m_Name: Cow_01_11
+      m_Hash: 85951675
+      m_Sprite: {fileID: 7362216192038213135, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7362216192038213135, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    - m_Name: Cow_01_12
+      m_Hash: 471258369
+      m_Sprite: {fileID: -2136635927754635002, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2136635927754635002, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    - m_Name: Cow_01_13
+      m_Hash: 722593175
+      m_Sprite: {fileID: -466993883075753279, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -466993883075753279, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkUp
+    m_Hash: 648049478
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_22
+      m_Hash: 926648002
+      m_Sprite: {fileID: 6870511681034988236, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6870511681034988236, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    - m_Name: Cow_01_23
+      m_Hash: 3978836
+      m_Sprite: {fileID: -7418474798840741895, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7418474798840741895, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    - m_Name: Cow_01_24
+      m_Hash: 509092855
+      m_Sprite: {fileID: -4335054495109898991, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4335054495109898991, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    - m_Name: Cow_01_25
+      m_Hash: 694096737
+      m_Sprite: {fileID: -8498899954937456252, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8498899954937456252, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    - m_Name: Cow_01_26
+      m_Hash: 810959579
+      m_Sprite: {fileID: -3120163782929397671, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3120163782929397671, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    - m_Name: Cow_01_27
+      m_Hash: 122778189
+      m_Sprite: {fileID: -812168218251536435, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -812168218251536435, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    - m_Name: Cow_01_28
+      m_Hash: 401502172
+      m_Sprite: {fileID: 7736399390178625930, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7736399390178625930, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    - m_Name: Cow_01_29
+      m_Hash: 552165194
+      m_Sprite: {fileID: -7603600178094739263, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7603600178094739263, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkDown
+    m_Hash: 459082627
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_14
+      m_Hash: 896888884
+      m_Sprite: {fileID: -7883460864818725966, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7883460864818725966, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    - m_Name: Cow_01_15
+      m_Hash: 41042082
+      m_Sprite: {fileID: -1603341736239928282, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1603341736239928282, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    - m_Name: Cow_01_16
+      m_Hash: 461050136
+      m_Sprite: {fileID: -6360615988789950560, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6360615988789950560, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    - m_Name: Cow_01_17
+      m_Hash: 746332558
+      m_Sprite: {fileID: 5210922330213593720, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5210922330213593720, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    - m_Name: Cow_01_18
+      m_Hash: 1019427871
+      m_Sprite: {fileID: -5998857117856402373, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5998857117856402373, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    - m_Name: Cow_01_19
+      m_Hash: 197397641
+      m_Sprite: {fileID: -7011220783831571268, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7011220783831571268, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    - m_Name: Cow_01_20
+      m_Hash: 422963182
+      m_Sprite: {fileID: -6644757924065694745, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6644757924065694745, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    - m_Name: Cow_01_21
+      m_Hash: 775083896
+      m_Sprite: {fileID: 6272442259581742421, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6272442259581742421, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Attack
+    m_Hash: 7088141
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_30
+      m_Hash: 3069615
+      m_Sprite: {fileID: 4476028075116237302, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4476028075116237302, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    - m_Name: Cow_01_31
+      m_Hash: 925492793
+      m_Sprite: {fileID: 311576906522210585, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 311576906522210585, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    - m_Name: Cow_01_32
+      m_Hash: 773896067
+      m_Sprite: {fileID: -7950337730190232984, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7950337730190232984, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    - m_Name: Cow_01_33
+      m_Hash: 422020885
+      m_Sprite: {fileID: 6856462308448029642, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6856462308448029642, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    - m_Name: Cow_01_34
+      m_Hash: 121836214
+      m_Sprite: {fileID: -5096219100346723520, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5096219100346723520, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    - m_Name: Cow_01_35
+      m_Hash: 809771552
+      m_Sprite: {fileID: 59685946074353693, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 59685946074353693, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    - m_Name: Cow_01_36
+      m_Hash: 692941722
+      m_Sprite: {fileID: -5028246798210501473, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5028246798210501473, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    - m_Name: Cow_01_37
+      m_Hash: 508183308
+      m_Sprite: {fileID: 5091439602682987736, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5091439602682987736, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Die
+    m_Hash: 20298039
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_70
+      m_Hash: 608310187
+      m_Sprite: {fileID: 2129401767, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2129401767, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    - m_Name: Cow_01_71
+      m_Hash: 323298109
+      m_Sprite: {fileID: 349964809, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 349964809, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    - m_Name: Cow_01_72
+      m_Hash: 172782215
+      m_Sprite: {fileID: -1270501175, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1270501175, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    - m_Name: Cow_01_73
+      m_Hash: 1028342289
+      m_Sprite: {fileID: 1214058861, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1214058861, guid: 265c1ca77092a5d43a17e30950effabf, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 4
+  m_PrimaryLibraryGUID: 
+  m_ModificationHash: 638924974477017144
+  m_Version: 1

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Cow/Cow_09.spriteLib.meta
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Cow/Cow_09.spriteLib.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 0c0032ae6ecb469cab1f84580b32b2ad
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 11500000, guid: db2778f6d440c47ddacff25997d7c062, type: 3}

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_01.spriteLib
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_01.spriteLib
@@ -1,0 +1,276 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5e6fedc2472449cead18ef23b5cb30d, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Unity.2D.Animation.Runtime::UnityEngine.U2D.Animation.SpriteLibrarySourceAsset
+  m_Library:
+  - m_Name: Idle
+    m_Hash: 1008081451
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_0
+      m_Hash: 500319545
+      m_Sprite: {fileID: 6233744874289106954, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6233744874289106954, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    - m_Name: Cow_01_1
+      m_Hash: 718632367
+      m_Sprite: {fileID: 557953842428019376, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 557953842428019376, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleUp
+    m_Hash: 486716119
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_4
+      m_Hash: 448758048
+      m_Sprite: {fileID: 7065800952894488982, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7065800952894488982, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    - m_Name: Cow_01_5
+      m_Hash: 767078838
+      m_Sprite: {fileID: 3875088655458564879, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3875088655458564879, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleDown
+    m_Hash: 526694748
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_2
+      m_Hash: 870065173
+      m_Sprite: {fileID: 2027683414521886804, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2027683414521886804, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    - m_Name: Cow_01_3
+      m_Hash: 81466499
+      m_Sprite: {fileID: 7447652651584984377, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7447652651584984377, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: Walk
+    m_Hash: 765711723
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_6
+      m_Hash: 884072460
+      m_Sprite: {fileID: 3238054575067599374, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3238054575067599374, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    - m_Name: Cow_01_7
+      m_Hash: 62312602
+      m_Sprite: {fileID: 8489867052783553671, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8489867052783553671, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    - m_Name: Cow_01_8
+      m_Hash: 319409419
+      m_Sprite: {fileID: -1707918574423445580, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1707918574423445580, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    - m_Name: Cow_01_9
+      m_Hash: 604962205
+      m_Sprite: {fileID: -3374348805247662981, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3374348805247662981, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    - m_Name: Cow_01_10
+      m_Hash: 840479789
+      m_Sprite: {fileID: -1042999018547727314, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1042999018547727314, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    - m_Name: Cow_01_11
+      m_Hash: 85951675
+      m_Sprite: {fileID: 7084894367557705932, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7084894367557705932, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    - m_Name: Cow_01_12
+      m_Hash: 471258369
+      m_Sprite: {fileID: 21358811546975186, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 21358811546975186, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    - m_Name: Cow_01_13
+      m_Hash: 722593175
+      m_Sprite: {fileID: -2946077355061127965, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2946077355061127965, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkUp
+    m_Hash: 648049478
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_22
+      m_Hash: 926648002
+      m_Sprite: {fileID: 1137881734392780602, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1137881734392780602, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    - m_Name: Cow_01_23
+      m_Hash: 3978836
+      m_Sprite: {fileID: 4170766004724170628, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4170766004724170628, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    - m_Name: Cow_01_24
+      m_Hash: 509092855
+      m_Sprite: {fileID: 3125187220817964385, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3125187220817964385, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    - m_Name: Cow_01_25
+      m_Hash: 694096737
+      m_Sprite: {fileID: 201430590607337905, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 201430590607337905, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    - m_Name: Cow_01_26
+      m_Hash: 810959579
+      m_Sprite: {fileID: 514562492947537035, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 514562492947537035, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    - m_Name: Cow_01_27
+      m_Hash: 122778189
+      m_Sprite: {fileID: -1443046359965970732, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1443046359965970732, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    - m_Name: Cow_01_28
+      m_Hash: 401502172
+      m_Sprite: {fileID: -8704060516807834794, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8704060516807834794, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    - m_Name: Cow_01_29
+      m_Hash: 552165194
+      m_Sprite: {fileID: 6383172146060792988, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6383172146060792988, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkDown
+    m_Hash: 459082627
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_14
+      m_Hash: 896888884
+      m_Sprite: {fileID: 7507076782046255173, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7507076782046255173, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    - m_Name: Cow_01_15
+      m_Hash: 41042082
+      m_Sprite: {fileID: -7849141136299982279, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7849141136299982279, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    - m_Name: Cow_01_16
+      m_Hash: 461050136
+      m_Sprite: {fileID: 7456414298784783832, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7456414298784783832, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    - m_Name: Cow_01_17
+      m_Hash: 746332558
+      m_Sprite: {fileID: 3263460961159427431, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3263460961159427431, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    - m_Name: Cow_01_18
+      m_Hash: 1019427871
+      m_Sprite: {fileID: 326329282649566775, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 326329282649566775, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    - m_Name: Cow_01_19
+      m_Hash: 197397641
+      m_Sprite: {fileID: -3442168239459455278, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3442168239459455278, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    - m_Name: Cow_01_20
+      m_Hash: 422963182
+      m_Sprite: {fileID: 828443254082063441, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 828443254082063441, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    - m_Name: Cow_01_21
+      m_Hash: 775083896
+      m_Sprite: {fileID: 5332448389335089269, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5332448389335089269, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Attack
+    m_Hash: 7088141
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_30
+      m_Hash: 3069615
+      m_Sprite: {fileID: 1320430747136999562, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1320430747136999562, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    - m_Name: Cow_01_31
+      m_Hash: 925492793
+      m_Sprite: {fileID: -8583242729976573685, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8583242729976573685, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    - m_Name: Cow_01_32
+      m_Hash: 773896067
+      m_Sprite: {fileID: -6622897743962145832, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6622897743962145832, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    - m_Name: Cow_01_33
+      m_Hash: 422020885
+      m_Sprite: {fileID: 5462189286232690587, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5462189286232690587, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    - m_Name: Cow_01_34
+      m_Hash: 121836214
+      m_Sprite: {fileID: -8987694779989992309, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8987694779989992309, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    - m_Name: Cow_01_35
+      m_Hash: 809771552
+      m_Sprite: {fileID: -1549202756427711772, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1549202756427711772, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    - m_Name: Cow_01_36
+      m_Hash: 692941722
+      m_Sprite: {fileID: -7903554647177699731, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7903554647177699731, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    - m_Name: Cow_01_37
+      m_Hash: 508183308
+      m_Sprite: {fileID: -3284775145171426161, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3284775145171426161, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Die
+    m_Hash: 20298039
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_70
+      m_Hash: 608310187
+      m_Sprite: {fileID: -1232825219, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1232825219, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    - m_Name: Cow_01_71
+      m_Hash: 323298109
+      m_Sprite: {fileID: 436520475, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 436520475, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    - m_Name: Cow_01_72
+      m_Hash: 172782215
+      m_Sprite: {fileID: 1924671051, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1924671051, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    - m_Name: Cow_01_73
+      m_Hash: 1028342289
+      m_Sprite: {fileID: 197809034, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 197809034, guid: d65892ca043916f43a05dcdee64c6352, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 4
+  m_PrimaryLibraryGUID:
+  m_ModificationHash: 638924974477017144
+  m_Version: 1

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_01.spriteLib.meta
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_01.spriteLib.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 6ba6f3d29fa24fb4a16e583c1b573d58
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 11500000, guid: db2778f6d440c47ddacff25997d7c062, type: 3}

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_02.spriteLib
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_02.spriteLib
@@ -1,0 +1,276 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5e6fedc2472449cead18ef23b5cb30d, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Unity.2D.Animation.Runtime::UnityEngine.U2D.Animation.SpriteLibrarySourceAsset
+  m_Library:
+  - m_Name: Idle
+    m_Hash: 1008081451
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_0
+      m_Hash: 500319545
+      m_Sprite: {fileID: 1545615722503676599, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1545615722503676599, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    - m_Name: Cow_01_1
+      m_Hash: 718632367
+      m_Sprite: {fileID: 5909032003699960462, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5909032003699960462, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleUp
+    m_Hash: 486716119
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_4
+      m_Hash: 448758048
+      m_Sprite: {fileID: -959540293292100457, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -959540293292100457, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    - m_Name: Cow_01_5
+      m_Hash: 767078838
+      m_Sprite: {fileID: -6472921468881178017, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6472921468881178017, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleDown
+    m_Hash: 526694748
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_2
+      m_Hash: 870065173
+      m_Sprite: {fileID: -8006646038349443467, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8006646038349443467, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    - m_Name: Cow_01_3
+      m_Hash: 81466499
+      m_Sprite: {fileID: 7260597139107561802, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7260597139107561802, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: Walk
+    m_Hash: 765711723
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_6
+      m_Hash: 884072460
+      m_Sprite: {fileID: 4410459018579291020, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4410459018579291020, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    - m_Name: Cow_01_7
+      m_Hash: 62312602
+      m_Sprite: {fileID: -8965275753250656468, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8965275753250656468, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    - m_Name: Cow_01_8
+      m_Hash: 319409419
+      m_Sprite: {fileID: -6899638703482350010, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6899638703482350010, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    - m_Name: Cow_01_9
+      m_Hash: 604962205
+      m_Sprite: {fileID: -2679692294258175650, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2679692294258175650, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    - m_Name: Cow_01_10
+      m_Hash: 840479789
+      m_Sprite: {fileID: -1998212847660501827, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1998212847660501827, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    - m_Name: Cow_01_11
+      m_Hash: 85951675
+      m_Sprite: {fileID: 3922462496749211369, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3922462496749211369, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    - m_Name: Cow_01_12
+      m_Hash: 471258369
+      m_Sprite: {fileID: -4003989634115624216, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4003989634115624216, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    - m_Name: Cow_01_13
+      m_Hash: 722593175
+      m_Sprite: {fileID: -741209614633357952, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -741209614633357952, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkUp
+    m_Hash: 648049478
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_22
+      m_Hash: 926648002
+      m_Sprite: {fileID: 3427643936903103846, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3427643936903103846, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    - m_Name: Cow_01_23
+      m_Hash: 3978836
+      m_Sprite: {fileID: -4857651964549513304, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4857651964549513304, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    - m_Name: Cow_01_24
+      m_Hash: 509092855
+      m_Sprite: {fileID: 5282832608723603514, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5282832608723603514, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    - m_Name: Cow_01_25
+      m_Hash: 694096737
+      m_Sprite: {fileID: -1478856792108277251, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1478856792108277251, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    - m_Name: Cow_01_26
+      m_Hash: 810959579
+      m_Sprite: {fileID: 6306239094615046770, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6306239094615046770, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    - m_Name: Cow_01_27
+      m_Hash: 122778189
+      m_Sprite: {fileID: -1533053622105069992, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1533053622105069992, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    - m_Name: Cow_01_28
+      m_Hash: 401502172
+      m_Sprite: {fileID: -3036941051682426005, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3036941051682426005, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    - m_Name: Cow_01_29
+      m_Hash: 552165194
+      m_Sprite: {fileID: 1493989998106765686, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1493989998106765686, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkDown
+    m_Hash: 459082627
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_14
+      m_Hash: 896888884
+      m_Sprite: {fileID: -6847127360344331609, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6847127360344331609, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    - m_Name: Cow_01_15
+      m_Hash: 41042082
+      m_Sprite: {fileID: 4883111951695525273, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4883111951695525273, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    - m_Name: Cow_01_16
+      m_Hash: 461050136
+      m_Sprite: {fileID: 3354841270211568102, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3354841270211568102, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    - m_Name: Cow_01_17
+      m_Hash: 746332558
+      m_Sprite: {fileID: 4507798008176448894, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4507798008176448894, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    - m_Name: Cow_01_18
+      m_Hash: 1019427871
+      m_Sprite: {fileID: -2054258378132860043, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2054258378132860043, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    - m_Name: Cow_01_19
+      m_Hash: 197397641
+      m_Sprite: {fileID: 6388274452704810278, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6388274452704810278, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    - m_Name: Cow_01_20
+      m_Hash: 422963182
+      m_Sprite: {fileID: -6588516369465230165, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6588516369465230165, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    - m_Name: Cow_01_21
+      m_Hash: 775083896
+      m_Sprite: {fileID: 7800951385470491937, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7800951385470491937, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Attack
+    m_Hash: 7088141
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_30
+      m_Hash: 3069615
+      m_Sprite: {fileID: 3126073245103602608, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3126073245103602608, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    - m_Name: Cow_01_31
+      m_Hash: 925492793
+      m_Sprite: {fileID: -5862346393934261765, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5862346393934261765, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    - m_Name: Cow_01_32
+      m_Hash: 773896067
+      m_Sprite: {fileID: -6958591243955047277, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6958591243955047277, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    - m_Name: Cow_01_33
+      m_Hash: 422020885
+      m_Sprite: {fileID: 4515554638698174698, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4515554638698174698, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    - m_Name: Cow_01_34
+      m_Hash: 121836214
+      m_Sprite: {fileID: -1840424870681084044, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1840424870681084044, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    - m_Name: Cow_01_35
+      m_Hash: 809771552
+      m_Sprite: {fileID: 4535406036902838355, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4535406036902838355, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    - m_Name: Cow_01_36
+      m_Hash: 692941722
+      m_Sprite: {fileID: -7851605286924506407, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7851605286924506407, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    - m_Name: Cow_01_37
+      m_Hash: 508183308
+      m_Sprite: {fileID: -4131930468586010684, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4131930468586010684, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Die
+    m_Hash: 20298039
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_70
+      m_Hash: 608310187
+      m_Sprite: {fileID: -601517806, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -601517806, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    - m_Name: Cow_01_71
+      m_Hash: 323298109
+      m_Sprite: {fileID: 1837161123, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1837161123, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    - m_Name: Cow_01_72
+      m_Hash: 172782215
+      m_Sprite: {fileID: 685811790, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 685811790, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    - m_Name: Cow_01_73
+      m_Hash: 1028342289
+      m_Sprite: {fileID: -1101616889, guid: 609a787fffa53104085937f509f690d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1101616889, guid: 609a787fffa53104085937f509f690d3, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 4
+  m_PrimaryLibraryGUID:
+  m_ModificationHash: 638924974477017144
+  m_Version: 1

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_02.spriteLib.meta
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_02.spriteLib.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: f3bcd4ed80b44d92bd5cfab2917fbafe
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 11500000, guid: db2778f6d440c47ddacff25997d7c062, type: 3}

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_03.spriteLib
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_03.spriteLib
@@ -1,0 +1,276 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5e6fedc2472449cead18ef23b5cb30d, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Unity.2D.Animation.Runtime::UnityEngine.U2D.Animation.SpriteLibrarySourceAsset
+  m_Library:
+  - m_Name: Idle
+    m_Hash: 1008081451
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_0
+      m_Hash: 500319545
+      m_Sprite: {fileID: 853589032397801146, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 853589032397801146, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    - m_Name: Cow_01_1
+      m_Hash: 718632367
+      m_Sprite: {fileID: 104465020751859552, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 104465020751859552, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleUp
+    m_Hash: 486716119
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_4
+      m_Hash: 448758048
+      m_Sprite: {fileID: 1447748423923974772, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1447748423923974772, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    - m_Name: Cow_01_5
+      m_Hash: 767078838
+      m_Sprite: {fileID: 780212490838106238, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 780212490838106238, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleDown
+    m_Hash: 526694748
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_2
+      m_Hash: 870065173
+      m_Sprite: {fileID: 4137316555819701134, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4137316555819701134, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    - m_Name: Cow_01_3
+      m_Hash: 81466499
+      m_Sprite: {fileID: 5888769020711295152, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5888769020711295152, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: Walk
+    m_Hash: 765711723
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_6
+      m_Hash: 884072460
+      m_Sprite: {fileID: 8324895539694221937, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8324895539694221937, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    - m_Name: Cow_01_7
+      m_Hash: 62312602
+      m_Sprite: {fileID: -8193409196770416605, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8193409196770416605, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    - m_Name: Cow_01_8
+      m_Hash: 319409419
+      m_Sprite: {fileID: 5875124248392272604, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5875124248392272604, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    - m_Name: Cow_01_9
+      m_Hash: 604962205
+      m_Sprite: {fileID: 1890302374821054715, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1890302374821054715, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    - m_Name: Cow_01_10
+      m_Hash: 840479789
+      m_Sprite: {fileID: 3576818165767167738, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3576818165767167738, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    - m_Name: Cow_01_11
+      m_Hash: 85951675
+      m_Sprite: {fileID: 9106837387614307667, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 9106837387614307667, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    - m_Name: Cow_01_12
+      m_Hash: 471258369
+      m_Sprite: {fileID: -8777918420888657173, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8777918420888657173, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    - m_Name: Cow_01_13
+      m_Hash: 722593175
+      m_Sprite: {fileID: -356425719540018252, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -356425719540018252, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkUp
+    m_Hash: 648049478
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_22
+      m_Hash: 926648002
+      m_Sprite: {fileID: 2698392188977050586, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2698392188977050586, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    - m_Name: Cow_01_23
+      m_Hash: 3978836
+      m_Sprite: {fileID: 666683327338599110, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 666683327338599110, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    - m_Name: Cow_01_24
+      m_Hash: 509092855
+      m_Sprite: {fileID: -4532126381361988044, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4532126381361988044, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    - m_Name: Cow_01_25
+      m_Hash: 694096737
+      m_Sprite: {fileID: 1115255395994866617, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1115255395994866617, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    - m_Name: Cow_01_26
+      m_Hash: 810959579
+      m_Sprite: {fileID: -6539431218112163020, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6539431218112163020, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    - m_Name: Cow_01_27
+      m_Hash: 122778189
+      m_Sprite: {fileID: -7459838051090772929, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7459838051090772929, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    - m_Name: Cow_01_28
+      m_Hash: 401502172
+      m_Sprite: {fileID: -5499206157977773111, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5499206157977773111, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    - m_Name: Cow_01_29
+      m_Hash: 552165194
+      m_Sprite: {fileID: 8798436182226907771, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8798436182226907771, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkDown
+    m_Hash: 459082627
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_14
+      m_Hash: 896888884
+      m_Sprite: {fileID: -7716774362134722174, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7716774362134722174, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    - m_Name: Cow_01_15
+      m_Hash: 41042082
+      m_Sprite: {fileID: -3746034540638379169, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3746034540638379169, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    - m_Name: Cow_01_16
+      m_Hash: 461050136
+      m_Sprite: {fileID: -7813911838269942568, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7813911838269942568, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    - m_Name: Cow_01_17
+      m_Hash: 746332558
+      m_Sprite: {fileID: -1534330128950945402, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1534330128950945402, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    - m_Name: Cow_01_18
+      m_Hash: 1019427871
+      m_Sprite: {fileID: -8746297133756561977, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8746297133756561977, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    - m_Name: Cow_01_19
+      m_Hash: 197397641
+      m_Sprite: {fileID: -2743877532123128545, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2743877532123128545, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    - m_Name: Cow_01_20
+      m_Hash: 422963182
+      m_Sprite: {fileID: 7721811260674648143, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7721811260674648143, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    - m_Name: Cow_01_21
+      m_Hash: 775083896
+      m_Sprite: {fileID: 95991329865918590, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 95991329865918590, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Attack
+    m_Hash: 7088141
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_30
+      m_Hash: 3069615
+      m_Sprite: {fileID: 353533502073938022, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 353533502073938022, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    - m_Name: Cow_01_31
+      m_Hash: 925492793
+      m_Sprite: {fileID: 5985083441503456100, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5985083441503456100, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    - m_Name: Cow_01_32
+      m_Hash: 773896067
+      m_Sprite: {fileID: -6975047243817758223, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6975047243817758223, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    - m_Name: Cow_01_33
+      m_Hash: 422020885
+      m_Sprite: {fileID: 7033890284504859294, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7033890284504859294, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    - m_Name: Cow_01_34
+      m_Hash: 121836214
+      m_Sprite: {fileID: -8293587910685399581, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8293587910685399581, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    - m_Name: Cow_01_35
+      m_Hash: 809771552
+      m_Sprite: {fileID: -4616336926166860089, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4616336926166860089, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    - m_Name: Cow_01_36
+      m_Hash: 692941722
+      m_Sprite: {fileID: 7608893026656729130, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7608893026656729130, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    - m_Name: Cow_01_37
+      m_Hash: 508183308
+      m_Sprite: {fileID: 8734964931280770136, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8734964931280770136, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Die
+    m_Hash: 20298039
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_70
+      m_Hash: 608310187
+      m_Sprite: {fileID: 1591070645, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1591070645, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    - m_Name: Cow_01_71
+      m_Hash: 323298109
+      m_Sprite: {fileID: -1102565218, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1102565218, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    - m_Name: Cow_01_72
+      m_Hash: 172782215
+      m_Sprite: {fileID: 1358537515, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1358537515, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    - m_Name: Cow_01_73
+      m_Hash: 1028342289
+      m_Sprite: {fileID: -1101232941, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1101232941, guid: c2beb759b595732488ad313ca18cb2f4, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 4
+  m_PrimaryLibraryGUID:
+  m_ModificationHash: 638924974477017144
+  m_Version: 1

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_03.spriteLib.meta
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_03.spriteLib.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: ab9bd1114c4b4dbbae5c61e256ad4728
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 11500000, guid: db2778f6d440c47ddacff25997d7c062, type: 3}

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_04.spriteLib
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_04.spriteLib
@@ -1,0 +1,276 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5e6fedc2472449cead18ef23b5cb30d, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Unity.2D.Animation.Runtime::UnityEngine.U2D.Animation.SpriteLibrarySourceAsset
+  m_Library:
+  - m_Name: Idle
+    m_Hash: 1008081451
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_0
+      m_Hash: 500319545
+      m_Sprite: {fileID: -6449290195636371856, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6449290195636371856, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    - m_Name: Cow_01_1
+      m_Hash: 718632367
+      m_Sprite: {fileID: -4742650514542681610, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4742650514542681610, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleUp
+    m_Hash: 486716119
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_4
+      m_Hash: 448758048
+      m_Sprite: {fileID: -566536294388913433, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -566536294388913433, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    - m_Name: Cow_01_5
+      m_Hash: 767078838
+      m_Sprite: {fileID: -8215299390717886837, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8215299390717886837, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleDown
+    m_Hash: 526694748
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_2
+      m_Hash: 870065173
+      m_Sprite: {fileID: -4654212685160391968, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4654212685160391968, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    - m_Name: Cow_01_3
+      m_Hash: 81466499
+      m_Sprite: {fileID: -2433560877550306408, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2433560877550306408, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: Walk
+    m_Hash: 765711723
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_6
+      m_Hash: 884072460
+      m_Sprite: {fileID: -4863982787725197204, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4863982787725197204, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    - m_Name: Cow_01_7
+      m_Hash: 62312602
+      m_Sprite: {fileID: -1052191869578363727, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1052191869578363727, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    - m_Name: Cow_01_8
+      m_Hash: 319409419
+      m_Sprite: {fileID: -4806480125471946908, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4806480125471946908, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    - m_Name: Cow_01_9
+      m_Hash: 604962205
+      m_Sprite: {fileID: 2253477356591364562, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2253477356591364562, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    - m_Name: Cow_01_10
+      m_Hash: 840479789
+      m_Sprite: {fileID: 4763247548496934322, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4763247548496934322, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    - m_Name: Cow_01_11
+      m_Hash: 85951675
+      m_Sprite: {fileID: -2486324080550015148, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2486324080550015148, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    - m_Name: Cow_01_12
+      m_Hash: 471258369
+      m_Sprite: {fileID: 4264018978771500570, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4264018978771500570, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    - m_Name: Cow_01_13
+      m_Hash: 722593175
+      m_Sprite: {fileID: 4745120957671104738, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4745120957671104738, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkUp
+    m_Hash: 648049478
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_22
+      m_Hash: 926648002
+      m_Sprite: {fileID: -8660024778548668108, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8660024778548668108, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    - m_Name: Cow_01_23
+      m_Hash: 3978836
+      m_Sprite: {fileID: -7266400251678465374, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7266400251678465374, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    - m_Name: Cow_01_24
+      m_Hash: 509092855
+      m_Sprite: {fileID: 6982326215604407302, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6982326215604407302, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    - m_Name: Cow_01_25
+      m_Hash: 694096737
+      m_Sprite: {fileID: -3938946037932399097, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3938946037932399097, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    - m_Name: Cow_01_26
+      m_Hash: 810959579
+      m_Sprite: {fileID: 410791236183207350, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 410791236183207350, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    - m_Name: Cow_01_27
+      m_Hash: 122778189
+      m_Sprite: {fileID: 8652073760763561206, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8652073760763561206, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    - m_Name: Cow_01_28
+      m_Hash: 401502172
+      m_Sprite: {fileID: -3183122538345338707, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3183122538345338707, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    - m_Name: Cow_01_29
+      m_Hash: 552165194
+      m_Sprite: {fileID: -1085056575180384033, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1085056575180384033, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkDown
+    m_Hash: 459082627
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_14
+      m_Hash: 896888884
+      m_Sprite: {fileID: -2392156068317576201, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2392156068317576201, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    - m_Name: Cow_01_15
+      m_Hash: 41042082
+      m_Sprite: {fileID: -94360873084885732, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -94360873084885732, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    - m_Name: Cow_01_16
+      m_Hash: 461050136
+      m_Sprite: {fileID: 7639275640841659421, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7639275640841659421, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    - m_Name: Cow_01_17
+      m_Hash: 746332558
+      m_Sprite: {fileID: -6563303720345472347, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6563303720345472347, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    - m_Name: Cow_01_18
+      m_Hash: 1019427871
+      m_Sprite: {fileID: 2619569424056801962, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2619569424056801962, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    - m_Name: Cow_01_19
+      m_Hash: 197397641
+      m_Sprite: {fileID: -110637762576566652, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -110637762576566652, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    - m_Name: Cow_01_20
+      m_Hash: 422963182
+      m_Sprite: {fileID: 7039291686567601113, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7039291686567601113, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    - m_Name: Cow_01_21
+      m_Hash: 775083896
+      m_Sprite: {fileID: 5519517272155531403, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5519517272155531403, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Attack
+    m_Hash: 7088141
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_30
+      m_Hash: 3069615
+      m_Sprite: {fileID: 186441991150332455, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 186441991150332455, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    - m_Name: Cow_01_31
+      m_Hash: 925492793
+      m_Sprite: {fileID: 5546728904187892770, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5546728904187892770, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    - m_Name: Cow_01_32
+      m_Hash: 773896067
+      m_Sprite: {fileID: -1509919335343843112, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1509919335343843112, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    - m_Name: Cow_01_33
+      m_Hash: 422020885
+      m_Sprite: {fileID: 4888258223389679348, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4888258223389679348, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    - m_Name: Cow_01_34
+      m_Hash: 121836214
+      m_Sprite: {fileID: 7607889364416027466, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7607889364416027466, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    - m_Name: Cow_01_35
+      m_Hash: 809771552
+      m_Sprite: {fileID: -3520766153755911809, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3520766153755911809, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    - m_Name: Cow_01_36
+      m_Hash: 692941722
+      m_Sprite: {fileID: 5885034720074700, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5885034720074700, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    - m_Name: Cow_01_37
+      m_Hash: 508183308
+      m_Sprite: {fileID: -1250887068954765260, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1250887068954765260, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Die
+    m_Hash: 20298039
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_70
+      m_Hash: 608310187
+      m_Sprite: {fileID: -1848582270, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1848582270, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    - m_Name: Cow_01_71
+      m_Hash: 323298109
+      m_Sprite: {fileID: 755720168, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 755720168, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    - m_Name: Cow_01_72
+      m_Hash: 172782215
+      m_Sprite: {fileID: -1800046124, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1800046124, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    - m_Name: Cow_01_73
+      m_Hash: 1028342289
+      m_Sprite: {fileID: -921104133, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -921104133, guid: 2e723e0b4cd02834bb92c4f14e914d7c, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 4
+  m_PrimaryLibraryGUID:
+  m_ModificationHash: 638924974477017144
+  m_Version: 1

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_04.spriteLib.meta
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_04.spriteLib.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: d642ebcb528147428d330470d5a8beee
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 11500000, guid: db2778f6d440c47ddacff25997d7c062, type: 3}

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_05.spriteLib
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_05.spriteLib
@@ -1,0 +1,276 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5e6fedc2472449cead18ef23b5cb30d, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Unity.2D.Animation.Runtime::UnityEngine.U2D.Animation.SpriteLibrarySourceAsset
+  m_Library:
+  - m_Name: Idle
+    m_Hash: 1008081451
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_0
+      m_Hash: 500319545
+      m_Sprite: {fileID: 7101348030578759207, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7101348030578759207, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    - m_Name: Cow_01_1
+      m_Hash: 718632367
+      m_Sprite: {fileID: -3005015896822754548, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3005015896822754548, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleUp
+    m_Hash: 486716119
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_4
+      m_Hash: 448758048
+      m_Sprite: {fileID: 2414074117158914326, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2414074117158914326, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    - m_Name: Cow_01_5
+      m_Hash: 767078838
+      m_Sprite: {fileID: -2267169281008844781, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2267169281008844781, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleDown
+    m_Hash: 526694748
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_2
+      m_Hash: 870065173
+      m_Sprite: {fileID: 9190738646395136427, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 9190738646395136427, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    - m_Name: Cow_01_3
+      m_Hash: 81466499
+      m_Sprite: {fileID: -2551435479851909817, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2551435479851909817, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: Walk
+    m_Hash: 765711723
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_6
+      m_Hash: 884072460
+      m_Sprite: {fileID: 6619362380701251576, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6619362380701251576, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    - m_Name: Cow_01_7
+      m_Hash: 62312602
+      m_Sprite: {fileID: 1075965748395093132, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1075965748395093132, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    - m_Name: Cow_01_8
+      m_Hash: 319409419
+      m_Sprite: {fileID: 2155425556133321202, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2155425556133321202, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    - m_Name: Cow_01_9
+      m_Hash: 604962205
+      m_Sprite: {fileID: 2510802466586566146, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2510802466586566146, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    - m_Name: Cow_01_10
+      m_Hash: 840479789
+      m_Sprite: {fileID: 7345130661003092438, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7345130661003092438, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    - m_Name: Cow_01_11
+      m_Hash: 85951675
+      m_Sprite: {fileID: -5326241317873252201, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5326241317873252201, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    - m_Name: Cow_01_12
+      m_Hash: 471258369
+      m_Sprite: {fileID: -801461917602580865, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -801461917602580865, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    - m_Name: Cow_01_13
+      m_Hash: 722593175
+      m_Sprite: {fileID: 3938634741019837914, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3938634741019837914, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkUp
+    m_Hash: 648049478
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_22
+      m_Hash: 926648002
+      m_Sprite: {fileID: -5293941652150293395, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5293941652150293395, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    - m_Name: Cow_01_23
+      m_Hash: 3978836
+      m_Sprite: {fileID: -164493766424583797, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -164493766424583797, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    - m_Name: Cow_01_24
+      m_Hash: 509092855
+      m_Sprite: {fileID: 9041156322328484088, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 9041156322328484088, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    - m_Name: Cow_01_25
+      m_Hash: 694096737
+      m_Sprite: {fileID: -2417064156982722549, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2417064156982722549, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    - m_Name: Cow_01_26
+      m_Hash: 810959579
+      m_Sprite: {fileID: -8682906742483041607, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8682906742483041607, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    - m_Name: Cow_01_27
+      m_Hash: 122778189
+      m_Sprite: {fileID: -4967770800769890749, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4967770800769890749, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    - m_Name: Cow_01_28
+      m_Hash: 401502172
+      m_Sprite: {fileID: 3183902238930529122, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3183902238930529122, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    - m_Name: Cow_01_29
+      m_Hash: 552165194
+      m_Sprite: {fileID: 6573440519251253584, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6573440519251253584, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkDown
+    m_Hash: 459082627
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_14
+      m_Hash: 896888884
+      m_Sprite: {fileID: -6784234650917998766, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6784234650917998766, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    - m_Name: Cow_01_15
+      m_Hash: 41042082
+      m_Sprite: {fileID: 1653990435270704469, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1653990435270704469, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    - m_Name: Cow_01_16
+      m_Hash: 461050136
+      m_Sprite: {fileID: -4506277427727938704, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4506277427727938704, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    - m_Name: Cow_01_17
+      m_Hash: 746332558
+      m_Sprite: {fileID: -6114110965275737275, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6114110965275737275, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    - m_Name: Cow_01_18
+      m_Hash: 1019427871
+      m_Sprite: {fileID: 3203486871358027833, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3203486871358027833, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    - m_Name: Cow_01_19
+      m_Hash: 197397641
+      m_Sprite: {fileID: 6090944795384804381, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6090944795384804381, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    - m_Name: Cow_01_20
+      m_Hash: 422963182
+      m_Sprite: {fileID: 2724980519861011475, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2724980519861011475, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    - m_Name: Cow_01_21
+      m_Hash: 775083896
+      m_Sprite: {fileID: -6711015241830831442, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6711015241830831442, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Attack
+    m_Hash: 7088141
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_30
+      m_Hash: 3069615
+      m_Sprite: {fileID: 4739273747221775231, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4739273747221775231, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    - m_Name: Cow_01_31
+      m_Hash: 925492793
+      m_Sprite: {fileID: 7980247878332044132, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7980247878332044132, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    - m_Name: Cow_01_32
+      m_Hash: 773896067
+      m_Sprite: {fileID: 6728911834438503935, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6728911834438503935, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    - m_Name: Cow_01_33
+      m_Hash: 422020885
+      m_Sprite: {fileID: -8036329699901520492, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8036329699901520492, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    - m_Name: Cow_01_34
+      m_Hash: 121836214
+      m_Sprite: {fileID: -7854362915588137207, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7854362915588137207, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    - m_Name: Cow_01_35
+      m_Hash: 809771552
+      m_Sprite: {fileID: 1256047668244838627, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1256047668244838627, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    - m_Name: Cow_01_36
+      m_Hash: 692941722
+      m_Sprite: {fileID: -638762035792130308, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -638762035792130308, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    - m_Name: Cow_01_37
+      m_Hash: 508183308
+      m_Sprite: {fileID: 167998430918946764, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 167998430918946764, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Die
+    m_Hash: 20298039
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_70
+      m_Hash: 608310187
+      m_Sprite: {fileID: -228393616, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -228393616, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    - m_Name: Cow_01_71
+      m_Hash: 323298109
+      m_Sprite: {fileID: 1873705746, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1873705746, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    - m_Name: Cow_01_72
+      m_Hash: 172782215
+      m_Sprite: {fileID: -109105243, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -109105243, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    - m_Name: Cow_01_73
+      m_Hash: 1028342289
+      m_Sprite: {fileID: 386652835, guid: de494b959606bf04281a736c245bc32a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 386652835, guid: de494b959606bf04281a736c245bc32a, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 4
+  m_PrimaryLibraryGUID:
+  m_ModificationHash: 638924974477017144
+  m_Version: 1

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_05.spriteLib.meta
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_05.spriteLib.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 6a601e6651d2473ea9ccbb8913817cd3
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 11500000, guid: db2778f6d440c47ddacff25997d7c062, type: 3}

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_06.spriteLib
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_06.spriteLib
@@ -1,0 +1,276 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5e6fedc2472449cead18ef23b5cb30d, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Unity.2D.Animation.Runtime::UnityEngine.U2D.Animation.SpriteLibrarySourceAsset
+  m_Library:
+  - m_Name: Idle
+    m_Hash: 1008081451
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_0
+      m_Hash: 500319545
+      m_Sprite: {fileID: 4644596138431475247, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4644596138431475247, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    - m_Name: Cow_01_1
+      m_Hash: 718632367
+      m_Sprite: {fileID: -1336814931388777027, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1336814931388777027, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleUp
+    m_Hash: 486716119
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_4
+      m_Hash: 448758048
+      m_Sprite: {fileID: -3807264192946451280, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3807264192946451280, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    - m_Name: Cow_01_5
+      m_Hash: 767078838
+      m_Sprite: {fileID: 6297398034126603971, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6297398034126603971, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleDown
+    m_Hash: 526694748
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_2
+      m_Hash: 870065173
+      m_Sprite: {fileID: 8708908043692958129, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8708908043692958129, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    - m_Name: Cow_01_3
+      m_Hash: 81466499
+      m_Sprite: {fileID: 1959915536493345679, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1959915536493345679, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: Walk
+    m_Hash: 765711723
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_6
+      m_Hash: 884072460
+      m_Sprite: {fileID: 7478504953872687608, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7478504953872687608, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    - m_Name: Cow_01_7
+      m_Hash: 62312602
+      m_Sprite: {fileID: 726530019193337788, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 726530019193337788, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    - m_Name: Cow_01_8
+      m_Hash: 319409419
+      m_Sprite: {fileID: 715047174312431821, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 715047174312431821, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    - m_Name: Cow_01_9
+      m_Hash: 604962205
+      m_Sprite: {fileID: -6317067988245000169, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6317067988245000169, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    - m_Name: Cow_01_10
+      m_Hash: 840479789
+      m_Sprite: {fileID: 7006206936239712344, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7006206936239712344, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    - m_Name: Cow_01_11
+      m_Hash: 85951675
+      m_Sprite: {fileID: -5703401882008035922, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5703401882008035922, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    - m_Name: Cow_01_12
+      m_Hash: 471258369
+      m_Sprite: {fileID: -6058527160358467391, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6058527160358467391, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    - m_Name: Cow_01_13
+      m_Hash: 722593175
+      m_Sprite: {fileID: 2006975548584437571, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2006975548584437571, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkUp
+    m_Hash: 648049478
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_22
+      m_Hash: 926648002
+      m_Sprite: {fileID: 4542247041373751869, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4542247041373751869, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    - m_Name: Cow_01_23
+      m_Hash: 3978836
+      m_Sprite: {fileID: -3963996278222314522, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3963996278222314522, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    - m_Name: Cow_01_24
+      m_Hash: 509092855
+      m_Sprite: {fileID: -6915050350757519063, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6915050350757519063, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    - m_Name: Cow_01_25
+      m_Hash: 694096737
+      m_Sprite: {fileID: 6784546311026994134, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6784546311026994134, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    - m_Name: Cow_01_26
+      m_Hash: 810959579
+      m_Sprite: {fileID: -5156816644762243680, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5156816644762243680, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    - m_Name: Cow_01_27
+      m_Hash: 122778189
+      m_Sprite: {fileID: 4481613128335319425, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4481613128335319425, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    - m_Name: Cow_01_28
+      m_Hash: 401502172
+      m_Sprite: {fileID: 8062255874791441630, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8062255874791441630, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    - m_Name: Cow_01_29
+      m_Hash: 552165194
+      m_Sprite: {fileID: 2377809918956319533, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2377809918956319533, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkDown
+    m_Hash: 459082627
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_14
+      m_Hash: 896888884
+      m_Sprite: {fileID: -8485391307258489286, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8485391307258489286, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    - m_Name: Cow_01_15
+      m_Hash: 41042082
+      m_Sprite: {fileID: -6804800282908252120, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6804800282908252120, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    - m_Name: Cow_01_16
+      m_Hash: 461050136
+      m_Sprite: {fileID: 1285717320572425912, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1285717320572425912, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    - m_Name: Cow_01_17
+      m_Hash: 746332558
+      m_Sprite: {fileID: 2337363219208140645, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2337363219208140645, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    - m_Name: Cow_01_18
+      m_Hash: 1019427871
+      m_Sprite: {fileID: -8056628155033675509, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8056628155033675509, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    - m_Name: Cow_01_19
+      m_Hash: 197397641
+      m_Sprite: {fileID: 3058998483538752608, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3058998483538752608, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    - m_Name: Cow_01_20
+      m_Hash: 422963182
+      m_Sprite: {fileID: 3552670364866083083, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3552670364866083083, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    - m_Name: Cow_01_21
+      m_Hash: 775083896
+      m_Sprite: {fileID: 6069438746863817201, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6069438746863817201, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Attack
+    m_Hash: 7088141
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_30
+      m_Hash: 3069615
+      m_Sprite: {fileID: -4450114124185857474, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4450114124185857474, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    - m_Name: Cow_01_31
+      m_Hash: 925492793
+      m_Sprite: {fileID: -5429825886554601835, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5429825886554601835, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    - m_Name: Cow_01_32
+      m_Hash: 773896067
+      m_Sprite: {fileID: 5537707142653975470, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5537707142653975470, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    - m_Name: Cow_01_33
+      m_Hash: 422020885
+      m_Sprite: {fileID: 3140350816195136201, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3140350816195136201, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    - m_Name: Cow_01_34
+      m_Hash: 121836214
+      m_Sprite: {fileID: 231303761994170078, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 231303761994170078, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    - m_Name: Cow_01_35
+      m_Hash: 809771552
+      m_Sprite: {fileID: 690761979726411868, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 690761979726411868, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    - m_Name: Cow_01_36
+      m_Hash: 692941722
+      m_Sprite: {fileID: -1308412748251424152, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1308412748251424152, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    - m_Name: Cow_01_37
+      m_Hash: 508183308
+      m_Sprite: {fileID: 4070808189248234688, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4070808189248234688, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Die
+    m_Hash: 20298039
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_70
+      m_Hash: 608310187
+      m_Sprite: {fileID: -1358684169, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1358684169, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    - m_Name: Cow_01_71
+      m_Hash: 323298109
+      m_Sprite: {fileID: -2039786688, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2039786688, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    - m_Name: Cow_01_72
+      m_Hash: 172782215
+      m_Sprite: {fileID: 1201486197, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1201486197, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    - m_Name: Cow_01_73
+      m_Hash: 1028342289
+      m_Sprite: {fileID: -954021273, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -954021273, guid: 0234184e8d861c3439aac3a50a35c0ef, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 4
+  m_PrimaryLibraryGUID:
+  m_ModificationHash: 638924974477017144
+  m_Version: 1

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_06.spriteLib.meta
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_06.spriteLib.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: fb52fae7d38140808b7206c7c0ea78b2
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 11500000, guid: db2778f6d440c47ddacff25997d7c062, type: 3}

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_07.spriteLib
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_07.spriteLib
@@ -1,0 +1,276 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5e6fedc2472449cead18ef23b5cb30d, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Unity.2D.Animation.Runtime::UnityEngine.U2D.Animation.SpriteLibrarySourceAsset
+  m_Library:
+  - m_Name: Idle
+    m_Hash: 1008081451
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_0
+      m_Hash: 500319545
+      m_Sprite: {fileID: 247346459926595321, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 247346459926595321, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    - m_Name: Cow_01_1
+      m_Hash: 718632367
+      m_Sprite: {fileID: -2449114294813504916, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2449114294813504916, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleUp
+    m_Hash: 486716119
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_4
+      m_Hash: 448758048
+      m_Sprite: {fileID: 7602007858551828414, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7602007858551828414, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    - m_Name: Cow_01_5
+      m_Hash: 767078838
+      m_Sprite: {fileID: -6999136480998791372, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6999136480998791372, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleDown
+    m_Hash: 526694748
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_2
+      m_Hash: 870065173
+      m_Sprite: {fileID: -3232978807033123706, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3232978807033123706, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    - m_Name: Cow_01_3
+      m_Hash: 81466499
+      m_Sprite: {fileID: 7919596011099050832, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7919596011099050832, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: Walk
+    m_Hash: 765711723
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_6
+      m_Hash: 884072460
+      m_Sprite: {fileID: 9033367439227472478, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 9033367439227472478, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    - m_Name: Cow_01_7
+      m_Hash: 62312602
+      m_Sprite: {fileID: -660750069742264474, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -660750069742264474, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    - m_Name: Cow_01_8
+      m_Hash: 319409419
+      m_Sprite: {fileID: 7040998711871730743, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7040998711871730743, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    - m_Name: Cow_01_9
+      m_Hash: 604962205
+      m_Sprite: {fileID: 1144458548121364996, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1144458548121364996, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    - m_Name: Cow_01_10
+      m_Hash: 840479789
+      m_Sprite: {fileID: 341554136632270916, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 341554136632270916, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    - m_Name: Cow_01_11
+      m_Hash: 85951675
+      m_Sprite: {fileID: 8259252474209099398, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8259252474209099398, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    - m_Name: Cow_01_12
+      m_Hash: 471258369
+      m_Sprite: {fileID: -885160764351352031, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -885160764351352031, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    - m_Name: Cow_01_13
+      m_Hash: 722593175
+      m_Sprite: {fileID: 4600199966191826853, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4600199966191826853, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkUp
+    m_Hash: 648049478
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_22
+      m_Hash: 926648002
+      m_Sprite: {fileID: 2275149289845257662, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2275149289845257662, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    - m_Name: Cow_01_23
+      m_Hash: 3978836
+      m_Sprite: {fileID: 1030768819180304840, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1030768819180304840, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    - m_Name: Cow_01_24
+      m_Hash: 509092855
+      m_Sprite: {fileID: -183505656310528420, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -183505656310528420, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    - m_Name: Cow_01_25
+      m_Hash: 694096737
+      m_Sprite: {fileID: -7554867154974857698, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7554867154974857698, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    - m_Name: Cow_01_26
+      m_Hash: 810959579
+      m_Sprite: {fileID: 35399888742915867, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 35399888742915867, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    - m_Name: Cow_01_27
+      m_Hash: 122778189
+      m_Sprite: {fileID: -5736477178032459395, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5736477178032459395, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    - m_Name: Cow_01_28
+      m_Hash: 401502172
+      m_Sprite: {fileID: -4245400704981476010, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4245400704981476010, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    - m_Name: Cow_01_29
+      m_Hash: 552165194
+      m_Sprite: {fileID: -3284643009514468567, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3284643009514468567, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkDown
+    m_Hash: 459082627
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_14
+      m_Hash: 896888884
+      m_Sprite: {fileID: -2343427600915039685, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2343427600915039685, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    - m_Name: Cow_01_15
+      m_Hash: 41042082
+      m_Sprite: {fileID: -692705222438401142, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -692705222438401142, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    - m_Name: Cow_01_16
+      m_Hash: 461050136
+      m_Sprite: {fileID: 1800863723836869560, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1800863723836869560, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    - m_Name: Cow_01_17
+      m_Hash: 746332558
+      m_Sprite: {fileID: 4335309455292893896, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4335309455292893896, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    - m_Name: Cow_01_18
+      m_Hash: 1019427871
+      m_Sprite: {fileID: -7194204632226044511, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7194204632226044511, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    - m_Name: Cow_01_19
+      m_Hash: 197397641
+      m_Sprite: {fileID: -1894307807037295839, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1894307807037295839, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    - m_Name: Cow_01_20
+      m_Hash: 422963182
+      m_Sprite: {fileID: 3206437954650442391, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3206437954650442391, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    - m_Name: Cow_01_21
+      m_Hash: 775083896
+      m_Sprite: {fileID: -8251132689016166730, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8251132689016166730, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Attack
+    m_Hash: 7088141
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_30
+      m_Hash: 3069615
+      m_Sprite: {fileID: 6859448359304825636, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6859448359304825636, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    - m_Name: Cow_01_31
+      m_Hash: 925492793
+      m_Sprite: {fileID: -7914601890567658079, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7914601890567658079, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    - m_Name: Cow_01_32
+      m_Hash: 773896067
+      m_Sprite: {fileID: 7257652074537685963, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7257652074537685963, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    - m_Name: Cow_01_33
+      m_Hash: 422020885
+      m_Sprite: {fileID: 3255865751149732001, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3255865751149732001, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    - m_Name: Cow_01_34
+      m_Hash: 121836214
+      m_Sprite: {fileID: -1891045118934762424, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1891045118934762424, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    - m_Name: Cow_01_35
+      m_Hash: 809771552
+      m_Sprite: {fileID: -2064821851100608833, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2064821851100608833, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    - m_Name: Cow_01_36
+      m_Hash: 692941722
+      m_Sprite: {fileID: -6271102788561027078, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6271102788561027078, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    - m_Name: Cow_01_37
+      m_Hash: 508183308
+      m_Sprite: {fileID: 2905275130207696944, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2905275130207696944, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Die
+    m_Hash: 20298039
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_70
+      m_Hash: 608310187
+      m_Sprite: {fileID: 330047226, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 330047226, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    - m_Name: Cow_01_71
+      m_Hash: 323298109
+      m_Sprite: {fileID: -1579557008, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1579557008, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    - m_Name: Cow_01_72
+      m_Hash: 172782215
+      m_Sprite: {fileID: 22553390, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 22553390, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    - m_Name: Cow_01_73
+      m_Hash: 1028342289
+      m_Sprite: {fileID: 663228974, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 663228974, guid: 2604aa9453d36dc478691c4297205a86, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 4
+  m_PrimaryLibraryGUID:
+  m_ModificationHash: 638924974477017144
+  m_Version: 1

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_07.spriteLib.meta
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_07.spriteLib.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 1b55258116c84e7e88234c82262787cb
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 11500000, guid: db2778f6d440c47ddacff25997d7c062, type: 3}

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_08.spriteLib
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_08.spriteLib
@@ -1,0 +1,276 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5e6fedc2472449cead18ef23b5cb30d, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Unity.2D.Animation.Runtime::UnityEngine.U2D.Animation.SpriteLibrarySourceAsset
+  m_Library:
+  - m_Name: Idle
+    m_Hash: 1008081451
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_0
+      m_Hash: 500319545
+      m_Sprite: {fileID: 4871388301813450653, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4871388301813450653, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    - m_Name: Cow_01_1
+      m_Hash: 718632367
+      m_Sprite: {fileID: 6589507223174906463, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6589507223174906463, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleUp
+    m_Hash: 486716119
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_4
+      m_Hash: 448758048
+      m_Sprite: {fileID: 5364038800706098102, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5364038800706098102, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    - m_Name: Cow_01_5
+      m_Hash: 767078838
+      m_Sprite: {fileID: 2808603602441742037, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2808603602441742037, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleDown
+    m_Hash: 526694748
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_2
+      m_Hash: 870065173
+      m_Sprite: {fileID: 1714629664205272986, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1714629664205272986, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    - m_Name: Cow_01_3
+      m_Hash: 81466499
+      m_Sprite: {fileID: 4560635834531600784, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4560635834531600784, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: Walk
+    m_Hash: 765711723
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_6
+      m_Hash: 884072460
+      m_Sprite: {fileID: -362763912974543681, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -362763912974543681, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    - m_Name: Cow_01_7
+      m_Hash: 62312602
+      m_Sprite: {fileID: -6641973537458577897, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6641973537458577897, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    - m_Name: Cow_01_8
+      m_Hash: 319409419
+      m_Sprite: {fileID: -6138749281799238504, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6138749281799238504, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    - m_Name: Cow_01_9
+      m_Hash: 604962205
+      m_Sprite: {fileID: -4817261307866464021, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4817261307866464021, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    - m_Name: Cow_01_10
+      m_Hash: 840479789
+      m_Sprite: {fileID: -3439747438255194154, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3439747438255194154, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    - m_Name: Cow_01_11
+      m_Hash: 85951675
+      m_Sprite: {fileID: -7923990069626672289, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7923990069626672289, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    - m_Name: Cow_01_12
+      m_Hash: 471258369
+      m_Sprite: {fileID: 962804205625836742, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 962804205625836742, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    - m_Name: Cow_01_13
+      m_Hash: 722593175
+      m_Sprite: {fileID: 7539080003985007178, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7539080003985007178, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkUp
+    m_Hash: 648049478
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_22
+      m_Hash: 926648002
+      m_Sprite: {fileID: 2771338034507272375, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2771338034507272375, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    - m_Name: Cow_01_23
+      m_Hash: 3978836
+      m_Sprite: {fileID: -4984369873069698133, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4984369873069698133, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    - m_Name: Cow_01_24
+      m_Hash: 509092855
+      m_Sprite: {fileID: -7386919641950762645, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7386919641950762645, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    - m_Name: Cow_01_25
+      m_Hash: 694096737
+      m_Sprite: {fileID: 3046720066190622421, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3046720066190622421, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    - m_Name: Cow_01_26
+      m_Hash: 810959579
+      m_Sprite: {fileID: 1439376319652970257, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1439376319652970257, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    - m_Name: Cow_01_27
+      m_Hash: 122778189
+      m_Sprite: {fileID: -9138230741917470384, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -9138230741917470384, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    - m_Name: Cow_01_28
+      m_Hash: 401502172
+      m_Sprite: {fileID: 1597991447317163560, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1597991447317163560, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    - m_Name: Cow_01_29
+      m_Hash: 552165194
+      m_Sprite: {fileID: 8285263236566584749, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8285263236566584749, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkDown
+    m_Hash: 459082627
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_14
+      m_Hash: 896888884
+      m_Sprite: {fileID: -6871199399114474009, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6871199399114474009, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    - m_Name: Cow_01_15
+      m_Hash: 41042082
+      m_Sprite: {fileID: -2465430333301818661, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2465430333301818661, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    - m_Name: Cow_01_16
+      m_Hash: 461050136
+      m_Sprite: {fileID: -7517837413950938126, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7517837413950938126, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    - m_Name: Cow_01_17
+      m_Hash: 746332558
+      m_Sprite: {fileID: -6777959369388261547, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6777959369388261547, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    - m_Name: Cow_01_18
+      m_Hash: 1019427871
+      m_Sprite: {fileID: -1680537126557836443, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1680537126557836443, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    - m_Name: Cow_01_19
+      m_Hash: 197397641
+      m_Sprite: {fileID: 7112937259737160972, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7112937259737160972, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    - m_Name: Cow_01_20
+      m_Hash: 422963182
+      m_Sprite: {fileID: 8150071853960549793, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8150071853960549793, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    - m_Name: Cow_01_21
+      m_Hash: 775083896
+      m_Sprite: {fileID: 274350058744584118, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 274350058744584118, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Attack
+    m_Hash: 7088141
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_30
+      m_Hash: 3069615
+      m_Sprite: {fileID: -6279002864552981499, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6279002864552981499, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    - m_Name: Cow_01_31
+      m_Hash: 925492793
+      m_Sprite: {fileID: 5818116220008783420, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5818116220008783420, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    - m_Name: Cow_01_32
+      m_Hash: 773896067
+      m_Sprite: {fileID: -4200081367025452660, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4200081367025452660, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    - m_Name: Cow_01_33
+      m_Hash: 422020885
+      m_Sprite: {fileID: 7113549919319662708, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7113549919319662708, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    - m_Name: Cow_01_34
+      m_Hash: 121836214
+      m_Sprite: {fileID: 4616671759766334191, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4616671759766334191, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    - m_Name: Cow_01_35
+      m_Hash: 809771552
+      m_Sprite: {fileID: -7211306729929359965, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7211306729929359965, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    - m_Name: Cow_01_36
+      m_Hash: 692941722
+      m_Sprite: {fileID: 4306838475963663901, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4306838475963663901, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    - m_Name: Cow_01_37
+      m_Hash: 508183308
+      m_Sprite: {fileID: -870956213666035792, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -870956213666035792, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Die
+    m_Hash: 20298039
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_70
+      m_Hash: 608310187
+      m_Sprite: {fileID: 1967443873, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1967443873, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    - m_Name: Cow_01_71
+      m_Hash: 323298109
+      m_Sprite: {fileID: -134840452, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -134840452, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    - m_Name: Cow_01_72
+      m_Hash: 172782215
+      m_Sprite: {fileID: -1454815190, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1454815190, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    - m_Name: Cow_01_73
+      m_Hash: 1028342289
+      m_Sprite: {fileID: -816824624, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -816824624, guid: 866ee013ef47ea74d851edcc04286e5d, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 4
+  m_PrimaryLibraryGUID:
+  m_ModificationHash: 638924974477017144
+  m_Version: 1

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_08.spriteLib.meta
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_08.spriteLib.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 2d72cb96e4984bb593cef118b395691a
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 11500000, guid: db2778f6d440c47ddacff25997d7c062, type: 3}

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_09.spriteLib
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_09.spriteLib
@@ -1,0 +1,276 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5e6fedc2472449cead18ef23b5cb30d, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Unity.2D.Animation.Runtime::UnityEngine.U2D.Animation.SpriteLibrarySourceAsset
+  m_Library:
+  - m_Name: Idle
+    m_Hash: 1008081451
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_0
+      m_Hash: 500319545
+      m_Sprite: {fileID: 2676409830213111978, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2676409830213111978, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    - m_Name: Cow_01_1
+      m_Hash: 718632367
+      m_Sprite: {fileID: 6347908355888783945, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6347908355888783945, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleUp
+    m_Hash: 486716119
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_4
+      m_Hash: 448758048
+      m_Sprite: {fileID: -6985332507713347984, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6985332507713347984, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    - m_Name: Cow_01_5
+      m_Hash: 767078838
+      m_Sprite: {fileID: -5432965996681062880, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5432965996681062880, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleDown
+    m_Hash: 526694748
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_2
+      m_Hash: 870065173
+      m_Sprite: {fileID: 2656257712591080051, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2656257712591080051, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    - m_Name: Cow_01_3
+      m_Hash: 81466499
+      m_Sprite: {fileID: 7528625265757283282, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7528625265757283282, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: Walk
+    m_Hash: 765711723
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_6
+      m_Hash: 884072460
+      m_Sprite: {fileID: -6681317939368366551, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6681317939368366551, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    - m_Name: Cow_01_7
+      m_Hash: 62312602
+      m_Sprite: {fileID: 3158613016379456256, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3158613016379456256, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    - m_Name: Cow_01_8
+      m_Hash: 319409419
+      m_Sprite: {fileID: 7704071056323436648, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7704071056323436648, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    - m_Name: Cow_01_9
+      m_Hash: 604962205
+      m_Sprite: {fileID: 1094403114615103021, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1094403114615103021, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    - m_Name: Cow_01_10
+      m_Hash: 840479789
+      m_Sprite: {fileID: 1112584350533075599, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1112584350533075599, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    - m_Name: Cow_01_11
+      m_Hash: 85951675
+      m_Sprite: {fileID: -799714767057406975, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -799714767057406975, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    - m_Name: Cow_01_12
+      m_Hash: 471258369
+      m_Sprite: {fileID: -1371656438224354739, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1371656438224354739, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    - m_Name: Cow_01_13
+      m_Hash: 722593175
+      m_Sprite: {fileID: 6069245627931704902, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6069245627931704902, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkUp
+    m_Hash: 648049478
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_22
+      m_Hash: 926648002
+      m_Sprite: {fileID: 7528746955087489592, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7528746955087489592, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    - m_Name: Cow_01_23
+      m_Hash: 3978836
+      m_Sprite: {fileID: -7607071488681145505, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7607071488681145505, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    - m_Name: Cow_01_24
+      m_Hash: 509092855
+      m_Sprite: {fileID: -6418116910397468988, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6418116910397468988, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    - m_Name: Cow_01_25
+      m_Hash: 694096737
+      m_Sprite: {fileID: 28331769928502714, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 28331769928502714, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    - m_Name: Cow_01_26
+      m_Hash: 810959579
+      m_Sprite: {fileID: 8993722641882964371, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8993722641882964371, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    - m_Name: Cow_01_27
+      m_Hash: 122778189
+      m_Sprite: {fileID: 7039579700270283174, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7039579700270283174, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    - m_Name: Cow_01_28
+      m_Hash: 401502172
+      m_Sprite: {fileID: 8221622673647847606, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8221622673647847606, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    - m_Name: Cow_01_29
+      m_Hash: 552165194
+      m_Sprite: {fileID: 9132890578838415951, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 9132890578838415951, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkDown
+    m_Hash: 459082627
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_14
+      m_Hash: 896888884
+      m_Sprite: {fileID: -4026314077049236044, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4026314077049236044, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    - m_Name: Cow_01_15
+      m_Hash: 41042082
+      m_Sprite: {fileID: 296706925941451924, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 296706925941451924, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    - m_Name: Cow_01_16
+      m_Hash: 461050136
+      m_Sprite: {fileID: 8973412718019733977, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8973412718019733977, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    - m_Name: Cow_01_17
+      m_Hash: 746332558
+      m_Sprite: {fileID: 3005212626374653486, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3005212626374653486, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    - m_Name: Cow_01_18
+      m_Hash: 1019427871
+      m_Sprite: {fileID: 1472944487523346174, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1472944487523346174, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    - m_Name: Cow_01_19
+      m_Hash: 197397641
+      m_Sprite: {fileID: -5418772763405282048, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5418772763405282048, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    - m_Name: Cow_01_20
+      m_Hash: 422963182
+      m_Sprite: {fileID: 1950942604910591608, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1950942604910591608, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    - m_Name: Cow_01_21
+      m_Hash: 775083896
+      m_Sprite: {fileID: 6860477391268056735, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6860477391268056735, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Attack
+    m_Hash: 7088141
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_30
+      m_Hash: 3069615
+      m_Sprite: {fileID: 4183964799516953438, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4183964799516953438, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    - m_Name: Cow_01_31
+      m_Hash: 925492793
+      m_Sprite: {fileID: 3605938330129150892, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3605938330129150892, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    - m_Name: Cow_01_32
+      m_Hash: 773896067
+      m_Sprite: {fileID: -55206677815944176, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -55206677815944176, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    - m_Name: Cow_01_33
+      m_Hash: 422020885
+      m_Sprite: {fileID: 2379506445616219035, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2379506445616219035, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    - m_Name: Cow_01_34
+      m_Hash: 121836214
+      m_Sprite: {fileID: 612102987868064362, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 612102987868064362, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    - m_Name: Cow_01_35
+      m_Hash: 809771552
+      m_Sprite: {fileID: -4373935731964524063, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4373935731964524063, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    - m_Name: Cow_01_36
+      m_Hash: 692941722
+      m_Sprite: {fileID: 8662861020828646009, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8662861020828646009, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    - m_Name: Cow_01_37
+      m_Hash: 508183308
+      m_Sprite: {fileID: -4156841219801380509, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4156841219801380509, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Die
+    m_Hash: 20298039
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_70
+      m_Hash: 608310187
+      m_Sprite: {fileID: 671143667, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 671143667, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    - m_Name: Cow_01_71
+      m_Hash: 323298109
+      m_Sprite: {fileID: -1618698391, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1618698391, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    - m_Name: Cow_01_72
+      m_Hash: 172782215
+      m_Sprite: {fileID: 1886286360, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1886286360, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    - m_Name: Cow_01_73
+      m_Hash: 1028342289
+      m_Sprite: {fileID: 1615022134, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1615022134, guid: d888a4fd2697e204580ad74ed7558c70, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 4
+  m_PrimaryLibraryGUID:
+  m_ModificationHash: 638924974477017144
+  m_Version: 1

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_09.spriteLib.meta
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_09.spriteLib.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 538c14c175e0492c87793b29b45b5034
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 11500000, guid: db2778f6d440c47ddacff25997d7c062, type: 3}

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_10.spriteLib
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_10.spriteLib
@@ -1,0 +1,276 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5e6fedc2472449cead18ef23b5cb30d, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Unity.2D.Animation.Runtime::UnityEngine.U2D.Animation.SpriteLibrarySourceAsset
+  m_Library:
+  - m_Name: Idle
+    m_Hash: 1008081451
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_0
+      m_Hash: 500319545
+      m_Sprite: {fileID: 5834093084971699976, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5834093084971699976, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    - m_Name: Cow_01_1
+      m_Hash: 718632367
+      m_Sprite: {fileID: 6937385479328193884, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6937385479328193884, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleUp
+    m_Hash: 486716119
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_4
+      m_Hash: 448758048
+      m_Sprite: {fileID: 3959105098726519069, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3959105098726519069, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    - m_Name: Cow_01_5
+      m_Hash: 767078838
+      m_Sprite: {fileID: -1587135138777765213, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1587135138777765213, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleDown
+    m_Hash: 526694748
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_2
+      m_Hash: 870065173
+      m_Sprite: {fileID: 1657268344328639366, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1657268344328639366, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    - m_Name: Cow_01_3
+      m_Hash: 81466499
+      m_Sprite: {fileID: 6031701345128659016, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6031701345128659016, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: Walk
+    m_Hash: 765711723
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_6
+      m_Hash: 884072460
+      m_Sprite: {fileID: -5460021279429417356, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5460021279429417356, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    - m_Name: Cow_01_7
+      m_Hash: 62312602
+      m_Sprite: {fileID: 1605388514462139463, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1605388514462139463, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    - m_Name: Cow_01_8
+      m_Hash: 319409419
+      m_Sprite: {fileID: 1872275990650179650, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1872275990650179650, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    - m_Name: Cow_01_9
+      m_Hash: 604962205
+      m_Sprite: {fileID: -3745947062211846644, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3745947062211846644, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    - m_Name: Cow_01_10
+      m_Hash: 840479789
+      m_Sprite: {fileID: 4852780432823047835, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4852780432823047835, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    - m_Name: Cow_01_11
+      m_Hash: 85951675
+      m_Sprite: {fileID: -3913631939725178799, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3913631939725178799, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    - m_Name: Cow_01_12
+      m_Hash: 471258369
+      m_Sprite: {fileID: 9191755995895255704, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 9191755995895255704, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    - m_Name: Cow_01_13
+      m_Hash: 722593175
+      m_Sprite: {fileID: 5915226742450319782, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5915226742450319782, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkUp
+    m_Hash: 648049478
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_22
+      m_Hash: 926648002
+      m_Sprite: {fileID: -3478337459104516061, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3478337459104516061, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    - m_Name: Cow_01_23
+      m_Hash: 3978836
+      m_Sprite: {fileID: 4015451031409271881, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4015451031409271881, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    - m_Name: Cow_01_24
+      m_Hash: 509092855
+      m_Sprite: {fileID: 6825366021284918221, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6825366021284918221, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    - m_Name: Cow_01_25
+      m_Hash: 694096737
+      m_Sprite: {fileID: -6906702557981421184, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6906702557981421184, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    - m_Name: Cow_01_26
+      m_Hash: 810959579
+      m_Sprite: {fileID: 3763475189050210426, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3763475189050210426, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    - m_Name: Cow_01_27
+      m_Hash: 122778189
+      m_Sprite: {fileID: -8790479713838333477, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8790479713838333477, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    - m_Name: Cow_01_28
+      m_Hash: 401502172
+      m_Sprite: {fileID: 3403832363014866185, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3403832363014866185, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    - m_Name: Cow_01_29
+      m_Hash: 552165194
+      m_Sprite: {fileID: -8631502676598417655, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8631502676598417655, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkDown
+    m_Hash: 459082627
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_14
+      m_Hash: 896888884
+      m_Sprite: {fileID: -708416652772906829, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -708416652772906829, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    - m_Name: Cow_01_15
+      m_Hash: 41042082
+      m_Sprite: {fileID: -7984713471743256315, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7984713471743256315, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    - m_Name: Cow_01_16
+      m_Hash: 461050136
+      m_Sprite: {fileID: 4705273671831491114, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4705273671831491114, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    - m_Name: Cow_01_17
+      m_Hash: 746332558
+      m_Sprite: {fileID: 4752210390395968359, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4752210390395968359, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    - m_Name: Cow_01_18
+      m_Hash: 1019427871
+      m_Sprite: {fileID: -1836864489608891436, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1836864489608891436, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    - m_Name: Cow_01_19
+      m_Hash: 197397641
+      m_Sprite: {fileID: -2186478680367871498, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2186478680367871498, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    - m_Name: Cow_01_20
+      m_Hash: 422963182
+      m_Sprite: {fileID: -2502322726456411726, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2502322726456411726, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    - m_Name: Cow_01_21
+      m_Hash: 775083896
+      m_Sprite: {fileID: -4528689483396363952, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4528689483396363952, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Attack
+    m_Hash: 7088141
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_30
+      m_Hash: 3069615
+      m_Sprite: {fileID: 8645950560596050748, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8645950560596050748, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    - m_Name: Cow_01_31
+      m_Hash: 925492793
+      m_Sprite: {fileID: 1764634965589640921, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1764634965589640921, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    - m_Name: Cow_01_32
+      m_Hash: 773896067
+      m_Sprite: {fileID: 1831143245641813505, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1831143245641813505, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    - m_Name: Cow_01_33
+      m_Hash: 422020885
+      m_Sprite: {fileID: 6293653444612271906, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6293653444612271906, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    - m_Name: Cow_01_34
+      m_Hash: 121836214
+      m_Sprite: {fileID: -5867180506939081658, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5867180506939081658, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    - m_Name: Cow_01_35
+      m_Hash: 809771552
+      m_Sprite: {fileID: 7111800654933711038, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7111800654933711038, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    - m_Name: Cow_01_36
+      m_Hash: 692941722
+      m_Sprite: {fileID: 8632416290837461712, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8632416290837461712, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    - m_Name: Cow_01_37
+      m_Hash: 508183308
+      m_Sprite: {fileID: -5027385082576892520, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5027385082576892520, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Die
+    m_Hash: 20298039
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_70
+      m_Hash: 608310187
+      m_Sprite: {fileID: -808407503, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -808407503, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    - m_Name: Cow_01_71
+      m_Hash: 323298109
+      m_Sprite: {fileID: 2098355992, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2098355992, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    - m_Name: Cow_01_72
+      m_Hash: 172782215
+      m_Sprite: {fileID: 774818063, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 774818063, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    - m_Name: Cow_01_73
+      m_Hash: 1028342289
+      m_Sprite: {fileID: 348316550, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 348316550, guid: c46ac6a856ed9db44abe4cd1a78d8b39, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 4
+  m_PrimaryLibraryGUID:
+  m_ModificationHash: 638924974477017144
+  m_Version: 1

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_10.spriteLib.meta
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_10.spriteLib.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: ce8061f081d04ea5821847bc6a7eba33
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 11500000, guid: db2778f6d440c47ddacff25997d7c062, type: 3}

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_11.spriteLib
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_11.spriteLib
@@ -1,0 +1,276 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5e6fedc2472449cead18ef23b5cb30d, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Unity.2D.Animation.Runtime::UnityEngine.U2D.Animation.SpriteLibrarySourceAsset
+  m_Library:
+  - m_Name: Idle
+    m_Hash: 1008081451
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_0
+      m_Hash: 500319545
+      m_Sprite: {fileID: 41018120819962524, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 41018120819962524, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    - m_Name: Cow_01_1
+      m_Hash: 718632367
+      m_Sprite: {fileID: -3099188411253486365, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3099188411253486365, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleUp
+    m_Hash: 486716119
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_4
+      m_Hash: 448758048
+      m_Sprite: {fileID: 6617838872478364187, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6617838872478364187, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    - m_Name: Cow_01_5
+      m_Hash: 767078838
+      m_Sprite: {fileID: -7380341155949188098, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7380341155949188098, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleDown
+    m_Hash: 526694748
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_2
+      m_Hash: 870065173
+      m_Sprite: {fileID: -8472309867647519451, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8472309867647519451, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    - m_Name: Cow_01_3
+      m_Hash: 81466499
+      m_Sprite: {fileID: 823579630644830334, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 823579630644830334, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: Walk
+    m_Hash: 765711723
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_6
+      m_Hash: 884072460
+      m_Sprite: {fileID: 5183586362364953085, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5183586362364953085, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    - m_Name: Cow_01_7
+      m_Hash: 62312602
+      m_Sprite: {fileID: 7006453728551750742, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7006453728551750742, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    - m_Name: Cow_01_8
+      m_Hash: 319409419
+      m_Sprite: {fileID: 5551359776277286194, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5551359776277286194, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    - m_Name: Cow_01_9
+      m_Hash: 604962205
+      m_Sprite: {fileID: 2264651419649023020, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2264651419649023020, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    - m_Name: Cow_01_10
+      m_Hash: 840479789
+      m_Sprite: {fileID: -3096139423305136521, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3096139423305136521, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    - m_Name: Cow_01_11
+      m_Hash: 85951675
+      m_Sprite: {fileID: -3445574881077228495, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3445574881077228495, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    - m_Name: Cow_01_12
+      m_Hash: 471258369
+      m_Sprite: {fileID: 3080611138394741596, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3080611138394741596, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    - m_Name: Cow_01_13
+      m_Hash: 722593175
+      m_Sprite: {fileID: -1374228948261214020, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1374228948261214020, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkUp
+    m_Hash: 648049478
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_22
+      m_Hash: 926648002
+      m_Sprite: {fileID: -7594830271157784255, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7594830271157784255, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    - m_Name: Cow_01_23
+      m_Hash: 3978836
+      m_Sprite: {fileID: -9076551630066802839, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -9076551630066802839, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    - m_Name: Cow_01_24
+      m_Hash: 509092855
+      m_Sprite: {fileID: 7972423873191068517, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7972423873191068517, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    - m_Name: Cow_01_25
+      m_Hash: 694096737
+      m_Sprite: {fileID: -66097951849691085, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -66097951849691085, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    - m_Name: Cow_01_26
+      m_Hash: 810959579
+      m_Sprite: {fileID: -6208902534571519315, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6208902534571519315, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    - m_Name: Cow_01_27
+      m_Hash: 122778189
+      m_Sprite: {fileID: -5033095253796470974, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5033095253796470974, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    - m_Name: Cow_01_28
+      m_Hash: 401502172
+      m_Sprite: {fileID: 6502773754370505804, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6502773754370505804, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    - m_Name: Cow_01_29
+      m_Hash: 552165194
+      m_Sprite: {fileID: -2261275709598654880, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2261275709598654880, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkDown
+    m_Hash: 459082627
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_14
+      m_Hash: 896888884
+      m_Sprite: {fileID: -6352973230128435902, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6352973230128435902, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    - m_Name: Cow_01_15
+      m_Hash: 41042082
+      m_Sprite: {fileID: -5134811449672648275, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5134811449672648275, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    - m_Name: Cow_01_16
+      m_Hash: 461050136
+      m_Sprite: {fileID: 5393202931801507035, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5393202931801507035, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    - m_Name: Cow_01_17
+      m_Hash: 746332558
+      m_Sprite: {fileID: -3716677998825745223, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3716677998825745223, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    - m_Name: Cow_01_18
+      m_Hash: 1019427871
+      m_Sprite: {fileID: 88630600329611375, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 88630600329611375, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    - m_Name: Cow_01_19
+      m_Hash: 197397641
+      m_Sprite: {fileID: 7591999225285088676, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7591999225285088676, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    - m_Name: Cow_01_20
+      m_Hash: 422963182
+      m_Sprite: {fileID: 8667213363538124493, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8667213363538124493, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    - m_Name: Cow_01_21
+      m_Hash: 775083896
+      m_Sprite: {fileID: 1954320122783521508, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1954320122783521508, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Attack
+    m_Hash: 7088141
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_30
+      m_Hash: 3069615
+      m_Sprite: {fileID: -2915471846522557978, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2915471846522557978, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    - m_Name: Cow_01_31
+      m_Hash: 925492793
+      m_Sprite: {fileID: 4383656654651064083, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4383656654651064083, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    - m_Name: Cow_01_32
+      m_Hash: 773896067
+      m_Sprite: {fileID: -8833128231973548620, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8833128231973548620, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    - m_Name: Cow_01_33
+      m_Hash: 422020885
+      m_Sprite: {fileID: -8584284374453359263, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8584284374453359263, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    - m_Name: Cow_01_34
+      m_Hash: 121836214
+      m_Sprite: {fileID: 4592804431769351747, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4592804431769351747, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    - m_Name: Cow_01_35
+      m_Hash: 809771552
+      m_Sprite: {fileID: -314730311666580592, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -314730311666580592, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    - m_Name: Cow_01_36
+      m_Hash: 692941722
+      m_Sprite: {fileID: 5115514048864869039, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5115514048864869039, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    - m_Name: Cow_01_37
+      m_Hash: 508183308
+      m_Sprite: {fileID: -6656452067659514731, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6656452067659514731, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Die
+    m_Hash: 20298039
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_70
+      m_Hash: 608310187
+      m_Sprite: {fileID: 1842719813, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1842719813, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    - m_Name: Cow_01_71
+      m_Hash: 323298109
+      m_Sprite: {fileID: 1648053639, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1648053639, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    - m_Name: Cow_01_72
+      m_Hash: 172782215
+      m_Sprite: {fileID: -169608474, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -169608474, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    - m_Name: Cow_01_73
+      m_Hash: 1028342289
+      m_Sprite: {fileID: -1529427660, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1529427660, guid: d4954d867d63ebd4095045b283555be5, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 4
+  m_PrimaryLibraryGUID:
+  m_ModificationHash: 638924974477017144
+  m_Version: 1

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_11.spriteLib.meta
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_11.spriteLib.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: a44e8da00a0b40a2a1b37b4ae7baacb4
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 11500000, guid: db2778f6d440c47ddacff25997d7c062, type: 3}

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_12.spriteLib
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_12.spriteLib
@@ -1,0 +1,276 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5e6fedc2472449cead18ef23b5cb30d, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Unity.2D.Animation.Runtime::UnityEngine.U2D.Animation.SpriteLibrarySourceAsset
+  m_Library:
+  - m_Name: Idle
+    m_Hash: 1008081451
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_0
+      m_Hash: 500319545
+      m_Sprite: {fileID: -1334149035498833490, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1334149035498833490, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    - m_Name: Cow_01_1
+      m_Hash: 718632367
+      m_Sprite: {fileID: -4240059462388414989, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4240059462388414989, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleUp
+    m_Hash: 486716119
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_4
+      m_Hash: 448758048
+      m_Sprite: {fileID: 6750975095718685469, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6750975095718685469, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    - m_Name: Cow_01_5
+      m_Hash: 767078838
+      m_Sprite: {fileID: 1356144727479123479, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1356144727479123479, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleDown
+    m_Hash: 526694748
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_2
+      m_Hash: 870065173
+      m_Sprite: {fileID: 2558405012378152315, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2558405012378152315, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    - m_Name: Cow_01_3
+      m_Hash: 81466499
+      m_Sprite: {fileID: -5095197255224535570, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5095197255224535570, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: Walk
+    m_Hash: 765711723
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_6
+      m_Hash: 884072460
+      m_Sprite: {fileID: 1097756946113410956, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1097756946113410956, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    - m_Name: Cow_01_7
+      m_Hash: 62312602
+      m_Sprite: {fileID: -5773817507004346218, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5773817507004346218, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    - m_Name: Cow_01_8
+      m_Hash: 319409419
+      m_Sprite: {fileID: 4095380287051004316, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4095380287051004316, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    - m_Name: Cow_01_9
+      m_Hash: 604962205
+      m_Sprite: {fileID: 1550578933343374244, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1550578933343374244, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    - m_Name: Cow_01_10
+      m_Hash: 840479789
+      m_Sprite: {fileID: 1916495621504852099, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1916495621504852099, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    - m_Name: Cow_01_11
+      m_Hash: 85951675
+      m_Sprite: {fileID: -7817163961407552764, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7817163961407552764, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    - m_Name: Cow_01_12
+      m_Hash: 471258369
+      m_Sprite: {fileID: -3860305433238517516, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3860305433238517516, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    - m_Name: Cow_01_13
+      m_Hash: 722593175
+      m_Sprite: {fileID: -8091070384182454007, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8091070384182454007, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkUp
+    m_Hash: 648049478
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_22
+      m_Hash: 926648002
+      m_Sprite: {fileID: 3309902895581390821, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3309902895581390821, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    - m_Name: Cow_01_23
+      m_Hash: 3978836
+      m_Sprite: {fileID: 7759656167987779428, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7759656167987779428, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    - m_Name: Cow_01_24
+      m_Hash: 509092855
+      m_Sprite: {fileID: 2789193013826737686, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2789193013826737686, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    - m_Name: Cow_01_25
+      m_Hash: 694096737
+      m_Sprite: {fileID: -5479436275972784383, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5479436275972784383, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    - m_Name: Cow_01_26
+      m_Hash: 810959579
+      m_Sprite: {fileID: 6379309316985374036, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6379309316985374036, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    - m_Name: Cow_01_27
+      m_Hash: 122778189
+      m_Sprite: {fileID: -4212475788962970218, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4212475788962970218, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    - m_Name: Cow_01_28
+      m_Hash: 401502172
+      m_Sprite: {fileID: 1145254189183728525, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1145254189183728525, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    - m_Name: Cow_01_29
+      m_Hash: 552165194
+      m_Sprite: {fileID: 8638876373087371262, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8638876373087371262, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkDown
+    m_Hash: 459082627
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_14
+      m_Hash: 896888884
+      m_Sprite: {fileID: 2537952277291113103, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2537952277291113103, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    - m_Name: Cow_01_15
+      m_Hash: 41042082
+      m_Sprite: {fileID: -3448138816342996698, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3448138816342996698, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    - m_Name: Cow_01_16
+      m_Hash: 461050136
+      m_Sprite: {fileID: -4863810521779257413, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4863810521779257413, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    - m_Name: Cow_01_17
+      m_Hash: 746332558
+      m_Sprite: {fileID: 6835239341078138442, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6835239341078138442, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    - m_Name: Cow_01_18
+      m_Hash: 1019427871
+      m_Sprite: {fileID: 772006933523943204, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 772006933523943204, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    - m_Name: Cow_01_19
+      m_Hash: 197397641
+      m_Sprite: {fileID: -7123366533652773938, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7123366533652773938, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    - m_Name: Cow_01_20
+      m_Hash: 422963182
+      m_Sprite: {fileID: -2717504958953720706, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2717504958953720706, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    - m_Name: Cow_01_21
+      m_Hash: 775083896
+      m_Sprite: {fileID: 8892719429043980886, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8892719429043980886, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Attack
+    m_Hash: 7088141
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_30
+      m_Hash: 3069615
+      m_Sprite: {fileID: -1514124067864088696, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1514124067864088696, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    - m_Name: Cow_01_31
+      m_Hash: 925492793
+      m_Sprite: {fileID: 556672899338440799, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 556672899338440799, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    - m_Name: Cow_01_32
+      m_Hash: 773896067
+      m_Sprite: {fileID: -3340467395406382099, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3340467395406382099, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    - m_Name: Cow_01_33
+      m_Hash: 422020885
+      m_Sprite: {fileID: 3472226251454432404, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3472226251454432404, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    - m_Name: Cow_01_34
+      m_Hash: 121836214
+      m_Sprite: {fileID: 8026744843629104300, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8026744843629104300, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    - m_Name: Cow_01_35
+      m_Hash: 809771552
+      m_Sprite: {fileID: -3142158761080191734, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3142158761080191734, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    - m_Name: Cow_01_36
+      m_Hash: 692941722
+      m_Sprite: {fileID: -5553322821630046315, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5553322821630046315, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    - m_Name: Cow_01_37
+      m_Hash: 508183308
+      m_Sprite: {fileID: 3074428076496610402, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3074428076496610402, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Die
+    m_Hash: 20298039
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_70
+      m_Hash: 608310187
+      m_Sprite: {fileID: -511994836, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -511994836, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    - m_Name: Cow_01_71
+      m_Hash: 323298109
+      m_Sprite: {fileID: 809977250, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 809977250, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    - m_Name: Cow_01_72
+      m_Hash: 172782215
+      m_Sprite: {fileID: -1366193022, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1366193022, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    - m_Name: Cow_01_73
+      m_Hash: 1028342289
+      m_Sprite: {fileID: 1437008052, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1437008052, guid: a7c2018a62644154caf0f049d8078b0a, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 4
+  m_PrimaryLibraryGUID:
+  m_ModificationHash: 638924974477017144
+  m_Version: 1

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_12.spriteLib.meta
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_12.spriteLib.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 7178ffc721ea4ff69bede2a87c583862
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 11500000, guid: db2778f6d440c47ddacff25997d7c062, type: 3}

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_13.spriteLib
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_13.spriteLib
@@ -1,0 +1,276 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5e6fedc2472449cead18ef23b5cb30d, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Unity.2D.Animation.Runtime::UnityEngine.U2D.Animation.SpriteLibrarySourceAsset
+  m_Library:
+  - m_Name: Idle
+    m_Hash: 1008081451
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_0
+      m_Hash: 500319545
+      m_Sprite: {fileID: -5263349279597718475, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5263349279597718475, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    - m_Name: Cow_01_1
+      m_Hash: 718632367
+      m_Sprite: {fileID: 7539534251699414774, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7539534251699414774, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleUp
+    m_Hash: 486716119
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_4
+      m_Hash: 448758048
+      m_Sprite: {fileID: -6144001274104333469, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6144001274104333469, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    - m_Name: Cow_01_5
+      m_Hash: 767078838
+      m_Sprite: {fileID: 2445951716462936956, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2445951716462936956, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleDown
+    m_Hash: 526694748
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_2
+      m_Hash: 870065173
+      m_Sprite: {fileID: 7256708098765730005, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7256708098765730005, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    - m_Name: Cow_01_3
+      m_Hash: 81466499
+      m_Sprite: {fileID: 6383983182912748645, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6383983182912748645, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: Walk
+    m_Hash: 765711723
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_6
+      m_Hash: 884072460
+      m_Sprite: {fileID: 2349142329066940645, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2349142329066940645, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    - m_Name: Cow_01_7
+      m_Hash: 62312602
+      m_Sprite: {fileID: -2302296389202696145, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2302296389202696145, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    - m_Name: Cow_01_8
+      m_Hash: 319409419
+      m_Sprite: {fileID: -7849829547626901784, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7849829547626901784, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    - m_Name: Cow_01_9
+      m_Hash: 604962205
+      m_Sprite: {fileID: 312692734052101617, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 312692734052101617, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    - m_Name: Cow_01_10
+      m_Hash: 840479789
+      m_Sprite: {fileID: -4174420790810676268, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4174420790810676268, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    - m_Name: Cow_01_11
+      m_Hash: 85951675
+      m_Sprite: {fileID: 7776851889595167550, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7776851889595167550, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    - m_Name: Cow_01_12
+      m_Hash: 471258369
+      m_Sprite: {fileID: 69942369352137089, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 69942369352137089, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    - m_Name: Cow_01_13
+      m_Hash: 722593175
+      m_Sprite: {fileID: 2650173905005222534, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2650173905005222534, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkUp
+    m_Hash: 648049478
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_22
+      m_Hash: 926648002
+      m_Sprite: {fileID: 2662672461700174890, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2662672461700174890, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    - m_Name: Cow_01_23
+      m_Hash: 3978836
+      m_Sprite: {fileID: 7476229196542841401, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7476229196542841401, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    - m_Name: Cow_01_24
+      m_Hash: 509092855
+      m_Sprite: {fileID: 3708572102294482752, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3708572102294482752, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    - m_Name: Cow_01_25
+      m_Hash: 694096737
+      m_Sprite: {fileID: 8561886338968404162, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8561886338968404162, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    - m_Name: Cow_01_26
+      m_Hash: 810959579
+      m_Sprite: {fileID: -3411084695770445549, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3411084695770445549, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    - m_Name: Cow_01_27
+      m_Hash: 122778189
+      m_Sprite: {fileID: -4556700380511015928, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4556700380511015928, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    - m_Name: Cow_01_28
+      m_Hash: 401502172
+      m_Sprite: {fileID: -1811991443919059785, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1811991443919059785, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    - m_Name: Cow_01_29
+      m_Hash: 552165194
+      m_Sprite: {fileID: 8450312653976147615, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8450312653976147615, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkDown
+    m_Hash: 459082627
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_14
+      m_Hash: 896888884
+      m_Sprite: {fileID: -5931486699802878745, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5931486699802878745, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    - m_Name: Cow_01_15
+      m_Hash: 41042082
+      m_Sprite: {fileID: -2651209048198844917, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2651209048198844917, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    - m_Name: Cow_01_16
+      m_Hash: 461050136
+      m_Sprite: {fileID: 4966508437387619249, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4966508437387619249, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    - m_Name: Cow_01_17
+      m_Hash: 746332558
+      m_Sprite: {fileID: -8096458667864771623, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8096458667864771623, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    - m_Name: Cow_01_18
+      m_Hash: 1019427871
+      m_Sprite: {fileID: 663233871000619350, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 663233871000619350, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    - m_Name: Cow_01_19
+      m_Hash: 197397641
+      m_Sprite: {fileID: -6258563155659440976, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6258563155659440976, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    - m_Name: Cow_01_20
+      m_Hash: 422963182
+      m_Sprite: {fileID: -2753416157159669435, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2753416157159669435, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    - m_Name: Cow_01_21
+      m_Hash: 775083896
+      m_Sprite: {fileID: -214498180836105638, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -214498180836105638, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Attack
+    m_Hash: 7088141
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_30
+      m_Hash: 3069615
+      m_Sprite: {fileID: -6296919716567435071, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6296919716567435071, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    - m_Name: Cow_01_31
+      m_Hash: 925492793
+      m_Sprite: {fileID: 4907939652431618364, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4907939652431618364, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    - m_Name: Cow_01_32
+      m_Hash: 773896067
+      m_Sprite: {fileID: 3530255219564863266, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3530255219564863266, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    - m_Name: Cow_01_33
+      m_Hash: 422020885
+      m_Sprite: {fileID: 8460659053836739498, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8460659053836739498, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    - m_Name: Cow_01_34
+      m_Hash: 121836214
+      m_Sprite: {fileID: -5202463706699420550, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5202463706699420550, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    - m_Name: Cow_01_35
+      m_Hash: 809771552
+      m_Sprite: {fileID: 4520033394428122099, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4520033394428122099, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    - m_Name: Cow_01_36
+      m_Hash: 692941722
+      m_Sprite: {fileID: 4155588920000647703, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4155588920000647703, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    - m_Name: Cow_01_37
+      m_Hash: 508183308
+      m_Sprite: {fileID: -6297753168569954962, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6297753168569954962, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Die
+    m_Hash: 20298039
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_70
+      m_Hash: 608310187
+      m_Sprite: {fileID: 1433244081, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1433244081, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    - m_Name: Cow_01_71
+      m_Hash: 323298109
+      m_Sprite: {fileID: 1009900415, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1009900415, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    - m_Name: Cow_01_72
+      m_Hash: 172782215
+      m_Sprite: {fileID: 1362267271, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1362267271, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    - m_Name: Cow_01_73
+      m_Hash: 1028342289
+      m_Sprite: {fileID: -828796262, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -828796262, guid: 8aa9310a11a957b4898f3bb24c067942, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 4
+  m_PrimaryLibraryGUID:
+  m_ModificationHash: 638924974477017144
+  m_Version: 1

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_13.spriteLib.meta
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_13.spriteLib.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 0cfdeff06a844437912b1716c8f56b91
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 11500000, guid: db2778f6d440c47ddacff25997d7c062, type: 3}

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_14.spriteLib
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_14.spriteLib
@@ -1,0 +1,276 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5e6fedc2472449cead18ef23b5cb30d, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Unity.2D.Animation.Runtime::UnityEngine.U2D.Animation.SpriteLibrarySourceAsset
+  m_Library:
+  - m_Name: Idle
+    m_Hash: 1008081451
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_0
+      m_Hash: 500319545
+      m_Sprite: {fileID: 844510255113199345, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 844510255113199345, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    - m_Name: Cow_01_1
+      m_Hash: 718632367
+      m_Sprite: {fileID: -7050068565206504666, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7050068565206504666, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleUp
+    m_Hash: 486716119
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_4
+      m_Hash: 448758048
+      m_Sprite: {fileID: -3501094402676903755, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3501094402676903755, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    - m_Name: Cow_01_5
+      m_Hash: 767078838
+      m_Sprite: {fileID: 6050934475382264153, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6050934475382264153, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleDown
+    m_Hash: 526694748
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_2
+      m_Hash: 870065173
+      m_Sprite: {fileID: -2145238781515843551, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2145238781515843551, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    - m_Name: Cow_01_3
+      m_Hash: 81466499
+      m_Sprite: {fileID: 6798167238574783265, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6798167238574783265, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: Walk
+    m_Hash: 765711723
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_6
+      m_Hash: 884072460
+      m_Sprite: {fileID: 3269585134666761718, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3269585134666761718, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    - m_Name: Cow_01_7
+      m_Hash: 62312602
+      m_Sprite: {fileID: 346837656353073617, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 346837656353073617, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    - m_Name: Cow_01_8
+      m_Hash: 319409419
+      m_Sprite: {fileID: -8595367395590726791, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8595367395590726791, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    - m_Name: Cow_01_9
+      m_Hash: 604962205
+      m_Sprite: {fileID: -7835643116601803609, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7835643116601803609, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    - m_Name: Cow_01_10
+      m_Hash: 840479789
+      m_Sprite: {fileID: -2984357236528744928, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2984357236528744928, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    - m_Name: Cow_01_11
+      m_Hash: 85951675
+      m_Sprite: {fileID: -7290200897224088777, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7290200897224088777, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    - m_Name: Cow_01_12
+      m_Hash: 471258369
+      m_Sprite: {fileID: -4442297230876792035, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4442297230876792035, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    - m_Name: Cow_01_13
+      m_Hash: 722593175
+      m_Sprite: {fileID: -8028288722040097479, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8028288722040097479, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkUp
+    m_Hash: 648049478
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_22
+      m_Hash: 926648002
+      m_Sprite: {fileID: -3757953171381004424, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3757953171381004424, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    - m_Name: Cow_01_23
+      m_Hash: 3978836
+      m_Sprite: {fileID: -7668691754641854883, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7668691754641854883, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    - m_Name: Cow_01_24
+      m_Hash: 509092855
+      m_Sprite: {fileID: -884097930922984341, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -884097930922984341, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    - m_Name: Cow_01_25
+      m_Hash: 694096737
+      m_Sprite: {fileID: -2162281438564611274, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2162281438564611274, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    - m_Name: Cow_01_26
+      m_Hash: 810959579
+      m_Sprite: {fileID: 8672465066683849055, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8672465066683849055, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    - m_Name: Cow_01_27
+      m_Hash: 122778189
+      m_Sprite: {fileID: 5569121701030347613, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5569121701030347613, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    - m_Name: Cow_01_28
+      m_Hash: 401502172
+      m_Sprite: {fileID: -1980069888259239938, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1980069888259239938, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    - m_Name: Cow_01_29
+      m_Hash: 552165194
+      m_Sprite: {fileID: -7057656705368473969, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7057656705368473969, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkDown
+    m_Hash: 459082627
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_14
+      m_Hash: 896888884
+      m_Sprite: {fileID: 7669584445663730648, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7669584445663730648, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    - m_Name: Cow_01_15
+      m_Hash: 41042082
+      m_Sprite: {fileID: -4183473209833659410, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4183473209833659410, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    - m_Name: Cow_01_16
+      m_Hash: 461050136
+      m_Sprite: {fileID: 5573409701345361626, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5573409701345361626, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    - m_Name: Cow_01_17
+      m_Hash: 746332558
+      m_Sprite: {fileID: -2488373212668264193, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2488373212668264193, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    - m_Name: Cow_01_18
+      m_Hash: 1019427871
+      m_Sprite: {fileID: -1744922153147234427, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1744922153147234427, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    - m_Name: Cow_01_19
+      m_Hash: 197397641
+      m_Sprite: {fileID: 8468272055076543093, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8468272055076543093, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    - m_Name: Cow_01_20
+      m_Hash: 422963182
+      m_Sprite: {fileID: -8844615285072266596, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8844615285072266596, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    - m_Name: Cow_01_21
+      m_Hash: 775083896
+      m_Sprite: {fileID: 1168070470232980497, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1168070470232980497, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Attack
+    m_Hash: 7088141
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_30
+      m_Hash: 3069615
+      m_Sprite: {fileID: 3657935330764472239, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3657935330764472239, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    - m_Name: Cow_01_31
+      m_Hash: 925492793
+      m_Sprite: {fileID: -5988524534687700282, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5988524534687700282, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    - m_Name: Cow_01_32
+      m_Hash: 773896067
+      m_Sprite: {fileID: -2353258314711285836, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2353258314711285836, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    - m_Name: Cow_01_33
+      m_Hash: 422020885
+      m_Sprite: {fileID: -8354178092495100536, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8354178092495100536, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    - m_Name: Cow_01_34
+      m_Hash: 121836214
+      m_Sprite: {fileID: 5173794666733170314, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5173794666733170314, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    - m_Name: Cow_01_35
+      m_Hash: 809771552
+      m_Sprite: {fileID: -455193159872294679, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -455193159872294679, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    - m_Name: Cow_01_36
+      m_Hash: 692941722
+      m_Sprite: {fileID: 7661284105966625563, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7661284105966625563, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    - m_Name: Cow_01_37
+      m_Hash: 508183308
+      m_Sprite: {fileID: 2226053204980105310, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2226053204980105310, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Die
+    m_Hash: 20298039
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_70
+      m_Hash: 608310187
+      m_Sprite: {fileID: -385894065, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -385894065, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    - m_Name: Cow_01_71
+      m_Hash: 323298109
+      m_Sprite: {fileID: 130441403, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 130441403, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    - m_Name: Cow_01_72
+      m_Hash: 172782215
+      m_Sprite: {fileID: 916750043, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 916750043, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    - m_Name: Cow_01_73
+      m_Hash: 1028342289
+      m_Sprite: {fileID: -633291640, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -633291640, guid: b6e67b1023a748b46b5550a9958a49d3, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 4
+  m_PrimaryLibraryGUID:
+  m_ModificationHash: 638924974477017144
+  m_Version: 1

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_14.spriteLib.meta
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_14.spriteLib.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 43bd5b68493646699b6155e76b9bb4e3
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 11500000, guid: db2778f6d440c47ddacff25997d7c062, type: 3}

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_15.spriteLib
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_15.spriteLib
@@ -1,0 +1,276 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5e6fedc2472449cead18ef23b5cb30d, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Unity.2D.Animation.Runtime::UnityEngine.U2D.Animation.SpriteLibrarySourceAsset
+  m_Library:
+  - m_Name: Idle
+    m_Hash: 1008081451
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_0
+      m_Hash: 500319545
+      m_Sprite: {fileID: 4619740377230215529, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4619740377230215529, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    - m_Name: Cow_01_1
+      m_Hash: 718632367
+      m_Sprite: {fileID: -6208228489988984782, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6208228489988984782, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleUp
+    m_Hash: 486716119
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_4
+      m_Hash: 448758048
+      m_Sprite: {fileID: 5020406727444399214, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5020406727444399214, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    - m_Name: Cow_01_5
+      m_Hash: 767078838
+      m_Sprite: {fileID: 8596071491372770637, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8596071491372770637, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleDown
+    m_Hash: 526694748
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_2
+      m_Hash: 870065173
+      m_Sprite: {fileID: -3039029796219566681, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3039029796219566681, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    - m_Name: Cow_01_3
+      m_Hash: 81466499
+      m_Sprite: {fileID: -1786651027000186663, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1786651027000186663, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: Walk
+    m_Hash: 765711723
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_6
+      m_Hash: 884072460
+      m_Sprite: {fileID: -8454398507913845779, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8454398507913845779, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    - m_Name: Cow_01_7
+      m_Hash: 62312602
+      m_Sprite: {fileID: -5104383742901415435, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5104383742901415435, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    - m_Name: Cow_01_8
+      m_Hash: 319409419
+      m_Sprite: {fileID: 7645058060165933932, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7645058060165933932, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    - m_Name: Cow_01_9
+      m_Hash: 604962205
+      m_Sprite: {fileID: 2015580350007360437, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2015580350007360437, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    - m_Name: Cow_01_10
+      m_Hash: 840479789
+      m_Sprite: {fileID: -3358933874243254480, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3358933874243254480, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    - m_Name: Cow_01_11
+      m_Hash: 85951675
+      m_Sprite: {fileID: 4357834736593572111, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4357834736593572111, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    - m_Name: Cow_01_12
+      m_Hash: 471258369
+      m_Sprite: {fileID: -4499821957437668752, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4499821957437668752, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    - m_Name: Cow_01_13
+      m_Hash: 722593175
+      m_Sprite: {fileID: 6841201051643535058, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6841201051643535058, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkUp
+    m_Hash: 648049478
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_22
+      m_Hash: 926648002
+      m_Sprite: {fileID: 8869075642950282245, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8869075642950282245, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    - m_Name: Cow_01_23
+      m_Hash: 3978836
+      m_Sprite: {fileID: 8050147236861711377, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8050147236861711377, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    - m_Name: Cow_01_24
+      m_Hash: 509092855
+      m_Sprite: {fileID: 3746945518432863786, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3746945518432863786, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    - m_Name: Cow_01_25
+      m_Hash: 694096737
+      m_Sprite: {fileID: 49396182172678188, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 49396182172678188, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    - m_Name: Cow_01_26
+      m_Hash: 810959579
+      m_Sprite: {fileID: -4935743148574089581, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4935743148574089581, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    - m_Name: Cow_01_27
+      m_Hash: 122778189
+      m_Sprite: {fileID: 6228012149692902017, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6228012149692902017, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    - m_Name: Cow_01_28
+      m_Hash: 401502172
+      m_Sprite: {fileID: 80257852697344344, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 80257852697344344, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    - m_Name: Cow_01_29
+      m_Hash: 552165194
+      m_Sprite: {fileID: 4616470035171302207, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4616470035171302207, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkDown
+    m_Hash: 459082627
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_14
+      m_Hash: 896888884
+      m_Sprite: {fileID: -6984137168963742884, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6984137168963742884, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    - m_Name: Cow_01_15
+      m_Hash: 41042082
+      m_Sprite: {fileID: 8056713467036631863, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8056713467036631863, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    - m_Name: Cow_01_16
+      m_Hash: 461050136
+      m_Sprite: {fileID: 3395547030145085832, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3395547030145085832, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    - m_Name: Cow_01_17
+      m_Hash: 746332558
+      m_Sprite: {fileID: 4175878484366892568, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4175878484366892568, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    - m_Name: Cow_01_18
+      m_Hash: 1019427871
+      m_Sprite: {fileID: -4945950117316590985, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4945950117316590985, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    - m_Name: Cow_01_19
+      m_Hash: 197397641
+      m_Sprite: {fileID: 3793256767564274965, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3793256767564274965, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    - m_Name: Cow_01_20
+      m_Hash: 422963182
+      m_Sprite: {fileID: -7415981931152926490, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7415981931152926490, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    - m_Name: Cow_01_21
+      m_Hash: 775083896
+      m_Sprite: {fileID: 4796516283439933949, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4796516283439933949, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Attack
+    m_Hash: 7088141
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_30
+      m_Hash: 3069615
+      m_Sprite: {fileID: 6816442153825420589, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6816442153825420589, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    - m_Name: Cow_01_31
+      m_Hash: 925492793
+      m_Sprite: {fileID: 3488689674477674007, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3488689674477674007, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    - m_Name: Cow_01_32
+      m_Hash: 773896067
+      m_Sprite: {fileID: 5720663838104424080, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5720663838104424080, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    - m_Name: Cow_01_33
+      m_Hash: 422020885
+      m_Sprite: {fileID: -8809678841037258739, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8809678841037258739, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    - m_Name: Cow_01_34
+      m_Hash: 121836214
+      m_Sprite: {fileID: -2592303127563611857, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2592303127563611857, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    - m_Name: Cow_01_35
+      m_Hash: 809771552
+      m_Sprite: {fileID: -2098463664662592648, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2098463664662592648, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    - m_Name: Cow_01_36
+      m_Hash: 692941722
+      m_Sprite: {fileID: -208766325003817633, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -208766325003817633, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    - m_Name: Cow_01_37
+      m_Hash: 508183308
+      m_Sprite: {fileID: 7819076164639262589, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7819076164639262589, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Die
+    m_Hash: 20298039
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_70
+      m_Hash: 608310187
+      m_Sprite: {fileID: 1698090511, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1698090511, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    - m_Name: Cow_01_71
+      m_Hash: 323298109
+      m_Sprite: {fileID: 2006709332, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2006709332, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    - m_Name: Cow_01_72
+      m_Hash: 172782215
+      m_Sprite: {fileID: -1649859476, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1649859476, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    - m_Name: Cow_01_73
+      m_Hash: 1028342289
+      m_Sprite: {fileID: -349454742, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -349454742, guid: 9a8f152767a984c44ac643ca1b8a0e4c, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 4
+  m_PrimaryLibraryGUID:
+  m_ModificationHash: 638924974477017144
+  m_Version: 1

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_15.spriteLib.meta
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_15.spriteLib.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 1f3626aba2b44fe682cf3d39af1f73ed
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 11500000, guid: db2778f6d440c47ddacff25997d7c062, type: 3}

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_16.spriteLib
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_16.spriteLib
@@ -1,0 +1,276 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5e6fedc2472449cead18ef23b5cb30d, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Unity.2D.Animation.Runtime::UnityEngine.U2D.Animation.SpriteLibrarySourceAsset
+  m_Library:
+  - m_Name: Idle
+    m_Hash: 1008081451
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_0
+      m_Hash: 500319545
+      m_Sprite: {fileID: -5087318933004752291, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5087318933004752291, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    - m_Name: Cow_01_1
+      m_Hash: 718632367
+      m_Sprite: {fileID: 992376072073896709, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 992376072073896709, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleUp
+    m_Hash: 486716119
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_4
+      m_Hash: 448758048
+      m_Sprite: {fileID: -7267356275248937092, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7267356275248937092, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    - m_Name: Cow_01_5
+      m_Hash: 767078838
+      m_Sprite: {fileID: -5478004874334703863, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5478004874334703863, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleDown
+    m_Hash: 526694748
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_2
+      m_Hash: 870065173
+      m_Sprite: {fileID: 583174743597310368, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 583174743597310368, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    - m_Name: Cow_01_3
+      m_Hash: 81466499
+      m_Sprite: {fileID: -1560777269006418931, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1560777269006418931, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: Walk
+    m_Hash: 765711723
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_6
+      m_Hash: 884072460
+      m_Sprite: {fileID: -2998643422111312188, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2998643422111312188, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    - m_Name: Cow_01_7
+      m_Hash: 62312602
+      m_Sprite: {fileID: 5557197954719634493, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5557197954719634493, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    - m_Name: Cow_01_8
+      m_Hash: 319409419
+      m_Sprite: {fileID: -834871338208414677, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -834871338208414677, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    - m_Name: Cow_01_9
+      m_Hash: 604962205
+      m_Sprite: {fileID: 7057317668582277279, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7057317668582277279, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    - m_Name: Cow_01_10
+      m_Hash: 840479789
+      m_Sprite: {fileID: 304620882025061360, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 304620882025061360, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    - m_Name: Cow_01_11
+      m_Hash: 85951675
+      m_Sprite: {fileID: -1585412336903198995, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1585412336903198995, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    - m_Name: Cow_01_12
+      m_Hash: 471258369
+      m_Sprite: {fileID: -2062378941623102529, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2062378941623102529, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    - m_Name: Cow_01_13
+      m_Hash: 722593175
+      m_Sprite: {fileID: -7985808473849543292, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7985808473849543292, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkUp
+    m_Hash: 648049478
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_22
+      m_Hash: 926648002
+      m_Sprite: {fileID: -4491027181490164395, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4491027181490164395, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    - m_Name: Cow_01_23
+      m_Hash: 3978836
+      m_Sprite: {fileID: -3213845054023314096, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3213845054023314096, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    - m_Name: Cow_01_24
+      m_Hash: 509092855
+      m_Sprite: {fileID: 6699884678658499611, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6699884678658499611, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    - m_Name: Cow_01_25
+      m_Hash: 694096737
+      m_Sprite: {fileID: -8410739166040861955, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8410739166040861955, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    - m_Name: Cow_01_26
+      m_Hash: 810959579
+      m_Sprite: {fileID: 6994031415229587405, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6994031415229587405, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    - m_Name: Cow_01_27
+      m_Hash: 122778189
+      m_Sprite: {fileID: 5662570971608754526, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5662570971608754526, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    - m_Name: Cow_01_28
+      m_Hash: 401502172
+      m_Sprite: {fileID: -1973752667766756976, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1973752667766756976, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    - m_Name: Cow_01_29
+      m_Hash: 552165194
+      m_Sprite: {fileID: -8773431838664841684, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8773431838664841684, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkDown
+    m_Hash: 459082627
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_14
+      m_Hash: 896888884
+      m_Sprite: {fileID: 8933344659527710989, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8933344659527710989, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    - m_Name: Cow_01_15
+      m_Hash: 41042082
+      m_Sprite: {fileID: 2506960036560273251, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2506960036560273251, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    - m_Name: Cow_01_16
+      m_Hash: 461050136
+      m_Sprite: {fileID: 2348899547837691179, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2348899547837691179, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    - m_Name: Cow_01_17
+      m_Hash: 746332558
+      m_Sprite: {fileID: 1002814526126839259, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1002814526126839259, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    - m_Name: Cow_01_18
+      m_Hash: 1019427871
+      m_Sprite: {fileID: 4351196464656471689, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4351196464656471689, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    - m_Name: Cow_01_19
+      m_Hash: 197397641
+      m_Sprite: {fileID: 698370227770593671, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 698370227770593671, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    - m_Name: Cow_01_20
+      m_Hash: 422963182
+      m_Sprite: {fileID: -753371242876486473, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -753371242876486473, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    - m_Name: Cow_01_21
+      m_Hash: 775083896
+      m_Sprite: {fileID: 8670305854920572250, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8670305854920572250, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Attack
+    m_Hash: 7088141
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_30
+      m_Hash: 3069615
+      m_Sprite: {fileID: 1472603693563665461, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1472603693563665461, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    - m_Name: Cow_01_31
+      m_Hash: 925492793
+      m_Sprite: {fileID: -4868174577620849287, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4868174577620849287, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    - m_Name: Cow_01_32
+      m_Hash: 773896067
+      m_Sprite: {fileID: 225795109198302395, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 225795109198302395, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    - m_Name: Cow_01_33
+      m_Hash: 422020885
+      m_Sprite: {fileID: 7175760941071556438, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7175760941071556438, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    - m_Name: Cow_01_34
+      m_Hash: 121836214
+      m_Sprite: {fileID: -2229500098541278359, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2229500098541278359, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    - m_Name: Cow_01_35
+      m_Hash: 809771552
+      m_Sprite: {fileID: 6804678116176710599, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6804678116176710599, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    - m_Name: Cow_01_36
+      m_Hash: 692941722
+      m_Sprite: {fileID: -143605295345608074, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -143605295345608074, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    - m_Name: Cow_01_37
+      m_Hash: 508183308
+      m_Sprite: {fileID: 2055743561018489942, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2055743561018489942, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Die
+    m_Hash: 20298039
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_70
+      m_Hash: 608310187
+      m_Sprite: {fileID: 778025252, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 778025252, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    - m_Name: Cow_01_71
+      m_Hash: 323298109
+      m_Sprite: {fileID: -148845397, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -148845397, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    - m_Name: Cow_01_72
+      m_Hash: 172782215
+      m_Sprite: {fileID: 964173161, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 964173161, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    - m_Name: Cow_01_73
+      m_Hash: 1028342289
+      m_Sprite: {fileID: -1799699891, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1799699891, guid: 433c13a6b6fd7384cb0090e2b3f4424b, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 4
+  m_PrimaryLibraryGUID:
+  m_ModificationHash: 638924974477017144
+  m_Version: 1

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_16.spriteLib.meta
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Pig/Pig_16.spriteLib.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 6857fc030c21484696d14df770c52d2d
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 11500000, guid: db2778f6d440c47ddacff25997d7c062, type: 3}

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Sheep/Sheep_01.spriteLib
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Sheep/Sheep_01.spriteLib
@@ -1,0 +1,276 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5e6fedc2472449cead18ef23b5cb30d, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Unity.2D.Animation.Runtime::UnityEngine.U2D.Animation.SpriteLibrarySourceAsset
+  m_Library:
+  - m_Name: Idle
+    m_Hash: 1008081451
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_0
+      m_Hash: 500319545
+      m_Sprite: {fileID: -6294243155114217349, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6294243155114217349, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    - m_Name: Cow_01_1
+      m_Hash: 718632367
+      m_Sprite: {fileID: -5772777664047436682, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5772777664047436682, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleUp
+    m_Hash: 486716119
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_4
+      m_Hash: 448758048
+      m_Sprite: {fileID: -3986861783246937371, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3986861783246937371, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    - m_Name: Cow_01_5
+      m_Hash: 767078838
+      m_Sprite: {fileID: -7447266163624050036, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7447266163624050036, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleDown
+    m_Hash: 526694748
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_2
+      m_Hash: 870065173
+      m_Sprite: {fileID: -3031946760040179155, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3031946760040179155, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    - m_Name: Cow_01_3
+      m_Hash: 81466499
+      m_Sprite: {fileID: -4172152392031520947, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4172152392031520947, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: Walk
+    m_Hash: 765711723
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_6
+      m_Hash: 884072460
+      m_Sprite: {fileID: 4511450220876936486, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4511450220876936486, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    - m_Name: Cow_01_7
+      m_Hash: 62312602
+      m_Sprite: {fileID: -8397436606525353678, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8397436606525353678, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    - m_Name: Cow_01_8
+      m_Hash: 319409419
+      m_Sprite: {fileID: 39224874054715933, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 39224874054715933, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    - m_Name: Cow_01_9
+      m_Hash: 604962205
+      m_Sprite: {fileID: 8688569142650549539, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8688569142650549539, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    - m_Name: Cow_01_10
+      m_Hash: 840479789
+      m_Sprite: {fileID: 8300249881043303410, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8300249881043303410, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    - m_Name: Cow_01_11
+      m_Hash: 85951675
+      m_Sprite: {fileID: -2987787252961386262, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2987787252961386262, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    - m_Name: Cow_01_12
+      m_Hash: 471258369
+      m_Sprite: {fileID: 8246618309142805633, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8246618309142805633, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    - m_Name: Cow_01_13
+      m_Hash: 722593175
+      m_Sprite: {fileID: 5887979794823379072, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5887979794823379072, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkUp
+    m_Hash: 648049478
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_22
+      m_Hash: 926648002
+      m_Sprite: {fileID: 2436597685199366767, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2436597685199366767, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    - m_Name: Cow_01_23
+      m_Hash: 3978836
+      m_Sprite: {fileID: 7228084091615318015, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7228084091615318015, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    - m_Name: Cow_01_24
+      m_Hash: 509092855
+      m_Sprite: {fileID: -1899525091273755185, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1899525091273755185, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    - m_Name: Cow_01_25
+      m_Hash: 694096737
+      m_Sprite: {fileID: 738618696204237246, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 738618696204237246, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    - m_Name: Cow_01_26
+      m_Hash: 810959579
+      m_Sprite: {fileID: 361329684131805338, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 361329684131805338, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    - m_Name: Cow_01_27
+      m_Hash: 122778189
+      m_Sprite: {fileID: -4400541573700099251, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4400541573700099251, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    - m_Name: Cow_01_28
+      m_Hash: 401502172
+      m_Sprite: {fileID: 5332801041267153350, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5332801041267153350, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    - m_Name: Cow_01_29
+      m_Hash: 552165194
+      m_Sprite: {fileID: -5971630868091475613, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5971630868091475613, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkDown
+    m_Hash: 459082627
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_14
+      m_Hash: 896888884
+      m_Sprite: {fileID: 3876033673892155474, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3876033673892155474, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    - m_Name: Cow_01_15
+      m_Hash: 41042082
+      m_Sprite: {fileID: -562060300447797200, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -562060300447797200, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    - m_Name: Cow_01_16
+      m_Hash: 461050136
+      m_Sprite: {fileID: 84814132638831256, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 84814132638831256, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    - m_Name: Cow_01_17
+      m_Hash: 746332558
+      m_Sprite: {fileID: 7051462918358070292, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7051462918358070292, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    - m_Name: Cow_01_18
+      m_Hash: 1019427871
+      m_Sprite: {fileID: 8141229917891186485, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8141229917891186485, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    - m_Name: Cow_01_19
+      m_Hash: 197397641
+      m_Sprite: {fileID: 6869054416503748461, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6869054416503748461, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    - m_Name: Cow_01_20
+      m_Hash: 422963182
+      m_Sprite: {fileID: 7814260113116182148, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7814260113116182148, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    - m_Name: Cow_01_21
+      m_Hash: 775083896
+      m_Sprite: {fileID: 3493091592736079509, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3493091592736079509, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Attack
+    m_Hash: 7088141
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_30
+      m_Hash: 3069615
+      m_Sprite: {fileID: 8959200672272292300, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8959200672272292300, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    - m_Name: Cow_01_31
+      m_Hash: 925492793
+      m_Sprite: {fileID: -3686782597385080230, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3686782597385080230, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    - m_Name: Cow_01_32
+      m_Hash: 773896067
+      m_Sprite: {fileID: 5615238164212211451, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5615238164212211451, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    - m_Name: Cow_01_33
+      m_Hash: 422020885
+      m_Sprite: {fileID: -8363855448774352979, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8363855448774352979, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    - m_Name: Cow_01_34
+      m_Hash: 121836214
+      m_Sprite: {fileID: 467652968439240982, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 467652968439240982, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    - m_Name: Cow_01_35
+      m_Hash: 809771552
+      m_Sprite: {fileID: 7868669650857134359, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7868669650857134359, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    - m_Name: Cow_01_36
+      m_Hash: 692941722
+      m_Sprite: {fileID: -3740682744710299216, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3740682744710299216, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    - m_Name: Cow_01_37
+      m_Hash: 508183308
+      m_Sprite: {fileID: -7510195276280905467, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7510195276280905467, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Die
+    m_Hash: 20298039
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_70
+      m_Hash: 608310187
+      m_Sprite: {fileID: 204859639, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 204859639, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    - m_Name: Cow_01_71
+      m_Hash: 323298109
+      m_Sprite: {fileID: -1592709234, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1592709234, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    - m_Name: Cow_01_72
+      m_Hash: 172782215
+      m_Sprite: {fileID: 132560267, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 132560267, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    - m_Name: Cow_01_73
+      m_Hash: 1028342289
+      m_Sprite: {fileID: -1390632482, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1390632482, guid: 0d0339619a0ed3043bf76eb794532a7d, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 4
+  m_PrimaryLibraryGUID:
+  m_ModificationHash: 638924974477017144
+  m_Version: 1

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Sheep/Sheep_01.spriteLib.meta
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Sheep/Sheep_01.spriteLib.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 95c4de17764c4d72b0145b681da99591
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 11500000, guid: db2778f6d440c47ddacff25997d7c062, type: 3}

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Sheep/Sheep_02.spriteLib
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Sheep/Sheep_02.spriteLib
@@ -1,0 +1,276 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5e6fedc2472449cead18ef23b5cb30d, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Unity.2D.Animation.Runtime::UnityEngine.U2D.Animation.SpriteLibrarySourceAsset
+  m_Library:
+  - m_Name: Idle
+    m_Hash: 1008081451
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_0
+      m_Hash: 500319545
+      m_Sprite: {fileID: 6259354024973118763, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6259354024973118763, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    - m_Name: Cow_01_1
+      m_Hash: 718632367
+      m_Sprite: {fileID: 7547218081170596395, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7547218081170596395, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleUp
+    m_Hash: 486716119
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_4
+      m_Hash: 448758048
+      m_Sprite: {fileID: -2215121796459898611, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2215121796459898611, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    - m_Name: Cow_01_5
+      m_Hash: 767078838
+      m_Sprite: {fileID: -8634744539661132540, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8634744539661132540, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleDown
+    m_Hash: 526694748
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_2
+      m_Hash: 870065173
+      m_Sprite: {fileID: 8376531516670177948, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8376531516670177948, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    - m_Name: Cow_01_3
+      m_Hash: 81466499
+      m_Sprite: {fileID: -7864527507666068436, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7864527507666068436, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: Walk
+    m_Hash: 765711723
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_6
+      m_Hash: 884072460
+      m_Sprite: {fileID: -956877725129150858, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -956877725129150858, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    - m_Name: Cow_01_7
+      m_Hash: 62312602
+      m_Sprite: {fileID: 3349931103383150239, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3349931103383150239, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    - m_Name: Cow_01_8
+      m_Hash: 319409419
+      m_Sprite: {fileID: 261758111629390896, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 261758111629390896, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    - m_Name: Cow_01_9
+      m_Hash: 604962205
+      m_Sprite: {fileID: -1352762717071092596, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1352762717071092596, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    - m_Name: Cow_01_10
+      m_Hash: 840479789
+      m_Sprite: {fileID: -3567124404217541379, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3567124404217541379, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    - m_Name: Cow_01_11
+      m_Hash: 85951675
+      m_Sprite: {fileID: 121574458681074006, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 121574458681074006, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    - m_Name: Cow_01_12
+      m_Hash: 471258369
+      m_Sprite: {fileID: 2172056209015896990, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2172056209015896990, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    - m_Name: Cow_01_13
+      m_Hash: 722593175
+      m_Sprite: {fileID: 3540973240790363156, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3540973240790363156, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkUp
+    m_Hash: 648049478
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_22
+      m_Hash: 926648002
+      m_Sprite: {fileID: -2302153377644118118, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2302153377644118118, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    - m_Name: Cow_01_23
+      m_Hash: 3978836
+      m_Sprite: {fileID: -1086255673651681812, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1086255673651681812, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    - m_Name: Cow_01_24
+      m_Hash: 509092855
+      m_Sprite: {fileID: -1683045308905525600, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1683045308905525600, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    - m_Name: Cow_01_25
+      m_Hash: 694096737
+      m_Sprite: {fileID: -4533960645793712037, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4533960645793712037, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    - m_Name: Cow_01_26
+      m_Hash: 810959579
+      m_Sprite: {fileID: -322807965820015047, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -322807965820015047, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    - m_Name: Cow_01_27
+      m_Hash: 122778189
+      m_Sprite: {fileID: 4076097909328221571, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4076097909328221571, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    - m_Name: Cow_01_28
+      m_Hash: 401502172
+      m_Sprite: {fileID: -3573873352596331341, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3573873352596331341, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    - m_Name: Cow_01_29
+      m_Hash: 552165194
+      m_Sprite: {fileID: 5565402888571162307, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5565402888571162307, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkDown
+    m_Hash: 459082627
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_14
+      m_Hash: 896888884
+      m_Sprite: {fileID: 8598771863631452029, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8598771863631452029, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    - m_Name: Cow_01_15
+      m_Hash: 41042082
+      m_Sprite: {fileID: 7145987023689805218, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7145987023689805218, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    - m_Name: Cow_01_16
+      m_Hash: 461050136
+      m_Sprite: {fileID: -2455887244489004496, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2455887244489004496, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    - m_Name: Cow_01_17
+      m_Hash: 746332558
+      m_Sprite: {fileID: 4200040381962793693, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4200040381962793693, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    - m_Name: Cow_01_18
+      m_Hash: 1019427871
+      m_Sprite: {fileID: -4904993392062467545, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4904993392062467545, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    - m_Name: Cow_01_19
+      m_Hash: 197397641
+      m_Sprite: {fileID: 8765058427589759558, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8765058427589759558, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    - m_Name: Cow_01_20
+      m_Hash: 422963182
+      m_Sprite: {fileID: -6300605492379351043, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6300605492379351043, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    - m_Name: Cow_01_21
+      m_Hash: 775083896
+      m_Sprite: {fileID: -8855425859357987265, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8855425859357987265, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Attack
+    m_Hash: 7088141
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_30
+      m_Hash: 3069615
+      m_Sprite: {fileID: 3551742619986409135, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3551742619986409135, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    - m_Name: Cow_01_31
+      m_Hash: 925492793
+      m_Sprite: {fileID: -3794882609809842462, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3794882609809842462, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    - m_Name: Cow_01_32
+      m_Hash: 773896067
+      m_Sprite: {fileID: 6017473302498930895, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6017473302498930895, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    - m_Name: Cow_01_33
+      m_Hash: 422020885
+      m_Sprite: {fileID: 5302872094822160477, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5302872094822160477, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    - m_Name: Cow_01_34
+      m_Hash: 121836214
+      m_Sprite: {fileID: 8778333305468929013, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8778333305468929013, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    - m_Name: Cow_01_35
+      m_Hash: 809771552
+      m_Sprite: {fileID: -5397894764248831094, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5397894764248831094, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    - m_Name: Cow_01_36
+      m_Hash: 692941722
+      m_Sprite: {fileID: 998558404976962380, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 998558404976962380, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    - m_Name: Cow_01_37
+      m_Hash: 508183308
+      m_Sprite: {fileID: 3519625109080126552, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3519625109080126552, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Die
+    m_Hash: 20298039
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_70
+      m_Hash: 608310187
+      m_Sprite: {fileID: 562269349, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 562269349, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    - m_Name: Cow_01_71
+      m_Hash: 323298109
+      m_Sprite: {fileID: -1265195938, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1265195938, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    - m_Name: Cow_01_72
+      m_Hash: 172782215
+      m_Sprite: {fileID: 1457457346, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1457457346, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    - m_Name: Cow_01_73
+      m_Hash: 1028342289
+      m_Sprite: {fileID: 23296703, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 23296703, guid: c4ad7c2b31f0ee848a1d190147888123, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 4
+  m_PrimaryLibraryGUID:
+  m_ModificationHash: 638924974477017144
+  m_Version: 1

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Sheep/Sheep_02.spriteLib.meta
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Sheep/Sheep_02.spriteLib.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: f914d53a1bb04d4c9aafd3f5e6105f21
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 11500000, guid: db2778f6d440c47ddacff25997d7c062, type: 3}

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Sheep/Sheep_03.spriteLib
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Sheep/Sheep_03.spriteLib
@@ -1,0 +1,276 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5e6fedc2472449cead18ef23b5cb30d, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Unity.2D.Animation.Runtime::UnityEngine.U2D.Animation.SpriteLibrarySourceAsset
+  m_Library:
+  - m_Name: Idle
+    m_Hash: 1008081451
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_0
+      m_Hash: 500319545
+      m_Sprite: {fileID: 862694138048757971, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 862694138048757971, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    - m_Name: Cow_01_1
+      m_Hash: 718632367
+      m_Sprite: {fileID: -6681161749519358269, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6681161749519358269, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleUp
+    m_Hash: 486716119
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_4
+      m_Hash: 448758048
+      m_Sprite: {fileID: -4703203945517451732, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4703203945517451732, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    - m_Name: Cow_01_5
+      m_Hash: 767078838
+      m_Sprite: {fileID: 7912705055032766026, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7912705055032766026, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleDown
+    m_Hash: 526694748
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_2
+      m_Hash: 870065173
+      m_Sprite: {fileID: -5572211118336340550, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5572211118336340550, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    - m_Name: Cow_01_3
+      m_Hash: 81466499
+      m_Sprite: {fileID: 1289866407994079321, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1289866407994079321, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: Walk
+    m_Hash: 765711723
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_6
+      m_Hash: 884072460
+      m_Sprite: {fileID: 6586927975339890904, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6586927975339890904, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    - m_Name: Cow_01_7
+      m_Hash: 62312602
+      m_Sprite: {fileID: 4240910919089811195, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4240910919089811195, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    - m_Name: Cow_01_8
+      m_Hash: 319409419
+      m_Sprite: {fileID: -1185754580261583938, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1185754580261583938, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    - m_Name: Cow_01_9
+      m_Hash: 604962205
+      m_Sprite: {fileID: 4237465219816374711, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4237465219816374711, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    - m_Name: Cow_01_10
+      m_Hash: 840479789
+      m_Sprite: {fileID: -5388525150562780673, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5388525150562780673, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    - m_Name: Cow_01_11
+      m_Hash: 85951675
+      m_Sprite: {fileID: -6583911217598778623, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6583911217598778623, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    - m_Name: Cow_01_12
+      m_Hash: 471258369
+      m_Sprite: {fileID: -8149253637737998184, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8149253637737998184, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    - m_Name: Cow_01_13
+      m_Hash: 722593175
+      m_Sprite: {fileID: 7383376880242587937, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7383376880242587937, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkUp
+    m_Hash: 648049478
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_22
+      m_Hash: 926648002
+      m_Sprite: {fileID: 7839084406780969536, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7839084406780969536, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    - m_Name: Cow_01_23
+      m_Hash: 3978836
+      m_Sprite: {fileID: -6675246946853552854, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6675246946853552854, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    - m_Name: Cow_01_24
+      m_Hash: 509092855
+      m_Sprite: {fileID: 3174257591088077211, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3174257591088077211, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    - m_Name: Cow_01_25
+      m_Hash: 694096737
+      m_Sprite: {fileID: -8628084572599694562, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8628084572599694562, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    - m_Name: Cow_01_26
+      m_Hash: 810959579
+      m_Sprite: {fileID: 5958813585474978855, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5958813585474978855, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    - m_Name: Cow_01_27
+      m_Hash: 122778189
+      m_Sprite: {fileID: -4103943801418034347, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4103943801418034347, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    - m_Name: Cow_01_28
+      m_Hash: 401502172
+      m_Sprite: {fileID: 5515825456691353060, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5515825456691353060, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    - m_Name: Cow_01_29
+      m_Hash: 552165194
+      m_Sprite: {fileID: 7500203050332921294, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7500203050332921294, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkDown
+    m_Hash: 459082627
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_14
+      m_Hash: 896888884
+      m_Sprite: {fileID: -4611098398083161300, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4611098398083161300, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    - m_Name: Cow_01_15
+      m_Hash: 41042082
+      m_Sprite: {fileID: 5203316246282794621, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5203316246282794621, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    - m_Name: Cow_01_16
+      m_Hash: 461050136
+      m_Sprite: {fileID: 6022516170013577653, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6022516170013577653, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    - m_Name: Cow_01_17
+      m_Hash: 746332558
+      m_Sprite: {fileID: 5100424263504638138, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5100424263504638138, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    - m_Name: Cow_01_18
+      m_Hash: 1019427871
+      m_Sprite: {fileID: 5448681612609125459, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5448681612609125459, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    - m_Name: Cow_01_19
+      m_Hash: 197397641
+      m_Sprite: {fileID: -4318569661567992861, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4318569661567992861, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    - m_Name: Cow_01_20
+      m_Hash: 422963182
+      m_Sprite: {fileID: -5637428009578618972, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5637428009578618972, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    - m_Name: Cow_01_21
+      m_Hash: 775083896
+      m_Sprite: {fileID: -5353628587294104800, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5353628587294104800, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Attack
+    m_Hash: 7088141
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_30
+      m_Hash: 3069615
+      m_Sprite: {fileID: 3416543218766660285, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3416543218766660285, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    - m_Name: Cow_01_31
+      m_Hash: 925492793
+      m_Sprite: {fileID: -5913503569211679453, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5913503569211679453, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    - m_Name: Cow_01_32
+      m_Hash: 773896067
+      m_Sprite: {fileID: -6650720223578507664, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6650720223578507664, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    - m_Name: Cow_01_33
+      m_Hash: 422020885
+      m_Sprite: {fileID: -514242136041972732, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -514242136041972732, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    - m_Name: Cow_01_34
+      m_Hash: 121836214
+      m_Sprite: {fileID: -2565219203759679582, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2565219203759679582, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    - m_Name: Cow_01_35
+      m_Hash: 809771552
+      m_Sprite: {fileID: 3869781902604650565, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3869781902604650565, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    - m_Name: Cow_01_36
+      m_Hash: 692941722
+      m_Sprite: {fileID: 2034351752946372766, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2034351752946372766, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    - m_Name: Cow_01_37
+      m_Hash: 508183308
+      m_Sprite: {fileID: -8547322698547360759, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8547322698547360759, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Die
+    m_Hash: 20298039
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_70
+      m_Hash: 608310187
+      m_Sprite: {fileID: -1580573415, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1580573415, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    - m_Name: Cow_01_71
+      m_Hash: 323298109
+      m_Sprite: {fileID: 1901051452, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1901051452, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    - m_Name: Cow_01_72
+      m_Hash: 172782215
+      m_Sprite: {fileID: -1899482252, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1899482252, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    - m_Name: Cow_01_73
+      m_Hash: 1028342289
+      m_Sprite: {fileID: 1950346572, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1950346572, guid: 471b2c097137dbe49a681e0e945f64b6, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 4
+  m_PrimaryLibraryGUID:
+  m_ModificationHash: 638924974477017144
+  m_Version: 1

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Sheep/Sheep_03.spriteLib.meta
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Sheep/Sheep_03.spriteLib.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: cdf4e27578ce4e649a038f170c0bf962
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 11500000, guid: db2778f6d440c47ddacff25997d7c062, type: 3}

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Sheep/Sheep_04.spriteLib
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Sheep/Sheep_04.spriteLib
@@ -1,0 +1,276 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5e6fedc2472449cead18ef23b5cb30d, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Unity.2D.Animation.Runtime::UnityEngine.U2D.Animation.SpriteLibrarySourceAsset
+  m_Library:
+  - m_Name: Idle
+    m_Hash: 1008081451
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_0
+      m_Hash: 500319545
+      m_Sprite: {fileID: 5445301083187703379, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5445301083187703379, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    - m_Name: Cow_01_1
+      m_Hash: 718632367
+      m_Sprite: {fileID: -2245681826130548651, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2245681826130548651, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleUp
+    m_Hash: 486716119
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_4
+      m_Hash: 448758048
+      m_Sprite: {fileID: -3892430122593329288, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3892430122593329288, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    - m_Name: Cow_01_5
+      m_Hash: 767078838
+      m_Sprite: {fileID: 2369738766520601452, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2369738766520601452, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleDown
+    m_Hash: 526694748
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_2
+      m_Hash: 870065173
+      m_Sprite: {fileID: -410652596701430213, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -410652596701430213, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    - m_Name: Cow_01_3
+      m_Hash: 81466499
+      m_Sprite: {fileID: 8469659355198221172, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8469659355198221172, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: Walk
+    m_Hash: 765711723
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_6
+      m_Hash: 884072460
+      m_Sprite: {fileID: -6316197235025815736, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6316197235025815736, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    - m_Name: Cow_01_7
+      m_Hash: 62312602
+      m_Sprite: {fileID: 3415064121580649272, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3415064121580649272, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    - m_Name: Cow_01_8
+      m_Hash: 319409419
+      m_Sprite: {fileID: -6361916700164672524, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6361916700164672524, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    - m_Name: Cow_01_9
+      m_Hash: 604962205
+      m_Sprite: {fileID: 6008082170664593206, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6008082170664593206, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    - m_Name: Cow_01_10
+      m_Hash: 840479789
+      m_Sprite: {fileID: -9140340620073405444, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -9140340620073405444, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    - m_Name: Cow_01_11
+      m_Hash: 85951675
+      m_Sprite: {fileID: -5440118871165695076, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5440118871165695076, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    - m_Name: Cow_01_12
+      m_Hash: 471258369
+      m_Sprite: {fileID: -5430040241559826496, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5430040241559826496, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    - m_Name: Cow_01_13
+      m_Hash: 722593175
+      m_Sprite: {fileID: -4795369148100588957, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4795369148100588957, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkUp
+    m_Hash: 648049478
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_22
+      m_Hash: 926648002
+      m_Sprite: {fileID: 6284032447324736567, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6284032447324736567, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    - m_Name: Cow_01_23
+      m_Hash: 3978836
+      m_Sprite: {fileID: 7925406249568663454, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7925406249568663454, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    - m_Name: Cow_01_24
+      m_Hash: 509092855
+      m_Sprite: {fileID: -7907635162298891820, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7907635162298891820, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    - m_Name: Cow_01_25
+      m_Hash: 694096737
+      m_Sprite: {fileID: -7077080457031643098, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7077080457031643098, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    - m_Name: Cow_01_26
+      m_Hash: 810959579
+      m_Sprite: {fileID: 8615159634987190268, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8615159634987190268, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    - m_Name: Cow_01_27
+      m_Hash: 122778189
+      m_Sprite: {fileID: -7953459594750261945, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7953459594750261945, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    - m_Name: Cow_01_28
+      m_Hash: 401502172
+      m_Sprite: {fileID: 2829789215367267961, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2829789215367267961, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    - m_Name: Cow_01_29
+      m_Hash: 552165194
+      m_Sprite: {fileID: -5288354571405853570, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5288354571405853570, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkDown
+    m_Hash: 459082627
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_14
+      m_Hash: 896888884
+      m_Sprite: {fileID: -7220702066099162919, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7220702066099162919, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    - m_Name: Cow_01_15
+      m_Hash: 41042082
+      m_Sprite: {fileID: -831789351794627057, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -831789351794627057, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    - m_Name: Cow_01_16
+      m_Hash: 461050136
+      m_Sprite: {fileID: 3382601644086803772, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3382601644086803772, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    - m_Name: Cow_01_17
+      m_Hash: 746332558
+      m_Sprite: {fileID: -5025203483250395961, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5025203483250395961, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    - m_Name: Cow_01_18
+      m_Hash: 1019427871
+      m_Sprite: {fileID: 5696722368931985567, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5696722368931985567, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    - m_Name: Cow_01_19
+      m_Hash: 197397641
+      m_Sprite: {fileID: -6335189866279647629, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6335189866279647629, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    - m_Name: Cow_01_20
+      m_Hash: 422963182
+      m_Sprite: {fileID: -5276030552996166916, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5276030552996166916, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    - m_Name: Cow_01_21
+      m_Hash: 775083896
+      m_Sprite: {fileID: -4940571809763063692, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4940571809763063692, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Attack
+    m_Hash: 7088141
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_30
+      m_Hash: 3069615
+      m_Sprite: {fileID: -7738742601524334065, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7738742601524334065, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    - m_Name: Cow_01_31
+      m_Hash: 925492793
+      m_Sprite: {fileID: 8075962909878165238, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8075962909878165238, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    - m_Name: Cow_01_32
+      m_Hash: 773896067
+      m_Sprite: {fileID: -3389008378364072629, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3389008378364072629, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    - m_Name: Cow_01_33
+      m_Hash: 422020885
+      m_Sprite: {fileID: -754133878692883358, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -754133878692883358, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    - m_Name: Cow_01_34
+      m_Hash: 121836214
+      m_Sprite: {fileID: 2338658932173672550, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2338658932173672550, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    - m_Name: Cow_01_35
+      m_Hash: 809771552
+      m_Sprite: {fileID: 7014546835982814857, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7014546835982814857, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    - m_Name: Cow_01_36
+      m_Hash: 692941722
+      m_Sprite: {fileID: -2728437205839923759, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2728437205839923759, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    - m_Name: Cow_01_37
+      m_Hash: 508183308
+      m_Sprite: {fileID: -6331199394835092491, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6331199394835092491, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Die
+    m_Hash: 20298039
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_70
+      m_Hash: 608310187
+      m_Sprite: {fileID: -203055385, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -203055385, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    - m_Name: Cow_01_71
+      m_Hash: 323298109
+      m_Sprite: {fileID: -153622977, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -153622977, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    - m_Name: Cow_01_72
+      m_Hash: 172782215
+      m_Sprite: {fileID: 1036986114, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1036986114, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    - m_Name: Cow_01_73
+      m_Hash: 1028342289
+      m_Sprite: {fileID: -1832797537, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1832797537, guid: 48ca55a5218d34f44ac6c45ca8ba6441, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 4
+  m_PrimaryLibraryGUID:
+  m_ModificationHash: 638924974477017144
+  m_Version: 1

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Sheep/Sheep_04.spriteLib.meta
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Sheep/Sheep_04.spriteLib.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 7b701b9dbc7249c5857067bcc576df11
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 11500000, guid: db2778f6d440c47ddacff25997d7c062, type: 3}

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Sheep/Sheep_05.spriteLib
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Sheep/Sheep_05.spriteLib
@@ -1,0 +1,276 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5e6fedc2472449cead18ef23b5cb30d, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Unity.2D.Animation.Runtime::UnityEngine.U2D.Animation.SpriteLibrarySourceAsset
+  m_Library:
+  - m_Name: Idle
+    m_Hash: 1008081451
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_0
+      m_Hash: 500319545
+      m_Sprite: {fileID: -692140057863097975, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -692140057863097975, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    - m_Name: Cow_01_1
+      m_Hash: 718632367
+      m_Sprite: {fileID: -2745768891827424330, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2745768891827424330, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleUp
+    m_Hash: 486716119
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_4
+      m_Hash: 448758048
+      m_Sprite: {fileID: 8627766076167205628, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8627766076167205628, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    - m_Name: Cow_01_5
+      m_Hash: 767078838
+      m_Sprite: {fileID: 6648305669694132904, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6648305669694132904, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleDown
+    m_Hash: 526694748
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_2
+      m_Hash: 870065173
+      m_Sprite: {fileID: 4625567337604659955, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4625567337604659955, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    - m_Name: Cow_01_3
+      m_Hash: 81466499
+      m_Sprite: {fileID: -4320714615331515274, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4320714615331515274, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: Walk
+    m_Hash: 765711723
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_6
+      m_Hash: 884072460
+      m_Sprite: {fileID: -7377024776520513045, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7377024776520513045, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    - m_Name: Cow_01_7
+      m_Hash: 62312602
+      m_Sprite: {fileID: -666666264144067297, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -666666264144067297, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    - m_Name: Cow_01_8
+      m_Hash: 319409419
+      m_Sprite: {fileID: 5218417935147647550, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5218417935147647550, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    - m_Name: Cow_01_9
+      m_Hash: 604962205
+      m_Sprite: {fileID: 7587629625374386628, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7587629625374386628, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    - m_Name: Cow_01_10
+      m_Hash: 840479789
+      m_Sprite: {fileID: 4473962958891633232, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4473962958891633232, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    - m_Name: Cow_01_11
+      m_Hash: 85951675
+      m_Sprite: {fileID: -1108807005547046256, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1108807005547046256, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    - m_Name: Cow_01_12
+      m_Hash: 471258369
+      m_Sprite: {fileID: 4307433594468835222, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4307433594468835222, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    - m_Name: Cow_01_13
+      m_Hash: 722593175
+      m_Sprite: {fileID: -2220712309327035741, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2220712309327035741, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkUp
+    m_Hash: 648049478
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_22
+      m_Hash: 926648002
+      m_Sprite: {fileID: -122888058536075843, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -122888058536075843, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    - m_Name: Cow_01_23
+      m_Hash: 3978836
+      m_Sprite: {fileID: 2760454883447357174, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2760454883447357174, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    - m_Name: Cow_01_24
+      m_Hash: 509092855
+      m_Sprite: {fileID: 2203873153732046041, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2203873153732046041, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    - m_Name: Cow_01_25
+      m_Hash: 694096737
+      m_Sprite: {fileID: 1025768566596544580, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1025768566596544580, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    - m_Name: Cow_01_26
+      m_Hash: 810959579
+      m_Sprite: {fileID: -8837254193625453717, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8837254193625453717, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    - m_Name: Cow_01_27
+      m_Hash: 122778189
+      m_Sprite: {fileID: -5830198374429769660, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5830198374429769660, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    - m_Name: Cow_01_28
+      m_Hash: 401502172
+      m_Sprite: {fileID: -2205009492616631756, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2205009492616631756, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    - m_Name: Cow_01_29
+      m_Hash: 552165194
+      m_Sprite: {fileID: -5694495621231937568, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5694495621231937568, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkDown
+    m_Hash: 459082627
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_14
+      m_Hash: 896888884
+      m_Sprite: {fileID: -6590534724242837705, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6590534724242837705, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    - m_Name: Cow_01_15
+      m_Hash: 41042082
+      m_Sprite: {fileID: 5867368287173120370, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5867368287173120370, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    - m_Name: Cow_01_16
+      m_Hash: 461050136
+      m_Sprite: {fileID: 7329946596995724108, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7329946596995724108, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    - m_Name: Cow_01_17
+      m_Hash: 746332558
+      m_Sprite: {fileID: -9217054314830178695, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -9217054314830178695, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    - m_Name: Cow_01_18
+      m_Hash: 1019427871
+      m_Sprite: {fileID: 4664639741768814242, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4664639741768814242, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    - m_Name: Cow_01_19
+      m_Hash: 197397641
+      m_Sprite: {fileID: 8783463328062196064, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8783463328062196064, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    - m_Name: Cow_01_20
+      m_Hash: 422963182
+      m_Sprite: {fileID: 522424124745001731, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 522424124745001731, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    - m_Name: Cow_01_21
+      m_Hash: 775083896
+      m_Sprite: {fileID: -4951152285829417228, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4951152285829417228, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Attack
+    m_Hash: 7088141
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_30
+      m_Hash: 3069615
+      m_Sprite: {fileID: -5302217756259649016, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5302217756259649016, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    - m_Name: Cow_01_31
+      m_Hash: 925492793
+      m_Sprite: {fileID: -2510678193414286378, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2510678193414286378, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    - m_Name: Cow_01_32
+      m_Hash: 773896067
+      m_Sprite: {fileID: 8213831520466439999, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8213831520466439999, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    - m_Name: Cow_01_33
+      m_Hash: 422020885
+      m_Sprite: {fileID: -6656613915936316659, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6656613915936316659, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    - m_Name: Cow_01_34
+      m_Hash: 121836214
+      m_Sprite: {fileID: 7695897660429845991, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7695897660429845991, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    - m_Name: Cow_01_35
+      m_Hash: 809771552
+      m_Sprite: {fileID: -3084678996828769088, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3084678996828769088, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    - m_Name: Cow_01_36
+      m_Hash: 692941722
+      m_Sprite: {fileID: 6161707801473685456, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6161707801473685456, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    - m_Name: Cow_01_37
+      m_Hash: 508183308
+      m_Sprite: {fileID: 2050682192238183325, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2050682192238183325, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Die
+    m_Hash: 20298039
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_70
+      m_Hash: 608310187
+      m_Sprite: {fileID: 1908068661, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1908068661, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    - m_Name: Cow_01_71
+      m_Hash: 323298109
+      m_Sprite: {fileID: 698264060, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 698264060, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    - m_Name: Cow_01_72
+      m_Hash: 172782215
+      m_Sprite: {fileID: 389248924, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 389248924, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    - m_Name: Cow_01_73
+      m_Hash: 1028342289
+      m_Sprite: {fileID: -1061555229, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1061555229, guid: 0ddb490749d7cf148b9963af103e988f, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 4
+  m_PrimaryLibraryGUID:
+  m_ModificationHash: 638924974477017144
+  m_Version: 1

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Sheep/Sheep_05.spriteLib.meta
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Sheep/Sheep_05.spriteLib.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: f4a11dc5b49e40798eb4560f08f859ea
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 11500000, guid: db2778f6d440c47ddacff25997d7c062, type: 3}

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Sheep/Sheep_06.spriteLib
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Sheep/Sheep_06.spriteLib
@@ -1,0 +1,276 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5e6fedc2472449cead18ef23b5cb30d, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Unity.2D.Animation.Runtime::UnityEngine.U2D.Animation.SpriteLibrarySourceAsset
+  m_Library:
+  - m_Name: Idle
+    m_Hash: 1008081451
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_0
+      m_Hash: 500319545
+      m_Sprite: {fileID: -5934662157904661322, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5934662157904661322, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    - m_Name: Cow_01_1
+      m_Hash: 718632367
+      m_Sprite: {fileID: 2735369671814424654, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2735369671814424654, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleUp
+    m_Hash: 486716119
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_4
+      m_Hash: 448758048
+      m_Sprite: {fileID: 118682905619512793, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 118682905619512793, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    - m_Name: Cow_01_5
+      m_Hash: 767078838
+      m_Sprite: {fileID: 8934230942439913358, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8934230942439913358, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleDown
+    m_Hash: 526694748
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_2
+      m_Hash: 870065173
+      m_Sprite: {fileID: 5767201146709690898, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5767201146709690898, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    - m_Name: Cow_01_3
+      m_Hash: 81466499
+      m_Sprite: {fileID: 5763350972196566636, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5763350972196566636, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: Walk
+    m_Hash: 765711723
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_6
+      m_Hash: 884072460
+      m_Sprite: {fileID: -284119401112204442, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -284119401112204442, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    - m_Name: Cow_01_7
+      m_Hash: 62312602
+      m_Sprite: {fileID: 331314948326669080, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 331314948326669080, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    - m_Name: Cow_01_8
+      m_Hash: 319409419
+      m_Sprite: {fileID: 5829801504298462859, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5829801504298462859, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    - m_Name: Cow_01_9
+      m_Hash: 604962205
+      m_Sprite: {fileID: -5514006000068873640, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5514006000068873640, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    - m_Name: Cow_01_10
+      m_Hash: 840479789
+      m_Sprite: {fileID: -7495112699987907294, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7495112699987907294, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    - m_Name: Cow_01_11
+      m_Hash: 85951675
+      m_Sprite: {fileID: 552113470978758915, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 552113470978758915, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    - m_Name: Cow_01_12
+      m_Hash: 471258369
+      m_Sprite: {fileID: 7826086594966524413, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7826086594966524413, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    - m_Name: Cow_01_13
+      m_Hash: 722593175
+      m_Sprite: {fileID: -6872444833370498222, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6872444833370498222, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkUp
+    m_Hash: 648049478
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_22
+      m_Hash: 926648002
+      m_Sprite: {fileID: -131937753859735340, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -131937753859735340, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    - m_Name: Cow_01_23
+      m_Hash: 3978836
+      m_Sprite: {fileID: 3470269729165025445, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3470269729165025445, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    - m_Name: Cow_01_24
+      m_Hash: 509092855
+      m_Sprite: {fileID: -3808959471655656052, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3808959471655656052, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    - m_Name: Cow_01_25
+      m_Hash: 694096737
+      m_Sprite: {fileID: 1084741831171405978, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1084741831171405978, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    - m_Name: Cow_01_26
+      m_Hash: 810959579
+      m_Sprite: {fileID: 662403874794021004, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 662403874794021004, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    - m_Name: Cow_01_27
+      m_Hash: 122778189
+      m_Sprite: {fileID: -3720058112204541770, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3720058112204541770, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    - m_Name: Cow_01_28
+      m_Hash: 401502172
+      m_Sprite: {fileID: -2005199458777542157, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2005199458777542157, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    - m_Name: Cow_01_29
+      m_Hash: 552165194
+      m_Sprite: {fileID: 2318854396273836990, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2318854396273836990, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkDown
+    m_Hash: 459082627
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_14
+      m_Hash: 896888884
+      m_Sprite: {fileID: -8171386587574453394, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8171386587574453394, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    - m_Name: Cow_01_15
+      m_Hash: 41042082
+      m_Sprite: {fileID: -6527545498814730047, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6527545498814730047, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    - m_Name: Cow_01_16
+      m_Hash: 461050136
+      m_Sprite: {fileID: 5316921593270079280, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5316921593270079280, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    - m_Name: Cow_01_17
+      m_Hash: 746332558
+      m_Sprite: {fileID: -8102813060042274971, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8102813060042274971, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    - m_Name: Cow_01_18
+      m_Hash: 1019427871
+      m_Sprite: {fileID: 8913205044288928782, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8913205044288928782, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    - m_Name: Cow_01_19
+      m_Hash: 197397641
+      m_Sprite: {fileID: 4443257301499829195, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4443257301499829195, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    - m_Name: Cow_01_20
+      m_Hash: 422963182
+      m_Sprite: {fileID: -5353899740405052218, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5353899740405052218, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    - m_Name: Cow_01_21
+      m_Hash: 775083896
+      m_Sprite: {fileID: 5793824791070789224, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5793824791070789224, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Attack
+    m_Hash: 7088141
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_30
+      m_Hash: 3069615
+      m_Sprite: {fileID: 7737888050171951300, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7737888050171951300, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    - m_Name: Cow_01_31
+      m_Hash: 925492793
+      m_Sprite: {fileID: -1653710667915938044, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1653710667915938044, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    - m_Name: Cow_01_32
+      m_Hash: 773896067
+      m_Sprite: {fileID: 1485208421904648365, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1485208421904648365, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    - m_Name: Cow_01_33
+      m_Hash: 422020885
+      m_Sprite: {fileID: -3238463395778457212, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3238463395778457212, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    - m_Name: Cow_01_34
+      m_Hash: 121836214
+      m_Sprite: {fileID: 2707558166381720905, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2707558166381720905, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    - m_Name: Cow_01_35
+      m_Hash: 809771552
+      m_Sprite: {fileID: 7508505885338548480, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7508505885338548480, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    - m_Name: Cow_01_36
+      m_Hash: 692941722
+      m_Sprite: {fileID: 2895271234325610015, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2895271234325610015, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    - m_Name: Cow_01_37
+      m_Hash: 508183308
+      m_Sprite: {fileID: -2250137554017916715, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2250137554017916715, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Die
+    m_Hash: 20298039
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_70
+      m_Hash: 608310187
+      m_Sprite: {fileID: -1392197986, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1392197986, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    - m_Name: Cow_01_71
+      m_Hash: 323298109
+      m_Sprite: {fileID: 1975968344, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1975968344, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    - m_Name: Cow_01_72
+      m_Hash: 172782215
+      m_Sprite: {fileID: 1253891105, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1253891105, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    - m_Name: Cow_01_73
+      m_Hash: 1028342289
+      m_Sprite: {fileID: -647526914, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -647526914, guid: cf9f82ee9435eee46883f9a8cb5d6a7b, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 4
+  m_PrimaryLibraryGUID:
+  m_ModificationHash: 638924974477017144
+  m_Version: 1

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Sheep/Sheep_06.spriteLib.meta
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Sheep/Sheep_06.spriteLib.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 5f0eee023f6a4e229634cb0f776ce34c
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 11500000, guid: db2778f6d440c47ddacff25997d7c062, type: 3}

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Sheep/Sheep_07.spriteLib
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Sheep/Sheep_07.spriteLib
@@ -1,0 +1,276 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5e6fedc2472449cead18ef23b5cb30d, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Unity.2D.Animation.Runtime::UnityEngine.U2D.Animation.SpriteLibrarySourceAsset
+  m_Library:
+  - m_Name: Idle
+    m_Hash: 1008081451
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_0
+      m_Hash: 500319545
+      m_Sprite: {fileID: 8528054569806708950, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8528054569806708950, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    - m_Name: Cow_01_1
+      m_Hash: 718632367
+      m_Sprite: {fileID: -6606250990489581929, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6606250990489581929, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleUp
+    m_Hash: 486716119
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_4
+      m_Hash: 448758048
+      m_Sprite: {fileID: -2955351268112803135, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2955351268112803135, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    - m_Name: Cow_01_5
+      m_Hash: 767078838
+      m_Sprite: {fileID: 8085401377570553873, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8085401377570553873, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleDown
+    m_Hash: 526694748
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_2
+      m_Hash: 870065173
+      m_Sprite: {fileID: 2204071017921978383, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2204071017921978383, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    - m_Name: Cow_01_3
+      m_Hash: 81466499
+      m_Sprite: {fileID: 5533736213504854615, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5533736213504854615, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: Walk
+    m_Hash: 765711723
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_6
+      m_Hash: 884072460
+      m_Sprite: {fileID: -60913824857013374, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -60913824857013374, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    - m_Name: Cow_01_7
+      m_Hash: 62312602
+      m_Sprite: {fileID: 3926715586117377666, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3926715586117377666, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    - m_Name: Cow_01_8
+      m_Hash: 319409419
+      m_Sprite: {fileID: -5987271878080282193, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5987271878080282193, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    - m_Name: Cow_01_9
+      m_Hash: 604962205
+      m_Sprite: {fileID: 967625620362097407, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 967625620362097407, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    - m_Name: Cow_01_10
+      m_Hash: 840479789
+      m_Sprite: {fileID: -126980038222781172, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -126980038222781172, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    - m_Name: Cow_01_11
+      m_Hash: 85951675
+      m_Sprite: {fileID: 6578054742929121822, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6578054742929121822, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    - m_Name: Cow_01_12
+      m_Hash: 471258369
+      m_Sprite: {fileID: 6543306939547690106, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6543306939547690106, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    - m_Name: Cow_01_13
+      m_Hash: 722593175
+      m_Sprite: {fileID: -553147062446054041, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -553147062446054041, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkUp
+    m_Hash: 648049478
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_22
+      m_Hash: 926648002
+      m_Sprite: {fileID: 169551076680806019, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 169551076680806019, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    - m_Name: Cow_01_23
+      m_Hash: 3978836
+      m_Sprite: {fileID: 301130129743567961, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 301130129743567961, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    - m_Name: Cow_01_24
+      m_Hash: 509092855
+      m_Sprite: {fileID: 4169979065346865456, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4169979065346865456, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    - m_Name: Cow_01_25
+      m_Hash: 694096737
+      m_Sprite: {fileID: -70386911866348431, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -70386911866348431, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    - m_Name: Cow_01_26
+      m_Hash: 810959579
+      m_Sprite: {fileID: -8484151364595379189, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8484151364595379189, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    - m_Name: Cow_01_27
+      m_Hash: 122778189
+      m_Sprite: {fileID: 6303187170036883299, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6303187170036883299, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    - m_Name: Cow_01_28
+      m_Hash: 401502172
+      m_Sprite: {fileID: 2340601136142051297, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2340601136142051297, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    - m_Name: Cow_01_29
+      m_Hash: 552165194
+      m_Sprite: {fileID: 5799687823966853405, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5799687823966853405, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkDown
+    m_Hash: 459082627
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_14
+      m_Hash: 896888884
+      m_Sprite: {fileID: -1279835193556934359, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1279835193556934359, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    - m_Name: Cow_01_15
+      m_Hash: 41042082
+      m_Sprite: {fileID: 7560648371998436588, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7560648371998436588, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    - m_Name: Cow_01_16
+      m_Hash: 461050136
+      m_Sprite: {fileID: 6107912502783415042, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6107912502783415042, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    - m_Name: Cow_01_17
+      m_Hash: 746332558
+      m_Sprite: {fileID: 5347657872021749725, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5347657872021749725, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    - m_Name: Cow_01_18
+      m_Hash: 1019427871
+      m_Sprite: {fileID: 5403139940069476308, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5403139940069476308, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    - m_Name: Cow_01_19
+      m_Hash: 197397641
+      m_Sprite: {fileID: 6397165765401084274, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6397165765401084274, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    - m_Name: Cow_01_20
+      m_Hash: 422963182
+      m_Sprite: {fileID: 6158282362279982833, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6158282362279982833, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    - m_Name: Cow_01_21
+      m_Hash: 775083896
+      m_Sprite: {fileID: 3922612491523728374, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3922612491523728374, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Attack
+    m_Hash: 7088141
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_30
+      m_Hash: 3069615
+      m_Sprite: {fileID: 6103754546329677879, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6103754546329677879, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    - m_Name: Cow_01_31
+      m_Hash: 925492793
+      m_Sprite: {fileID: 8055328382967215981, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8055328382967215981, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    - m_Name: Cow_01_32
+      m_Hash: 773896067
+      m_Sprite: {fileID: 6840402790685843230, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6840402790685843230, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    - m_Name: Cow_01_33
+      m_Hash: 422020885
+      m_Sprite: {fileID: 6352951498089684824, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6352951498089684824, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    - m_Name: Cow_01_34
+      m_Hash: 121836214
+      m_Sprite: {fileID: 7945607202897163955, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7945607202897163955, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    - m_Name: Cow_01_35
+      m_Hash: 809771552
+      m_Sprite: {fileID: -5293424743917354170, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5293424743917354170, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    - m_Name: Cow_01_36
+      m_Hash: 692941722
+      m_Sprite: {fileID: 5181974005538899239, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5181974005538899239, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    - m_Name: Cow_01_37
+      m_Hash: 508183308
+      m_Sprite: {fileID: -4440033151144378855, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4440033151144378855, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Die
+    m_Hash: 20298039
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_70
+      m_Hash: 608310187
+      m_Sprite: {fileID: -723284738, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -723284738, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    - m_Name: Cow_01_71
+      m_Hash: 323298109
+      m_Sprite: {fileID: 539981336, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 539981336, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    - m_Name: Cow_01_72
+      m_Hash: 172782215
+      m_Sprite: {fileID: -1224277717, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1224277717, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    - m_Name: Cow_01_73
+      m_Hash: 1028342289
+      m_Sprite: {fileID: -488918459, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -488918459, guid: 6cff1866ecc32b948a151679ae8a7174, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 4
+  m_PrimaryLibraryGUID:
+  m_ModificationHash: 638924974477017144
+  m_Version: 1

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Sheep/Sheep_07.spriteLib.meta
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Sheep/Sheep_07.spriteLib.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 4837db3a1e9c4c5f958c66cc6123fc69
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 11500000, guid: db2778f6d440c47ddacff25997d7c062, type: 3}

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Sheep/Sheep_08.spriteLib
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Sheep/Sheep_08.spriteLib
@@ -1,0 +1,276 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5e6fedc2472449cead18ef23b5cb30d, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Unity.2D.Animation.Runtime::UnityEngine.U2D.Animation.SpriteLibrarySourceAsset
+  m_Library:
+  - m_Name: Idle
+    m_Hash: 1008081451
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_0
+      m_Hash: 500319545
+      m_Sprite: {fileID: 6031011946272301876, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6031011946272301876, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    - m_Name: Cow_01_1
+      m_Hash: 718632367
+      m_Sprite: {fileID: 6716853403366644364, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6716853403366644364, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleUp
+    m_Hash: 486716119
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_4
+      m_Hash: 448758048
+      m_Sprite: {fileID: 6037458596567681722, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6037458596567681722, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    - m_Name: Cow_01_5
+      m_Hash: 767078838
+      m_Sprite: {fileID: 5744906978873718986, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5744906978873718986, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleDown
+    m_Hash: 526694748
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_2
+      m_Hash: 870065173
+      m_Sprite: {fileID: -6294916333212053813, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6294916333212053813, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    - m_Name: Cow_01_3
+      m_Hash: 81466499
+      m_Sprite: {fileID: -3709830655402035518, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3709830655402035518, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: Walk
+    m_Hash: 765711723
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_6
+      m_Hash: 884072460
+      m_Sprite: {fileID: -5969984400911891254, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5969984400911891254, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    - m_Name: Cow_01_7
+      m_Hash: 62312602
+      m_Sprite: {fileID: 3800317898506817301, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3800317898506817301, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    - m_Name: Cow_01_8
+      m_Hash: 319409419
+      m_Sprite: {fileID: -2748641494192561314, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2748641494192561314, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    - m_Name: Cow_01_9
+      m_Hash: 604962205
+      m_Sprite: {fileID: 6652215758530400089, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6652215758530400089, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    - m_Name: Cow_01_10
+      m_Hash: 840479789
+      m_Sprite: {fileID: 2843987632695129991, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2843987632695129991, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    - m_Name: Cow_01_11
+      m_Hash: 85951675
+      m_Sprite: {fileID: 4971040247865947609, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4971040247865947609, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    - m_Name: Cow_01_12
+      m_Hash: 471258369
+      m_Sprite: {fileID: -280295540857180912, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -280295540857180912, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    - m_Name: Cow_01_13
+      m_Hash: 722593175
+      m_Sprite: {fileID: -7435520526383949085, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7435520526383949085, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkUp
+    m_Hash: 648049478
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_22
+      m_Hash: 926648002
+      m_Sprite: {fileID: 932198436148210417, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 932198436148210417, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    - m_Name: Cow_01_23
+      m_Hash: 3978836
+      m_Sprite: {fileID: -3242291505112901302, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3242291505112901302, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    - m_Name: Cow_01_24
+      m_Hash: 509092855
+      m_Sprite: {fileID: 2360897403046883779, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2360897403046883779, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    - m_Name: Cow_01_25
+      m_Hash: 694096737
+      m_Sprite: {fileID: -4869475485186029198, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4869475485186029198, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    - m_Name: Cow_01_26
+      m_Hash: 810959579
+      m_Sprite: {fileID: 6772694391230446933, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6772694391230446933, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    - m_Name: Cow_01_27
+      m_Hash: 122778189
+      m_Sprite: {fileID: 4131869418427663092, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4131869418427663092, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    - m_Name: Cow_01_28
+      m_Hash: 401502172
+      m_Sprite: {fileID: 6623261507013435567, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6623261507013435567, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    - m_Name: Cow_01_29
+      m_Hash: 552165194
+      m_Sprite: {fileID: -129605344987233381, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -129605344987233381, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkDown
+    m_Hash: 459082627
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_14
+      m_Hash: 896888884
+      m_Sprite: {fileID: 4728471254051060518, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4728471254051060518, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    - m_Name: Cow_01_15
+      m_Hash: 41042082
+      m_Sprite: {fileID: -6428361816684522882, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6428361816684522882, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    - m_Name: Cow_01_16
+      m_Hash: 461050136
+      m_Sprite: {fileID: -6497004142224144174, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -6497004142224144174, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    - m_Name: Cow_01_17
+      m_Hash: 746332558
+      m_Sprite: {fileID: 5899569263260172956, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5899569263260172956, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    - m_Name: Cow_01_18
+      m_Hash: 1019427871
+      m_Sprite: {fileID: 3538969415005528817, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3538969415005528817, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    - m_Name: Cow_01_19
+      m_Hash: 197397641
+      m_Sprite: {fileID: -4730882852270617083, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4730882852270617083, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    - m_Name: Cow_01_20
+      m_Hash: 422963182
+      m_Sprite: {fileID: -5256670480942649592, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -5256670480942649592, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    - m_Name: Cow_01_21
+      m_Hash: 775083896
+      m_Sprite: {fileID: 1768817458155293361, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1768817458155293361, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Attack
+    m_Hash: 7088141
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_30
+      m_Hash: 3069615
+      m_Sprite: {fileID: -7126688704336564421, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7126688704336564421, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    - m_Name: Cow_01_31
+      m_Hash: 925492793
+      m_Sprite: {fileID: -2699160739089185258, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2699160739089185258, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    - m_Name: Cow_01_32
+      m_Hash: 773896067
+      m_Sprite: {fileID: 7893163135228947357, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7893163135228947357, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    - m_Name: Cow_01_33
+      m_Hash: 422020885
+      m_Sprite: {fileID: -8517887403352575642, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8517887403352575642, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    - m_Name: Cow_01_34
+      m_Hash: 121836214
+      m_Sprite: {fileID: -57171256286610270, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -57171256286610270, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    - m_Name: Cow_01_35
+      m_Hash: 809771552
+      m_Sprite: {fileID: 2409711774431877845, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2409711774431877845, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    - m_Name: Cow_01_36
+      m_Hash: 692941722
+      m_Sprite: {fileID: -4397902547593670494, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4397902547593670494, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    - m_Name: Cow_01_37
+      m_Hash: 508183308
+      m_Sprite: {fileID: 8231903487445057541, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8231903487445057541, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Die
+    m_Hash: 20298039
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_70
+      m_Hash: 608310187
+      m_Sprite: {fileID: -1167396609, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1167396609, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    - m_Name: Cow_01_71
+      m_Hash: 323298109
+      m_Sprite: {fileID: 700578592, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 700578592, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    - m_Name: Cow_01_72
+      m_Hash: 172782215
+      m_Sprite: {fileID: 1423000182, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1423000182, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    - m_Name: Cow_01_73
+      m_Hash: 1028342289
+      m_Sprite: {fileID: 826190804, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 826190804, guid: 9dda4ffaf5856734f8e3b27f2a23fbcc, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 4
+  m_PrimaryLibraryGUID:
+  m_ModificationHash: 638924974477017144
+  m_Version: 1

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Sheep/Sheep_08.spriteLib.meta
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Sheep/Sheep_08.spriteLib.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 812d8db57bf444a080d07660ae2a6c73
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 11500000, guid: db2778f6d440c47ddacff25997d7c062, type: 3}

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Sheep/Sheep_09.spriteLib
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Sheep/Sheep_09.spriteLib
@@ -1,0 +1,276 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5e6fedc2472449cead18ef23b5cb30d, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Unity.2D.Animation.Runtime::UnityEngine.U2D.Animation.SpriteLibrarySourceAsset
+  m_Library:
+  - m_Name: Idle
+    m_Hash: 1008081451
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_0
+      m_Hash: 500319545
+      m_Sprite: {fileID: 3543794442665688282, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3543794442665688282, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    - m_Name: Cow_01_1
+      m_Hash: 718632367
+      m_Sprite: {fileID: -359091574072592203, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -359091574072592203, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleUp
+    m_Hash: 486716119
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_4
+      m_Hash: 448758048
+      m_Sprite: {fileID: 7888471697160348839, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 7888471697160348839, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    - m_Name: Cow_01_5
+      m_Hash: 767078838
+      m_Sprite: {fileID: -4748153484482660807, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -4748153484482660807, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: IdleDown
+    m_Hash: 526694748
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_2
+      m_Hash: 870065173
+      m_Sprite: {fileID: -1656656559581085045, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1656656559581085045, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    - m_Name: Cow_01_3
+      m_Hash: 81466499
+      m_Sprite: {fileID: -1911119255492621812, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1911119255492621812, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 2
+  - m_Name: Walk
+    m_Hash: 765711723
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_6
+      m_Hash: 884072460
+      m_Sprite: {fileID: 745543627186186480, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 745543627186186480, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    - m_Name: Cow_01_7
+      m_Hash: 62312602
+      m_Sprite: {fileID: -2595101821974388475, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2595101821974388475, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    - m_Name: Cow_01_8
+      m_Hash: 319409419
+      m_Sprite: {fileID: -8086450379823277467, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -8086450379823277467, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    - m_Name: Cow_01_9
+      m_Hash: 604962205
+      m_Sprite: {fileID: 8035347245536179120, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8035347245536179120, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    - m_Name: Cow_01_10
+      m_Hash: 840479789
+      m_Sprite: {fileID: 2165322334365480576, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2165322334365480576, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    - m_Name: Cow_01_11
+      m_Hash: 85951675
+      m_Sprite: {fileID: 3170683845009557872, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3170683845009557872, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    - m_Name: Cow_01_12
+      m_Hash: 471258369
+      m_Sprite: {fileID: -7367974395787560144, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -7367974395787560144, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    - m_Name: Cow_01_13
+      m_Hash: 722593175
+      m_Sprite: {fileID: -2280349549891622562, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -2280349549891622562, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkUp
+    m_Hash: 648049478
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_22
+      m_Hash: 926648002
+      m_Sprite: {fileID: 3235688290132747863, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3235688290132747863, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    - m_Name: Cow_01_23
+      m_Hash: 3978836
+      m_Sprite: {fileID: 2621216974548243992, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 2621216974548243992, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    - m_Name: Cow_01_24
+      m_Hash: 509092855
+      m_Sprite: {fileID: -676944921348703901, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -676944921348703901, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    - m_Name: Cow_01_25
+      m_Hash: 694096737
+      m_Sprite: {fileID: 4475903073275638781, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4475903073275638781, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    - m_Name: Cow_01_26
+      m_Hash: 810959579
+      m_Sprite: {fileID: 8547748830669522310, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8547748830669522310, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    - m_Name: Cow_01_27
+      m_Hash: 122778189
+      m_Sprite: {fileID: -3063688527028343313, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3063688527028343313, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    - m_Name: Cow_01_28
+      m_Hash: 401502172
+      m_Sprite: {fileID: -475123990824837308, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -475123990824837308, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    - m_Name: Cow_01_29
+      m_Hash: 552165194
+      m_Sprite: {fileID: 8594767409473942374, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8594767409473942374, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: WalkDown
+    m_Hash: 459082627
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_14
+      m_Hash: 896888884
+      m_Sprite: {fileID: 3488428406760661039, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3488428406760661039, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    - m_Name: Cow_01_15
+      m_Hash: 41042082
+      m_Sprite: {fileID: 8330910959344093380, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8330910959344093380, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    - m_Name: Cow_01_16
+      m_Hash: 461050136
+      m_Sprite: {fileID: 4975666918087259558, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4975666918087259558, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    - m_Name: Cow_01_17
+      m_Hash: 746332558
+      m_Sprite: {fileID: -3522224500784385238, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3522224500784385238, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    - m_Name: Cow_01_18
+      m_Hash: 1019427871
+      m_Sprite: {fileID: -451623643943165628, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -451623643943165628, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    - m_Name: Cow_01_19
+      m_Hash: 197397641
+      m_Sprite: {fileID: 8143363517107766210, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8143363517107766210, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    - m_Name: Cow_01_20
+      m_Hash: 422963182
+      m_Sprite: {fileID: -3069547483047417960, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -3069547483047417960, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    - m_Name: Cow_01_21
+      m_Hash: 775083896
+      m_Sprite: {fileID: 4140129640445658556, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4140129640445658556, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Attack
+    m_Hash: 7088141
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_30
+      m_Hash: 3069615
+      m_Sprite: {fileID: 3454493177713200471, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 3454493177713200471, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    - m_Name: Cow_01_31
+      m_Hash: 925492793
+      m_Sprite: {fileID: 1246423520308995229, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1246423520308995229, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    - m_Name: Cow_01_32
+      m_Hash: 773896067
+      m_Sprite: {fileID: 8289210653360319551, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 8289210653360319551, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    - m_Name: Cow_01_33
+      m_Hash: 422020885
+      m_Sprite: {fileID: 6309650110137699129, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6309650110137699129, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    - m_Name: Cow_01_34
+      m_Hash: 121836214
+      m_Sprite: {fileID: 6393343578667650236, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6393343578667650236, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    - m_Name: Cow_01_35
+      m_Hash: 809771552
+      m_Sprite: {fileID: 6453199105628351930, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 6453199105628351930, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    - m_Name: Cow_01_36
+      m_Hash: 692941722
+      m_Sprite: {fileID: 5537441022940397256, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 5537441022940397256, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    - m_Name: Cow_01_37
+      m_Hash: 508183308
+      m_Sprite: {fileID: 4068353157244113690, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 4068353157244113690, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 8
+  - m_Name: Die
+    m_Hash: 20298039
+    m_CategoryList: []
+    m_OverrideEntries:
+    - m_Name: Cow_01_70
+      m_Hash: 608310187
+      m_Sprite: {fileID: 1738876371, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1738876371, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    - m_Name: Cow_01_71
+      m_Hash: 323298109
+      m_Sprite: {fileID: -1510012571, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: -1510012571, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    - m_Name: Cow_01_72
+      m_Hash: 172782215
+      m_Sprite: {fileID: 1462217270, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 1462217270, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    - m_Name: Cow_01_73
+      m_Hash: 1028342289
+      m_Sprite: {fileID: 989739756, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+      m_FromMain: 0
+      m_SpriteOverride: {fileID: 989739756, guid: 7d1bdab06d63f3248b48dc0d280ed12a, type: 3}
+    m_FromMain: 0
+    m_EntryOverrideCount: 4
+  m_PrimaryLibraryGUID:
+  m_ModificationHash: 638924974477017144
+  m_Version: 1

--- a/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Sheep/Sheep_09.spriteLib.meta
+++ b/Assets/Art/Packs/Cute_Fantasy/Animals/FarmlandsEnemies/Sheep/Sheep_09.spriteLib.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: e06ee7b361e540fdb7140273df87a4fc
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 11500000, guid: db2778f6d440c47ddacff25997d7c062, type: 3}


### PR DESCRIPTION
## Summary
- Align sprite labels in all cow, pig, and sheep sprite libraries to shared `Cow_01_*` names for consistent animations

## Testing
- `npm test` *(fails: Could not read package.json)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a4cbcdf4832e826c2b311bed46c8