### PR TITLE
Gate milestone activation UI behind slot unlock

### DIFF
--- a/Assets/Scripts/Skills/MilestoneBonusUI.cs
+++ b/Assets/Scripts/Skills/MilestoneBonusUI.cs
@@ -121,6 +121,7 @@ namespace TimelessEchoes.Skills
             int tierIndex = state != null ? state.TierIndex : -1;
             bool unlocked = tierIndex >= 0;
             bool active = state != null && state.IsActive;
+            bool hasActiveSlots = controller != null && controller.TotalActiveSlots > 0;
 
             string title = definition.DisplayName;
             int nextTierLevel = definition.GetNextTierLevel(currentLevel);
@@ -151,14 +152,14 @@ namespace TimelessEchoes.Skills
                 }
                 else
                 {
-                    bool showPassivePrefix = controller != null && controller.TotalActiveSlots > 0;
+                    bool showPassivePrefix = hasActiveSlots && definition.HasActiveEffect;
                     refs.PassiveText.text = showPassivePrefix ? $"Passive: {passiveDesc}" : passiveDesc;
                 }
             }
 
             if (refs.ActiveText != null)
             {
-                bool canShowActive = unlocked && definition.HasActiveEffect;
+                bool canShowActive = unlocked && definition.HasActiveEffect && hasActiveSlots;
                 if (canShowActive)
                 {
                     string activeDesc = definition.GetActiveDescriptionForTier(displayTier, skill?.skillName);
@@ -196,7 +197,8 @@ namespace TimelessEchoes.Skills
             if (refs.ToggleButton != null)
             {
                 refs.ToggleButton.onClick.RemoveAllListeners();
-                bool canToggle = unlocked && definition.CanActivate && controller != null;
+                bool canToggle = unlocked && definition.CanActivate && controller != null && hasActiveSlots;
+                refs.ToggleButton.gameObject.SetActive(hasActiveSlots && unlocked && definition.CanActivate);
                 refs.ToggleButton.interactable = canToggle;
                 if (canToggle)
                     refs.ToggleButton.onClick.AddListener(() => HandleToggle(binding));
@@ -204,10 +206,11 @@ namespace TimelessEchoes.Skills
 
             if (refs.ToggleImage != null)
             {
-                if (!unlocked || !definition.CanActivate)
+                bool canDisplayToggle = hasActiveSlots && unlocked && definition.CanActivate;
+                if (!canDisplayToggle)
                 {
                     refs.ToggleImage.sprite = null;
-                    refs.ToggleImage.color = unlocked ? unlockedColor : lockedColor;
+                    refs.ToggleImage.color = unlocked && hasActiveSlots ? unlockedColor : lockedColor;
                     refs.ToggleImage.gameObject.SetActive(false);
                 }
                 else

--- a/DevStuff/Changes.md
+++ b/DevStuff/Changes.md
@@ -1,3 +1,4 @@
+- Hid milestone activation toggles and active descriptions until the player unlocks active slots for a skill.
 - Added per-skill task speed lines to the skills totals panel, excluding the combat skill bonus.
 - Added a first-run intro screen controller that gates closing for 10 seconds, toggles prompts, and persists completion via PlayerPrefs.
 - Reworked forge actions so the craft button becomes Stop during auto-crafting, pauses the auto-run button, and keeps the latest craft available for Replace after cancelling.


### PR DESCRIPTION
## Summary
- hide milestone activation toggles until at least one active slot has been earned
- prevent active milestone descriptions from appearing before slots are unlocked and document the change in Changes.md

## Testing
- not run (Unity editor unavailable in CI)


------
https://chatgpt.com/codex/tasks/task_e_68e198073ea0832ebc69827c3c81bb16